### PR TITLE
b.image() - bug fix and added error handling

### DIFF
--- a/includes/image.js
+++ b/includes/image.js
@@ -2,11 +2,11 @@
 // Image
 
 /**
- * Adds an image to the document. If the image argument is given as a string the image file  must be in the document's
+ * Adds an image to the document. If the image argument is given as a string the image file must be in the document's
  * data directory which is in the same directory where the document is saved in. The image argument can also be a File
  * instance which can be placed even before the document was saved.
  * The second argument can either be the x position of the frame to create or an instance of a rectangle,
- * oval or polygon to place the image in.
+ * oval or polygon to place the image in. If an x position is given, a y position must be given, too.
  * If x and y positions are given and width and height are not given, the frame's size gets set to the original image size.
  *
  * @cat Document
@@ -36,30 +36,38 @@ pub.image = function(img, x, y, w, h) {
       x instanceof Oval ||
       x instanceof Polygon) {
     frame = x;
-  } else {
+    fitOptions = FitOptions.FILL_PROPORTIONALLY;
+  } else if (typeof x === 'number' && typeof y === 'number') {
     width = 1;
     height = 1;
     if (currImageMode === pub.CORNERS) {
-      if (w && h){
+      if (typeof w === 'number' && typeof h === 'number'){
         width = w - x;
         height = h - y;
         fitOptions = FitOptions.FILL_PROPORTIONALLY;
-      } else {
+      } else if (arguments.length === 3){
         fitOptions = FitOptions.frameToContent;
+      } else {
+        error(imgErrorMsg);
       }
     } else {
-      if (w && h) {
+      if (typeof w === 'number' && typeof h === 'number'){
+        if (w <= 0 || h <= 0) error("b.image, invalid parameters. When using b.image(img, x, y, w, h) with the default imageMode b.CORNER, parameters w and h need to be greater than 0.") 
         width = w;
         height = h;
         fitOptions = FitOptions.FILL_PROPORTIONALLY;
-      } else {
+      } else if (arguments.length === 3){
         fitOptions = FitOptions.frameToContent;
+      } else {
+        error(imgErrorMsg);
       }
     }
     
     frame = currentPage().rectangles.add(currentLayer(), 
       { geometricBounds:[y, x, y + height, x + width] }
     );
+  } else {
+    error(imgErrorMsg);
   }
   
   frame.place(file);

--- a/includes/image.js
+++ b/includes/image.js
@@ -24,7 +24,14 @@ pub.image = function(img, x, y, w, h) {
     frame = null,
     fitOptions = null,
     width = null,
-    height = null;
+    height = null,
+    imgErrorMsg = "b.image(), wrong parameters. Use:\n"
+      + "b.image( {String|File}, {Rectangle|Oval|Polygon} ) or\n"
+      + "b.image( {String|File}, x, y ) or\n"
+      + "b.image( {String|File}, x, y, w, h )";
+
+  if(arguments.length < 2 || arguments.length === 4 || arguments.length > 5) error(imgErrorMsg);
+
   if (x instanceof Rectangle ||
       x instanceof Oval ||
       x instanceof Polygon) {
@@ -33,9 +40,13 @@ pub.image = function(img, x, y, w, h) {
     width = 1;
     height = 1;
     if (currImageMode === pub.CORNERS) {
-      width = w - x;
-      height = h - y;
-      fitOptions = FitOptions.FILL_PROPORTIONALLY;
+      if (w && h){
+        width = w - x;
+        height = h - y;
+        fitOptions = FitOptions.FILL_PROPORTIONALLY;
+      } else {
+        fitOptions = FitOptions.frameToContent;
+      }
     } else {
       if (w && h) {
         width = w;


### PR DESCRIPTION
This fixes and improves b.image().

- there was no error handling, when wrong parameters were passed. Now, meaningful error messages are given: a `imgErrorMsg` explains possible options to the user. 
- there was a bug (that was not "issued" yet) that gave a wrong image size when using `b.image(img, x, y)` with `b.imageMode(b.CORNERS)`. This was fixed now, it now imports the image in its original size at the provided corner, as the method description would let you expect it.
- throws an error now if `w` or `h` are not greater than `0` when using `b.image(img, x, y, w, h)` with `b.imageMode(b.CORNER)`.
- updates the method doc to make more clear that you cannot use `b.image(img, x)`, but have to use `b.image(img, x, y)` (as there was some confusion about this). However, even if the user uses `b.image(img, x)`, then he gets the new meaningful error message.

Fixes #49.

This passes all tests. Please review.