### PR TITLE
b.placeholder()

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.0.10 2016.10.24-18:38:50 */
+/* Basil.js v1.0.10 2016.11.07-17:50:59 */
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -4818,15 +4818,19 @@ pub.linkTextFrames = function (textFrameA, textFrameB) {
 };
 
 /**
- * Fills the given textFrame and all linked textFrame with random placeholder text. Text already existing in the textFrames will not be overwritten.
+ * Fills the given textFrame and all linked textFrame with random placeholder text. The placeholder text will be added at the end of any already existing text in the text frame.
  *
  * @cat Story
  * @method placeholder
  * @param  {TextFrame} textFrame
+ * @return {Text} The inserted placeholder text.
  */
 pub.placeholder = function (textFrame) {
   if (textFrame instanceof TextFrame) {
-    textFrame.parentStory.insertionPoints[-1].contents = TextFrameContents.PLACEHOLDER_TEXT;
+    var startIx = textFrame.parentStory.insertionPoints[-1].index;
+    textFrame.contents = TextFrameContents.PLACEHOLDER_TEXT;
+    var endIx = textFrame.parentStory.insertionPoints[-1].index - 1;
+    return textFrame.parentStory.characters.itemByRange(startIx, endIx);
   } else {
     error("placeholder(), wrong type of parameter! Use: textFrame");
   }

--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.0.10 2016.10.10-08:25:01 */
+/* Basil.js v1.0.10 2016.10.24-18:38:50 */
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -4817,6 +4817,20 @@ pub.linkTextFrames = function (textFrameA, textFrameB) {
   }
 };
 
+/**
+ * Fills the given textFrame and all linked textFrame with random placeholder text. Text already existing in the textFrames will not be overwritten.
+ *
+ * @cat Story
+ * @method placeholder
+ * @param  {TextFrame} textFrame
+ */
+pub.placeholder = function (textFrame) {
+  if (textFrame instanceof TextFrame) {
+    textFrame.parentStory.insertionPoints[-1].contents = TextFrameContents.PLACEHOLDER_TEXT;
+  } else {
+    error("placeholder(), wrong type of parameter! Use: textFrame");
+  }
+};
 // ----------------------------------------
 // Image
 

--- a/scripts/examples/typography/placeholder.jsx
+++ b/scripts/examples/typography/placeholder.jsx
@@ -1,0 +1,18 @@
+#includepath "~/Documents/;%USERPROFILE%Documents";
+#include "basiljs/bundle/basil.js";
+
+function draw() {
+
+  b.clear(b.doc());
+
+  var textFrameA = b.text("", 0, 0, 200, 200);
+  var textFrameB = b.text("", 200, 200, 200, 200);
+
+  b.linkTextFrames(textFrameA, textFrameB);
+
+  textFrameA.contents = TextFrameContents.PLACEHOLDER_TEXT;
+
+}
+
+
+b.go();

--- a/scripts/examples/typography/placeholder.jsx
+++ b/scripts/examples/typography/placeholder.jsx
@@ -3,16 +3,27 @@
 
 function draw() {
 
-  b.clear(b.doc());
+  b.units(b.MM);
 
-  var textFrameA = b.text("Lorem ipsum", 0, 0, 200, 200);
-  var textFrameB = b.text("", 200, 200, 200, 200);
+  // filling an empty text frame with placeholder text
+  var textFrameA = b.text("", 0, 0, 60, 60);
+  var placeholderA = b.placeholder(textFrameA);
 
-  b.linkTextFrames(textFrameA, textFrameB);
+  // filling a non-empty text frame with placeholder text
+  var textFrameB = b.text("Placeholder text is added behind existing text: ", 0, 80, 60, 60);
+  var placeholderB = b.placeholder(textFrameB);
 
-  b.placeholder(textFrameA);
+  // filling linked text frames with placeholder text
+  var textFrameC = b.text("Placeholder text filling linked text frames: ", 0, 160, 60, 60);
+  var textFrameD = b.text("", 60, 220, 60, 60);
+  b.linkTextFrames(textFrameC, textFrameD);
+  var placeholderC = b.placeholder(textFrameC);
+
+  // styling placeholder text
+  b.typo(placeholderA, "fillColor", b.color(255, 0, 0));
+  b.typo(placeholderB, "fillColor", b.color(0, 200, 0));
+  b.typo(placeholderC, "fillColor", b.color(0, 0, 255));
 
 }
-
 
 b.go();

--- a/scripts/examples/typography/placeholder.jsx
+++ b/scripts/examples/typography/placeholder.jsx
@@ -5,12 +5,12 @@ function draw() {
 
   b.clear(b.doc());
 
-  var textFrameA = b.text("", 0, 0, 200, 200);
+  var textFrameA = b.text("Lorem ipsum", 0, 0, 200, 200);
   var textFrameB = b.text("", 200, 200, 200, 200);
 
   b.linkTextFrames(textFrameA, textFrameB);
 
-  textFrameA.contents = TextFrameContents.PLACEHOLDER_TEXT;
+  b.placeholder(textFrameA);
 
 }
 

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -294,15 +294,19 @@ pub.linkTextFrames = function (textFrameA, textFrameB) {
 };
 
 /**
- * Fills the given textFrame and all linked textFrame with random placeholder text. Text already existing in the textFrames will not be overwritten.
+ * Fills the given textFrame and all linked textFrame with random placeholder text. The placeholder text will be added at the end of any already existing text in the text frame.
  *
  * @cat Story
  * @method placeholder
  * @param  {TextFrame} textFrame
+ * @return {Text} The inserted placeholder text.
  */
 pub.placeholder = function (textFrame) {
   if (textFrame instanceof TextFrame) {
-    textFrame.parentStory.insertionPoints[-1].contents = TextFrameContents.PLACEHOLDER_TEXT;
+    var startIx = textFrame.parentStory.insertionPoints[-1].index;
+    textFrame.contents = TextFrameContents.PLACEHOLDER_TEXT;
+    var endIx = textFrame.parentStory.insertionPoints[-1].index - 1;
+    return textFrame.parentStory.characters.itemByRange(startIx, endIx);
   } else {
     error("placeholder(), wrong type of parameter! Use: textFrame");
   }

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -292,3 +292,18 @@ pub.linkTextFrames = function (textFrameA, textFrameB) {
     error("linkTextFrames(), wrong type of parameter! linkTextFrames() needs two textFrame objects to link the stories. Use: textFrameA, textFrameB");
   }
 };
+
+/**
+ * Fills the given textFrame and all linked textFrame with random placeholder text. Text already existing in the textFrames will not be overwritten.
+ *
+ * @cat Story
+ * @method placeholder
+ * @param  {TextFrame} textFrame
+ */
+pub.placeholder = function (textFrame) {
+  if (textFrame instanceof TextFrame) {
+    textFrame.parentStory.insertionPoints[-1].contents = TextFrameContents.PLACEHOLDER_TEXT;
+  } else {
+    error("placeholder(), wrong type of parameter! Use: textFrame");
+  }
+};


### PR DESCRIPTION
As discussed in #108 this adds `b.placeholder()` which can be used to fill textFrames with InDesign's semi-random placeholder text.

Usage is simply `b.placeholder(tf);`. It also returns the generated placeholder text, so you can do

```js
var tf = b.text("Initial text", 0, 0, 100, 100);
var ph = b.placeholder(tf);
b.typo(ph, "fillColor", b.color(255, 0, 0);
```

Added an example script as well, which creates these simple sample cases:

![bildschirmfoto 2016-11-07 um 18 09 29](https://cloud.githubusercontent.com/assets/9803905/20067507/b4f7e02a-a515-11e6-809a-328a7491d4c5.png)

This passes all tests. Please review. 😎 