### PR TITLE
Unit improvements, changed default unit to MM

### DIFF
--- a/includes/core.js
+++ b/includes/core.js
@@ -215,7 +215,7 @@ var setCurrDoc = function(doc) {
   currLeading = currDoc.textDefaults.leading;
   currKerning = 0;
   currTracking = currDoc.textDefaults.tracking;
-  pub.units(pub.PT);
+  pub.units(pub.MM);
   
   updatePublicPageSizeVars();
 };

--- a/includes/environment.js
+++ b/includes/environment.js
@@ -499,11 +499,11 @@ pub.nameOnPage = function(name) {
 };
 
 /**
- * Sets the units of the document (like right clicking the rulers). The default units of basil.js are PT.
+ * Sets the units of the document (like right clicking the rulers). The default unit setting of basil.js is MM.
  *
  * @cat Document
  * @method units
- * @param  {Constant} [units] Supported units: PT, PX, CM, MM or IN
+ * @param  {Constant} [units] Supported units: MM, PT, PX, CM, IN
  * @return {Constant} Current unit setting
  */
 var unitsCalledCounter = 0;
@@ -538,7 +538,7 @@ pub.units = function (units) {
     currUnits = units;
     updatePublicPageSizeVars();
   } else {
-    error("b.unit(), not supported unit");
+    error("b.unit(), invalid unit. Please use: P.MM, P.PT, P.PX, P.CM or P.IN.");
   }
   if (unitsCalledCounter === 1) {
     warning("Please note that b.units() will reset the current transformation matrix."); 

--- a/includes/environment.js
+++ b/includes/environment.js
@@ -536,7 +536,7 @@ pub.units = function (units) {
       verticalMeasurementUnits = unitType;
     }
     currUnits = units;
-    updatePublicPageSizeVars();
+    if (unitsCalledCounter) updatePublicPageSizeVars();
   } else {
     error("b.unit(), invalid unit. Please use: P.MM, P.PT, P.PX, P.CM or P.IN.");
   }

--- a/test/transform-tests.jsx
+++ b/test/transform-tests.jsx
@@ -68,35 +68,43 @@ b.test('TransformTests', {
 
   testWidth: function(b) {
     var doc = b.doc();
+    // use tolerance value to avoid rounding errors
+    var tolerance = 0.0001;
     // create box at 0,0
     var rect = b.rect(0,0,100,100);
-    assert( b.itemWidth(rect) === 100 );    
+    assert( b.itemWidth(rect) > (100 - tolerance) && b.itemWidth(rect) < (100 + tolerance) );
     // move to 50,0
     b.itemWidth(rect, 50);
     // check new x coordinate
-    assert( b.itemWidth(rect) === 50 );    
+    assert( b.itemWidth(rect) > (50 - tolerance) && b.itemWidth(rect) < (50 + tolerance) );
   },
 
   testHeight: function(b) {
     var doc = b.doc();
+    // use tolerance value to avoid rounding errors
+    var tolerance = 0.0001;
     // create box at 0,0
     var rect = b.rect(0,0,100,100);
-    assert( b.itemHeight(rect) === 100 );    
+    assert( b.itemHeight(rect) > (100 - tolerance) && b.itemHeight(rect) < (100 + tolerance) );
     // move to 50,0
     b.itemHeight(rect, 50);
     // check new x coordinate
-    assert( b.itemHeight(rect) === 50 );    
+    assert( b.itemHeight(rect) > (50 - tolerance) && b.itemHeight(rect) < (50 + tolerance) );
   },
 
   testSize: function(b) {
     var doc = b.doc();
+    // use tolerance value to avoid rounding errors
+    var tolerance = 0.0001;
     // create box at 0,0
     var rect = b.rect(0,0,100,100);
-    assert( b.itemSize(rect).width === 100 && b.itemSize(rect).height === 100 );    
+    assert( b.itemSize(rect).width > (100 - tolerance) && b.itemSize(rect).width < (100 + tolerance) );
+    assert( b.itemSize(rect).height > (100 - tolerance) && b.itemSize(rect).height < (100 + tolerance) );
     // move to 50,0
     b.itemSize(rect, 50, 50);
     // check new x coordinate
-    assert( b.itemSize(rect).width === 50 && b.itemSize(rect).height === 50 );    
+    assert( b.itemSize(rect).width > (50 - tolerance) && b.itemSize(rect).width < (50 + tolerance) );
+    assert( b.itemSize(rect).height > (50 - tolerance) && b.itemSize(rect).height < (50 + tolerance) );
   }
 
   // todo: add matrix transformation tests here ...
@@ -105,5 +113,4 @@ b.test('TransformTests', {
 
 // print collected test results
 b.test.result();
-
 

--- a/test/transform-tests.jsx
+++ b/test/transform-tests.jsx
@@ -1,1 +1,109 @@
-if (typeof b === 'undefined') {  #include "../basil.js";}if (typeof b.test === 'undefined') {  #include "../lib/basil.test.js";  }b.test('TransformTests', {    setUpTest: function(b) {  },  tearDownTest: function(b) {  },  setUp: function(b) {  },  tearDown: function(b) {     b.close(SaveOptions.no);   },  testMoveX: function(b) {    b.rectMode(b.CORNER);    var doc = b.doc();    // create box at 0,0    var rect = b.rect(0,0,100,100);    assert( b.itemX(rect) === 0);        // move to 50,0    b.itemX(rect, 50);    // check new x coordinate    assert( b.itemX(rect) === 50);    rect.remove();    //~     b.rectMode(b.CENTER);//~     // create box at 0,0//~     var rect = b.rect(0,0,100,100);//~   //~     assert( b.itemX(rect) === 0);//~     // move to 50,0//~     b.itemX(rect, 50);//~     // check new x coordinate//~     assert( b.itemX(rect) === 50);//~     rect.remove();  },  testMoveY: function(b) {    var doc = b.doc();    // create box at 0,0    var rect = b.rect(0,0,100,100);    assert( b.itemY(rect) === 0);        // move to 50,0    b.itemY(rect, 50);    // check new x coordinate    assert( b.itemY(rect) === 50);  },  testPosition: function(b) {    var doc = b.doc();    // create box at 0,0    var rect = b.rect(0,0,100,100);    assert( b.itemPosition(rect).x === 0 && b.itemPosition(rect).y === 0);        // move to 50,0    b.itemPosition(rect, 50, 50);    // check new x coordinate    assert( b.itemPosition(rect).x === 50 && b.itemPosition(rect).y === 50);      },  testWidth: function(b) {    var doc = b.doc();    // create box at 0,0    var rect = b.rect(0,0,100,100);    assert( b.itemWidth(rect) === 100 );        // move to 50,0    b.itemWidth(rect, 50);    // check new x coordinate    assert( b.itemWidth(rect) === 50 );      },  testHeight: function(b) {    var doc = b.doc();    // create box at 0,0    var rect = b.rect(0,0,100,100);    assert( b.itemHeight(rect) === 100 );        // move to 50,0    b.itemHeight(rect, 50);    // check new x coordinate    assert( b.itemHeight(rect) === 50 );      },  testSize: function(b) {    var doc = b.doc();    // create box at 0,0    var rect = b.rect(0,0,100,100);    assert( b.itemSize(rect).width === 100 && b.itemSize(rect).height === 100 );        // move to 50,0    b.itemSize(rect, 50, 50);    // check new x coordinate    assert( b.itemSize(rect).width === 50 && b.itemSize(rect).height === 50 );      }  // todo: add matrix transformation tests here ...});// print collected test resultsb.test.result();
+if (typeof b === 'undefined') {
+  #include "../basil.js";
+}
+if (typeof b.test === 'undefined') {
+  #include "../lib/basil.test.js";  
+}
+
+b.test('TransformTests', {
+  
+  setUpTest: function(b) {
+  },
+
+  tearDownTest: function(b) {
+  },
+
+  setUp: function(b) {
+  },
+
+  tearDown: function(b) { 
+    b.close(SaveOptions.no); 
+  },
+
+  testMoveX: function(b) {
+    b.rectMode(b.CORNER);
+    var doc = b.doc();
+    // create box at 0,0
+    var rect = b.rect(0,0,100,100);
+    assert( b.itemX(rect) === 0);    
+    // move to 50,0
+    b.itemX(rect, 50);
+    // check new x coordinate
+    assert( b.itemX(rect) === 50);
+    rect.remove();
+    
+//~     b.rectMode(b.CENTER);
+//~     // create box at 0,0
+//~     var rect = b.rect(0,0,100,100);
+//~   
+//~     assert( b.itemX(rect) === 0);
+//~     // move to 50,0
+//~     b.itemX(rect, 50);
+//~     // check new x coordinate
+//~     assert( b.itemX(rect) === 50);
+//~     rect.remove();
+  },
+
+  testMoveY: function(b) {
+    var doc = b.doc();
+    // create box at 0,0
+    var rect = b.rect(0,0,100,100);
+    assert( b.itemY(rect) === 0);    
+    // move to 50,0
+    b.itemY(rect, 50);
+    // check new x coordinate
+    assert( b.itemY(rect) === 50);
+  },
+
+  testPosition: function(b) {
+    var doc = b.doc();
+    // create box at 0,0
+    var rect = b.rect(0,0,100,100);
+    assert( b.itemPosition(rect).x === 0 && b.itemPosition(rect).y === 0);    
+    // move to 50,0
+    b.itemPosition(rect, 50, 50);
+    // check new x coordinate
+    assert( b.itemPosition(rect).x === 50 && b.itemPosition(rect).y === 50);    
+  },
+
+  testWidth: function(b) {
+    var doc = b.doc();
+    // create box at 0,0
+    var rect = b.rect(0,0,100,100);
+    assert( b.itemWidth(rect) === 100 );    
+    // move to 50,0
+    b.itemWidth(rect, 50);
+    // check new x coordinate
+    assert( b.itemWidth(rect) === 50 );    
+  },
+
+  testHeight: function(b) {
+    var doc = b.doc();
+    // create box at 0,0
+    var rect = b.rect(0,0,100,100);
+    assert( b.itemHeight(rect) === 100 );    
+    // move to 50,0
+    b.itemHeight(rect, 50);
+    // check new x coordinate
+    assert( b.itemHeight(rect) === 50 );    
+  },
+
+  testSize: function(b) {
+    var doc = b.doc();
+    // create box at 0,0
+    var rect = b.rect(0,0,100,100);
+    assert( b.itemSize(rect).width === 100 && b.itemSize(rect).height === 100 );    
+    // move to 50,0
+    b.itemSize(rect, 50, 50);
+    // check new x coordinate
+    assert( b.itemSize(rect).width === 50 && b.itemSize(rect).height === 50 );    
+  }
+
+  // todo: add matrix transformation tests here ...
+
+});
+
+// print collected test results
+b.test.result();
+
+


### PR DESCRIPTION
This changes the default unit to MM and adds other minor improvements.

NOTE: I did run the test suite and it does _fail_ two of the tests in `/test/transform-tests.jsx`: `testHeight` and `testSize`.
However, after further testing, I think this might be due to some rounding error. When I insert some writeln statements before the failing assertions, it shows me that in fact it does, what it is expected to do. Try for example `/test/transform-tests.jsx` with these inserted writeln statements in the `testHeight` function:

```JavaScript
  testHeight: function(b) {
    var doc = b.doc();
    // create box at 0,0
    var rect = b.rect(0,0,100,100);

    $.writeln(b.itemHeight(rect)); // --> 100
    $.writeln(b.itemHeight(rect) === 100); // --> false - *should* be true, I guess?

    assert( b.itemHeight(rect) === 100 ); // --> fails here
    // move to 50,0
    b.itemHeight(rect, 50);
    // check new x coordinate
    $.writeln("BBB b.itemHeight(rect): " + b.itemHeight(rect));
    assert( b.itemHeight(rect) === 50 );
  },
```

This looks like a rounding error to me. In `testWidth` for example this does not happen. Maybe InDesign is calculating internally with PT and then has rounding errors happening sometimes when working with MM. Fact is, when you exit the script right before the failing assertion a rect was created which is exactly 100 mm x 100 mm large, according to the UI.