### PR TITLE
feat(size): Added document size function

### DIFF
--- a/includes/environment.js
+++ b/includes/environment.js
@@ -19,6 +19,46 @@ pub.doc = function(doc) {
 };
 
 /**
+ * @cat Document
+ * @method size
+ * @param  {Number} width The desired width of the current document
+ * @param  {Number} [height] optional the desired height of the current document. If not provided the widht will be used as the height.
+ * @return {Object} if no argument is given it returns an object containing the current widht and height of the document.
+ *
+ */
+pub.size = function(width, height){
+  if(app.documents.length === 0){
+    // there are no documents
+    warning('b.size(width, height)', 'You have no open document.');
+    return;
+  } else {
+    if (arguments.length === 0){
+      // no arguments given
+      // return the curent values
+      // warning('b.size(width, height)', 'no arguments given');
+      return {width: pub.width, height: pub.height};
+    }
+
+    if(arguments.length === 1){
+      // only one argument set the first to the secound
+      height = width;
+    }
+    var doc = app.documents[0];
+    // set the documents pageHeiht and pageWidth
+    doc.properties =  {
+      documentPreferences:{
+      pageHeight: height,
+      pageWidth: width
+      }
+    };
+    // set height and width
+    pub.height = height;
+    pub.width = width;
+  }
+
+}
+
+/**
  * Closes the current document.
  *
  * @cat Document

--- a/includes/environment.js
+++ b/includes/environment.js
@@ -19,11 +19,15 @@ pub.doc = function(doc) {
 };
 
 /**
+ * Sets the size of the current document, if arguments are given.
+ * If only one argument is given, both the width and the height are set to this value.
+ * If no argument is given, an object containing the current document's width and height is returned.
+ *
  * @cat Document
  * @method size
  * @param  {Number} width The desired width of the current document
- * @param  {Number} [height] optional the desired height of the current document. If not provided the widht will be used as the height.
- * @return {Object} if no argument is given it returns an object containing the current widht and height of the document.
+ * @param  {Number} [height] optional the desired height of the current document. If not provided the width will be used as the height.
+ * @return {Object} if no argument is given it returns an object containing the current width and height of the document.
  *
  */
 pub.size = function(width, height){

--- a/scripts/examples/environment/size.jsx
+++ b/scripts/examples/environment/size.jsx
@@ -1,0 +1,41 @@
+#includepath "~/Documents/;%USERPROFILE%Documents";
+#include "basiljs/bundle/basil.js";
+
+
+// The b.size([width,[height]]) function allows to get/set the size of
+// the current document.
+//
+// If no argument is given it returns the current values of
+// b.width and b.height in an object {"width":Number,"height":Number}.
+//
+// If one argument is provided the width and height both get set this this value.
+//
+// If two arguments are provided the first value is the width the second is the height.
+//
+// Lets try this out:
+//
+function setup(){
+  // For starters - lets get the size
+  var documentSize = b.size();
+  b.println(documentSize.toSource()); // lets see what we've got
+  // to see the changes of that document we add a text in the exact size
+  b.text(documentSize.toSource(), 0, 0, documentSize.width, documentSize.height);
+  // next we pass only one argument
+  b.size(documentSize.width * 2);
+  // lets get the size again for the next text frame.
+  documentSize = b.size();
+  // and draw the text again
+  b.text(documentSize.toSource(), 0, 0, documentSize.width, documentSize.height);
+  // finally lets set the size for width and height separately
+  b.size(documentSize.width, documentSize.height * 3);
+  // get the size again
+  documentSize = b.size();
+  // and draw another box
+  b.text(documentSize.toSource(),0, 0, documentSize.width, documentSize.height);
+}
+
+function draw(){
+  // nothing to see here
+}
+
+b.go();

--- a/test/environment-tests.jsx
+++ b/test/environment-tests.jsx
@@ -17,12 +17,34 @@ b.test('EnvironmentTests', {
   },
 
   tearDown: function(b) {
-    b.close(SaveOptions.no); 
+    b.close(SaveOptions.no);
   },
 
+  testSizeAllArgs: function(b){
+    var doc = app.documents.add();
+    b.size(100,200);
+    assert(doc.documentPreferences.pageWidth === 100);
+    assert(doc.documentPreferences.pageHeight === 200);
+  },
+  testSizeOneArg: function(b){
+    var doc = app.documents.add();
+    b.size(100);
+    assert(doc.documentPreferences.pageWidth === 100);
+    assert(doc.documentPreferences.pageHeight === 100);
+  },
+    testSizeNoArg: function(b){
+    var doc = app.documents.add();
+    var result = b.size();
+    assert(result instanceof Object);
+    assert(result.hasOwnProperty('height') === true);
+    assert(result.hasOwnProperty('width') === true);
+    assert(result.height === b.height);
+    assert(result.width === b.width);
+
+  },
   testDocCreatesDocument: function(b) {
     var doc = b.doc();
-        
+
     assert(doc instanceof Document);
     assert(app.documents.length === 1);
   },


### PR DESCRIPTION
Allows to get the current size as an Object set the width and height with one value or set the width
and height with two values

see issue #42 

test script:  

    function setup () {
      doc = b.doc();
      b.println('Get the size()');
      b.println(b.size().toSource()); // get the height and width
      b.println('set the size(100)');
      b.size(100); // set width and height to 100
      b.println('b.height: ' + b.height);
      b.println('b.width: ' + b.width);
      b.println('doc.documentPreferences.pageHeight: ' + doc.documentPreferences.pageHeight);
      b.println('doc.documentPreferences.pageWidth: ' + doc.documentPreferences.pageWidth);
      b.size(200,400);
      b.println('b.height: ' + b.height);
      b.println('b.width: ' + b.width);
      b.println('doc.documentPreferences.pageHeight: ' + doc.documentPreferences.pageHeight);
      b.println('doc.documentPreferences.pageWidth: ' + doc.documentPreferences.pageWidth);
    }
    
    function draw() {
    
    }
    b.go();