### PR TITLE
Adding b.LOREM; placing it in two example scripts

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.0.10 2016.11.01-00:17:16 */
+/* Basil.js v1.0.10 2016.11.04-20:27:57 */
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -33,6 +33,9 @@
   Please note: Big general parts e.g. random() of the basil.js source code are copied
   from processing.js by the Processing.js team. We would have had a hard time
   to figure all of that out on our own!
+
+  The Lorem ipsum string of b.LOREM is taken from https://indieweb.org/Lorem_ipsum and
+  is available under a CC0 public domain dedication.
 
   Supported Adobe InDesign versions: CS 5+
 
@@ -331,7 +334,7 @@ pub.AFTER = LocationOptions.AFTER;
  * @property LOREM {String}
  * @cat Typography
  */
-pub.LOREM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.";
+pub.LOREM = "Lorem ipsum is dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
 
 /**
 * Used with b.go() to set Performance Mode. Disables ScreenRedraw during processing.

--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.0.10 2016.10.24-03:18:56 */
+/* Basil.js v1.0.10 2016.11.01-00:17:16 */
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -325,6 +325,13 @@ pub.BEFORE = LocationOptions.BEFORE;
  * @subcat Page
  */
 pub.AFTER = LocationOptions.AFTER;
+
+/**
+ * Returns a Lorem ipsum string that can be used for testing.
+ * @property LOREM {String}
+ * @cat Typography
+ */
+pub.LOREM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.";
 
 /**
 * Used with b.go() to set Performance Mode. Disables ScreenRedraw during processing.

--- a/scripts/examples/shape/bounds.jsx
+++ b/scripts/examples/shape/bounds.jsx
@@ -2,22 +2,21 @@
 #include "basiljs/bundle/basil.js";
 
 function draw() {
-  var lorem = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
   b.textSize(21);
   b.strokeWeight(1);
   var oval = b.ellipse(400,50,150,80);
 
-  var textframe = b.text(lorem, 50,70,300,500);
+  var textframe = b.text(b.LOREM, 50,70,300,500);
 
   // text related bounds
   b.noFill();
   b.words(textframe, function (word) {
-    var txtbounds = b.bounds(word);  
+    var txtbounds = b.bounds(word);
     b.rect(txtbounds.left, txtbounds.top, txtbounds.width, txtbounds.height);
     b.ellipse( txtbounds.left, txtbounds.xHeight, 3,3 );
   });
 
-  
+
   b.fill('Black');
 
   // bounds of the oval

--- a/scripts/examples/shape/bounds.jsx
+++ b/scripts/examples/shape/bounds.jsx
@@ -4,32 +4,33 @@
 function draw() {
   b.textSize(21);
   b.strokeWeight(1);
-  var oval = b.ellipse(400,50,150,80);
+  var oval = b.ellipse(400, 50, 150, 80);
 
-  var textframe = b.text(b.LOREM, 50,70,300,500);
+  var textFrame = b.text(b.LOREM, 50, 70, 300, 500);
+
+  b.typo(textFrame, "hyphenation", false);
 
   // text related bounds
   b.noFill();
-  b.words(textframe, function (word) {
-    var txtbounds = b.bounds(word);
-    b.rect(txtbounds.left, txtbounds.top, txtbounds.width, txtbounds.height);
-    b.ellipse( txtbounds.left, txtbounds.xHeight, 3,3 );
+  b.words(textFrame, function (word) {
+    var textBounds = b.bounds(word);
+    b.rect(textBounds.left, textBounds.top, textBounds.width, textBounds.height);
+    b.ellipse(textBounds.left, textBounds.xHeight, 3, 3);
   });
 
-
-  b.fill('Black');
+  b.fill("Black");
 
   // bounds of the oval
-  var ovalbounds = b.bounds( oval );
-  b.text("ovalbounds", ovalbounds.left, ovalbounds.top, ovalbounds.width, ovalbounds.height);
+  var ovalBounds = b.bounds( oval );
+  b.text("ovalBounds", ovalBounds.left, ovalBounds.top, ovalBounds.width, ovalBounds.height);
 
   // bounds of page items
-  var pagebounds = b.bounds( b.page() );
-  for (var prop in pagebounds) {
-    b.println(prop+" "+pagebounds[prop]);
+  var pageBounds = b.bounds( b.page() );
+  for (var prop in pageBounds) {
+    b.println(prop + " " + pageBounds[prop]);
   }
-  b.println( pagebounds.width);
-  b.text("pagebounds", pagebounds.left, pagebounds.top, pagebounds.width, pagebounds.height);
+  b.println( pageBounds.width);
+  b.text("pageBounds", pageBounds.left, pageBounds.top, pageBounds.width, pageBounds.height);
 };
 
 b.go();

--- a/scripts/examples/typography/linkTextFrames.jsx
+++ b/scripts/examples/typography/linkTextFrames.jsx
@@ -3,11 +3,9 @@
 
 function draw() {
   b.textFont('Helvetica\tBold');
-  b.textSize(22);
+  b.textSize(16);
 
-  var lorem = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient";
-
-  var textframeA = b.text(lorem, 0, 0, 100, 100);
+  var textframeA = b.text(b.LOREM, 0, 0, 100, 100);
   var textframeB = b.text('', 100, 100, 100, 100);
   b.linkTextFrames(textframeA, textframeB);
   var textframeC = b.text('', 200, 200, 100, 100);

--- a/src/includes/constants.js
+++ b/src/includes/constants.js
@@ -269,6 +269,13 @@ pub.BEFORE = LocationOptions.BEFORE;
 pub.AFTER = LocationOptions.AFTER;
 
 /**
+ * Returns a Lorem ipsum string that can be used for testing.
+ * @property LOREM {String}
+ * @cat Typography
+ */
+pub.LOREM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.";
+
+/**
 * Used with b.go() to set Performance Mode. Disables ScreenRedraw during processing.
 * @property MODESILENT {String}
 * @cat Environment

--- a/src/includes/constants.js
+++ b/src/includes/constants.js
@@ -273,7 +273,7 @@ pub.AFTER = LocationOptions.AFTER;
  * @property LOREM {String}
  * @cat Typography
  */
-pub.LOREM = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.";
+pub.LOREM = "Lorem ipsum is dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
 
 /**
 * Used with b.go() to set Performance Mode. Disables ScreenRedraw during processing.

--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,9 @@
   from processing.js by the Processing.js team. We would have had a hard time
   to figure all of that out on our own!
 
+  The Lorem ipsum string of b.LOREM is taken from https://indieweb.org/Lorem_ipsum and
+  is available under a CC0 public domain dedication.
+
   Supported Adobe InDesign versions: CS 5+
 
   .--.--.- .-.-......-....--.-- -.... -..---.-.... .-- . .---.- -... -.-..---.-. ..--.-- -.. -


### PR DESCRIPTION
To get things going: the new `b.LOREM`.

I put it in two example scripts where I found it appropriate. There are 2 or 3 more example scripts with a lorem at the moment, but I think in those other cases we could use the upcoming `b.placeholder()` instead.

Closes #108.