### PR TITLE
Allowing gradients for strokes

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.0.10 2016.10.10-08:25:01 */
+/* Basil.js v1.0.10 2016.10.24-03:18:56 */
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -4029,11 +4029,11 @@ pub.fill = function (fillColor) {
     } else if (arguments.length === 5) {
       currFillColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
     } else {
-      error("b.fill(), wrong parameters. Use: "
-        + "R,G,B,name or "
-        + "C,M,Y,K,name. "
-        + "Grey,name "
-        + "Name is optional");
+      error("b.fill(), wrong parameters. Use:\n"
+        + "R,G,B,[name] or\n"
+        + "C,M,Y,K,[name] or\n"
+        + "GREY,[name].\n"
+        + "Name is optional.");
     }
   }
 };
@@ -4050,14 +4050,14 @@ pub.noFill = function () {
 };
 
 /**
- * Sets the color used to draw lines and borders around shapes.
+ * Sets the color or gradient used to draw lines and borders around shapes.
  * @cat Color
  * @method stroke
- * @param  {Color|Swatch|Numbers} strokeColor  Accepts a Color/swatch or a string with the name of a color. Or values: C,M,Y,K / R,G,B / Grey
+ * @param  {Color|Gradient|Swatch|Numbers} strokeColor  Accepts a color/gradient/swatch or a string with the name of a color. Or values: C,M,Y,K / R,G,B / Grey
  */
 pub.stroke = function (strokeColor) {
   checkNull(strokeColor);
-  if (strokeColor instanceof Color || strokeColor instanceof Swatch) {
+  if (strokeColor instanceof Color || strokeColor instanceof Swatch || strokeColor instanceof Gradient) {
     currStrokeColor = strokeColor;
   } else {
     if (arguments.length === 1) {
@@ -4071,10 +4071,11 @@ pub.stroke = function (strokeColor) {
     } else if (arguments.length === 5) {
       currStrokeColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
     } else {
-      error("b.stroke(), too many parameters. Use: "
-        + "R,G,B,name or "
-        + "C,M,Y,K,name. "
-        + "Grey,name ");
+      error("b.stroke(), wrong parameters. Use:\n"
+        + "R,G,B,[name] or\n"
+        + "C,M,Y,K,[name] or\n"
+        + "GREY,[name].\n"
+        + "Name is optional.");
     }
   }
 };

--- a/scripts/examples/color/gradient.jsx
+++ b/scripts/examples/color/gradient.jsx
@@ -3,6 +3,7 @@
 
 function draw() {
   b.clear(b.doc());
+  b.noStroke();
 
   var dist = b.height / 4;
 
@@ -24,7 +25,7 @@ function draw() {
 
   // draw rectangles and fill them with different types of gradients
 
-  // grandient from color1 to color2 
+  // grandient from color1 to color2
   b.fill( b.gradient(red, blue, "RedBlueLinear") );
   b.rect(0, dist * 0, b.width, dist);
 
@@ -40,6 +41,13 @@ function draw() {
   b.gradientMode( b.RADIAL );
   b.fill( b.gradient(red, blue, "RedBlueRadial") );
   b.rect(0, dist * 3, b.width, dist);
+
+  // stroke gradient
+  b.noFill();
+  b.strokeWeight(4);
+  b.gradientMode( b.LINEAR );
+  b.stroke( b.gradient(blue, red, "BlueRedLinear"));
+  b.ellipse(b.width / 2, b.height / 2, dist * 2, dist * 2);
 }
 
 b.go();

--- a/src/includes/color.js
+++ b/src/includes/color.js
@@ -24,11 +24,11 @@ pub.fill = function (fillColor) {
     } else if (arguments.length === 5) {
       currFillColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
     } else {
-      error("b.fill(), wrong parameters. Use: "
-        + "R,G,B,name or "
-        + "C,M,Y,K,name. "
-        + "Grey,name "
-        + "Name is optional");
+      error("b.fill(), wrong parameters. Use:\n"
+        + "R,G,B,[name] or\n"
+        + "C,M,Y,K,[name] or\n"
+        + "GREY,[name].\n"
+        + "Name is optional.");
     }
   }
 };
@@ -45,14 +45,14 @@ pub.noFill = function () {
 };
 
 /**
- * Sets the color used to draw lines and borders around shapes.
+ * Sets the color or gradient used to draw lines and borders around shapes.
  * @cat Color
  * @method stroke
- * @param  {Color|Swatch|Numbers} strokeColor  Accepts a Color/swatch or a string with the name of a color. Or values: C,M,Y,K / R,G,B / Grey
+ * @param  {Color|Gradient|Swatch|Numbers} strokeColor  Accepts a color/gradient/swatch or a string with the name of a color. Or values: C,M,Y,K / R,G,B / Grey
  */
 pub.stroke = function (strokeColor) {
   checkNull(strokeColor);
-  if (strokeColor instanceof Color || strokeColor instanceof Swatch) {
+  if (strokeColor instanceof Color || strokeColor instanceof Swatch || strokeColor instanceof Gradient) {
     currStrokeColor = strokeColor;
   } else {
     if (arguments.length === 1) {
@@ -66,10 +66,11 @@ pub.stroke = function (strokeColor) {
     } else if (arguments.length === 5) {
       currStrokeColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
     } else {
-      error("b.stroke(), too many parameters. Use: "
-        + "R,G,B,name or "
-        + "C,M,Y,K,name. "
-        + "Grey,name ");
+      error("b.stroke(), wrong parameters. Use:\n"
+        + "R,G,B,[name] or\n"
+        + "C,M,Y,K,[name] or\n"
+        + "GREY,[name].\n"
+        + "Name is optional.");
     }
   }
 };


### PR DESCRIPTION
The recently introduced `b.gradient()` did not work with `b.stroke()` yet (oops …). This PR fixes that and updates and improves the docs and error messages for both `b.fill()` and `b.stroke()`.

A sample of using `b.gradient()` with a stroke has been added to the `gradient.jsx` sample script.

Passes all tests.