### PR TITLE
Text collection fix

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.0.10 2016.11.04-20:27:57 */
+/* Basil.js v1.0.10 2016.11.08-02:37:21 */
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -1232,30 +1232,20 @@ pub.stories = function(doc, cb) {
 };
 
 /**
- * If no callback function is given it returns a Collection of items otherwise calls the given callback function with each paragraph of the given document, story or text frame.
+ * If no callback function is given it returns a Collection of paragraphs in the container otherwise calls the given callback function with each paragraph of the given document, page, story or textFrame.
  *
  * @cat Document
  * @subcat Multi-Getters
  * @method paragraphs
- * @param  {Document|Story|TextFrame} item The story or text frame instance to iterate the paragraphs in
+ * @param  {Document|Page|Story|TextFrame} container The document, story, page or textFrame instance to iterate the paragraphs in
  * @param  {Function} [cb]  Optional: The callback function to call with each paragraph. When this function returns false the loop stops. Passed arguments: para, loopCount
  * @return {Paragraphs[]} Array of Paragraphs.
  */
-pub.paragraphs = function(item, cb) {
+pub.paragraphs = function(container, cb) {
 
-  checkNull(item);
+  var legalContainers = "Document, Story, Page or TextFrame.";
+  textCollection("paragraphs", legalContainers, container, cb);
 
-  if(!item.hasOwnProperty("contents")) error("b.paragraphs(), Wrong object type.");
-
-  if(arguments.length === 1) {
-    return item.paragraphs;
-  } else if (cb instanceof Function) {
-    if (item instanceof Document) {
-      return forEachStoryProperty(item, "paragraphs", cb);
-    } else {
-      return forEach(item.paragraphs, cb);
-    }
-  }
 };
 
 // /**
@@ -1302,101 +1292,107 @@ pub.paragraphs = function(item, cb) {
 // };
 
 /**
- * If no callback function is given it returns a Collection of items otherwise calls the given callback function with each line of the given document, story, text frame or paragraph.
+ * If no callback function is given it returns a Collection of lines in the container otherwise calls the given callback function with each line of the given document, page, story, textFrame or paragraph.
  *
  * @cat Document
  * @subcat Multi-Getters
  * @method lines
- * @param  {Document|Story|TextFrame|Paragraph} item The document, story, text frame or paragraph instance to
+ * @param  {Document|Page|Story|TextFrame|Paragraph} container The document, page, story, textFrame or paragraph instance to
  *                                                   iterate the lines in
  * @param  {Function} [cb] Optional: The callback function to call with each line. When this function returns false the loop stops. Passed arguments: line, loopCount
  * @return {Lines[]} Array of lines.
  */
-pub.lines = function(item, cb) {
+pub.lines = function(container, cb) {
 
-  checkNull(item);
+  var legalContainers = "Document, Story, Page, TextFrame or Paragraph.";
+  textCollection("lines", legalContainers, container, cb);
 
-  if(!item.hasOwnProperty("contents")) error("b.lines(), Wrong object type.");
-
-  if(arguments.length === 1) {
-    return item.lines;
-  } else if (cb instanceof Function) {
-    if (item instanceof Document) {
-      return forEachStoryProperty(item, "lines", cb);
-    } else {
-      return forEach(item.lines, cb);
-    }
-  }
 };
 
 /**
- * If no callback function is given it returns a Collection of items otherwise calls the given callback function with each word of the given document, story, text frame, paragraph or line.
+ * If no callback function is given it returns a Collection of words in the container otherwise calls the given callback function with each word of the given document, page, story, textFrame, paragraph or line.
  *
  * @cat Document
  * @subcat Multi-Getters
  * @method words
- * @param  {Document|Story|TextFrame|Paragraph|Line} item The document, story, text frame, paragraph or line instance
+ * @param  {Document|Page|Story|TextFrame|Paragraph|Line} container The document, page, story, textFrame, paragraph or line instance
  *                                                        to iterate the words in
  * @param  {Function} [cb] Optional: The callback function to call with each word. When this function returns false the loop stops. Passed arguments: word, loopCount
  * @return {Words[]} Array of Words.
  */
-pub.words = function(item, cb) {
+pub.words = function(container, cb) {
 
-  checkNull(item);
+  var legalContainers = "Document, Story, Page, TextFrame, Paragraph or Line.";
+  textCollection("words", legalContainers, container, cb);
 
-  if(!item.hasOwnProperty("contents")) error("b.words(), Wrong object type.");
-
-  if(arguments.length === 1) {
-    return item.words;
-  } else if (cb instanceof Function) {
-    if (item instanceof Document) {
-      return forEachStoryProperty(item, "words", cb);
-    } else {
-      return forEach(item.words, cb);
-    }
-  }
 };
 
 /**
- * If no callback function is given it returns a Collection of items otherwise calls the given callback function with each character of the given document, story, text frame, paragraph, line or word.
+ * If no callback function is given it returns a Collection of characters in the container otherwise calls the given callback function with each character of the given document, page, story, textFrame, paragraph, line or word.
  *
  * @cat Document
  * @subcat Multi-Getters
  * @method characters
- * @param  {Document|Story|TextFrame|Paragraph|Line|Word} item The document, story, text frame, paragraph, line or word instance to
+ * @param  {Document|Page|Story|TextFrame|Paragraph|Line|Word} container The document, page, story, textFrame, paragraph, line or word instance to
  *                                                    iterate the characters in
  * @param  {Function} [cb] Optional: The callback function to call with each character. When this function returns false the loop stops. Passed arguments: character, loopCount
  * @return {Characters} You can use it like an array.
  */
-pub.characters = function(item, cb) {
+pub.characters = function(container, cb) {
 
-  checkNull(item);
+  var legalContainers = "Document, Story, Page, TextFrame, Paragraph, Line or Word.";
+  textCollection("characters", legalContainers, container, cb);
 
-  if(!item.hasOwnProperty("contents")) error("b.characters(), Wrong object type.");
+};
 
-  if(arguments.length === 1) {
-    return item.characters;
-  } else if (cb instanceof Function) {
-    if (item instanceof Document) {
-      return forEachStoryProperty(item, "characters", cb);
+var textCollection = function(collection, legalContainers, container, cb) {
+
+  checkNull(container);
+
+  if(!(container.hasOwnProperty("contents") || container instanceof Document || container instanceof Page)) {
+    error("b." + collection + "(), wrong object type. Use: " + legalContainers);
+  }
+  if(arguments.length > 3 && !(cb instanceof Function)) {
+    error("b." + collection + "(), wrong function parameter. Use: container, cb. cb must be a function.");
+  }
+
+  if(cb) {
+    // callback function is passed
+    if (container instanceof Document || container instanceof Page) {
+      return forEachTextCollection(container, collection, cb);
     } else {
-      return forEach(item.characters, cb);
+      return forEach(container[collection], cb);
+    }
+  } else {
+    // no callback function is passed
+    if(container instanceof Document) {
+      return container.stories.everyItem()[collection];
+    } else if (container instanceof Page) {
+      return container.textFrames.everyItem()[collection];
+    } else {
+      return container[collection];
     }
   }
+}
+
+var forEachTextCollection = function(container, collection, cb) {
+  var collection;
+  if(container instanceof Document) {
+    collection = container.stories.everyItem()[collection];
+  } else if (container instanceof Page) {
+    collection = container.textFrames.everyItem()[collection];
+  } else {
+    collection = container[collection];
+  }
+
+  for (var i = 0; i < collection.length; i++) {
+    if(cb(collection[i], i) === false) {
+      return false;
+    }
+  }
+  return true;
 };
 
-var forEachStoryProperty = function(doc, property, cb) {
-  var loopCount = 0;
-  pub.stories(doc, function(story) {
-    var properties = story[property];
-    for (var i = 0, len = properties.length; i < len; i++) {
-      if(cb(properties[i], loopCount++) === false) {
-        return false;
-      }
-    }
-    return true;
-  });
-};
 
 /**
  * If no callback function is given it returns a Collection of items otherwise calls the given callback function for each of the PageItems in the given Document, Page, Layer or Group.

--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.0.10 2016.11.08-02:37:21 */
+/* Basil.js v1.0.10 2016.11.08-03:38:37 */
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -1379,10 +1379,8 @@ var forEachTextCollection = function(container, collection, cb) {
   var collection;
   if(container instanceof Document) {
     collection = container.stories.everyItem()[collection];
-  } else if (container instanceof Page) {
-    collection = container.textFrames.everyItem()[collection];
   } else {
-    collection = container[collection];
+    collection = container.textFrames.everyItem()[collection];
   }
 
   for (var i = 0; i < collection.length; i++) {

--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.0.10 2016.11.08-03:38:37 */
+/* Basil.js v1.0.10 2016.11.08-04:13:40 */
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -1244,7 +1244,7 @@ pub.stories = function(doc, cb) {
 pub.paragraphs = function(container, cb) {
 
   var legalContainers = "Document, Story, Page or TextFrame.";
-  textCollection("paragraphs", legalContainers, container, cb);
+  return textCollection("paragraphs", legalContainers, container, cb);
 
 };
 
@@ -1305,7 +1305,7 @@ pub.paragraphs = function(container, cb) {
 pub.lines = function(container, cb) {
 
   var legalContainers = "Document, Story, Page, TextFrame or Paragraph.";
-  textCollection("lines", legalContainers, container, cb);
+  return textCollection("lines", legalContainers, container, cb);
 
 };
 
@@ -1323,7 +1323,7 @@ pub.lines = function(container, cb) {
 pub.words = function(container, cb) {
 
   var legalContainers = "Document, Story, Page, TextFrame, Paragraph or Line.";
-  textCollection("words", legalContainers, container, cb);
+  return textCollection("words", legalContainers, container, cb);
 
 };
 
@@ -1341,7 +1341,7 @@ pub.words = function(container, cb) {
 pub.characters = function(container, cb) {
 
   var legalContainers = "Document, Story, Page, TextFrame, Paragraph, Line or Word.";
-  textCollection("characters", legalContainers, container, cb);
+  return textCollection("characters", legalContainers, container, cb);
 
 };
 
@@ -1352,11 +1352,8 @@ var textCollection = function(collection, legalContainers, container, cb) {
   if(!(container.hasOwnProperty("contents") || container instanceof Document || container instanceof Page)) {
     error("b." + collection + "(), wrong object type. Use: " + legalContainers);
   }
-  if(arguments.length > 3 && !(cb instanceof Function)) {
-    error("b." + collection + "(), wrong function parameter. Use: container, cb. cb must be a function.");
-  }
 
-  if(cb) {
+  if(cb instanceof Function) {
     // callback function is passed
     if (container instanceof Document || container instanceof Page) {
       return forEachTextCollection(container, collection, cb);

--- a/scripts/examples/structure/forEach-loops.jsx
+++ b/scripts/examples/structure/forEach-loops.jsx
@@ -2,7 +2,7 @@
 #include "basiljs/bundle/basil.js";
 
 function setup() {
-  var contents = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\rUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.';
+  var contents = 'This is the first paragraph of the text frame.\rThis is the second one.';
   b.text(contents, 0, 0, 400, 200);
   b.text(contents, 0, 400, 400, 200);
 

--- a/src/includes/structure.js
+++ b/src/includes/structure.js
@@ -184,10 +184,8 @@ var forEachTextCollection = function(container, collection, cb) {
   var collection;
   if(container instanceof Document) {
     collection = container.stories.everyItem()[collection];
-  } else if (container instanceof Page) {
-    collection = container.textFrames.everyItem()[collection];
   } else {
-    collection = container[collection];
+    collection = container.textFrames.everyItem()[collection];
   }
 
   for (var i = 0; i < collection.length; i++) {

--- a/src/includes/structure.js
+++ b/src/includes/structure.js
@@ -37,30 +37,20 @@ pub.stories = function(doc, cb) {
 };
 
 /**
- * If no callback function is given it returns a Collection of items otherwise calls the given callback function with each paragraph of the given document, story or text frame.
+ * If no callback function is given it returns a Collection of paragraphs in the container otherwise calls the given callback function with each paragraph of the given document, page, story or textFrame.
  *
  * @cat Document
  * @subcat Multi-Getters
  * @method paragraphs
- * @param  {Document|Story|TextFrame} item The story or text frame instance to iterate the paragraphs in
+ * @param  {Document|Page|Story|TextFrame} container The document, story, page or textFrame instance to iterate the paragraphs in
  * @param  {Function} [cb]  Optional: The callback function to call with each paragraph. When this function returns false the loop stops. Passed arguments: para, loopCount
  * @return {Paragraphs[]} Array of Paragraphs.
  */
-pub.paragraphs = function(item, cb) {
+pub.paragraphs = function(container, cb) {
 
-  checkNull(item);
+  var legalContainers = "Document, Story, Page or TextFrame.";
+  textCollection("paragraphs", legalContainers, container, cb);
 
-  if(!item.hasOwnProperty("contents")) error("b.paragraphs(), Wrong object type.");
-
-  if(arguments.length === 1) {
-    return item.paragraphs;
-  } else if (cb instanceof Function) {
-    if (item instanceof Document) {
-      return forEachStoryProperty(item, "paragraphs", cb);
-    } else {
-      return forEach(item.paragraphs, cb);
-    }
-  }
 };
 
 // /**
@@ -107,101 +97,107 @@ pub.paragraphs = function(item, cb) {
 // };
 
 /**
- * If no callback function is given it returns a Collection of items otherwise calls the given callback function with each line of the given document, story, text frame or paragraph.
+ * If no callback function is given it returns a Collection of lines in the container otherwise calls the given callback function with each line of the given document, page, story, textFrame or paragraph.
  *
  * @cat Document
  * @subcat Multi-Getters
  * @method lines
- * @param  {Document|Story|TextFrame|Paragraph} item The document, story, text frame or paragraph instance to
+ * @param  {Document|Page|Story|TextFrame|Paragraph} container The document, page, story, textFrame or paragraph instance to
  *                                                   iterate the lines in
  * @param  {Function} [cb] Optional: The callback function to call with each line. When this function returns false the loop stops. Passed arguments: line, loopCount
  * @return {Lines[]} Array of lines.
  */
-pub.lines = function(item, cb) {
+pub.lines = function(container, cb) {
 
-  checkNull(item);
+  var legalContainers = "Document, Story, Page, TextFrame or Paragraph.";
+  textCollection("lines", legalContainers, container, cb);
 
-  if(!item.hasOwnProperty("contents")) error("b.lines(), Wrong object type.");
-
-  if(arguments.length === 1) {
-    return item.lines;
-  } else if (cb instanceof Function) {
-    if (item instanceof Document) {
-      return forEachStoryProperty(item, "lines", cb);
-    } else {
-      return forEach(item.lines, cb);
-    }
-  }
 };
 
 /**
- * If no callback function is given it returns a Collection of items otherwise calls the given callback function with each word of the given document, story, text frame, paragraph or line.
+ * If no callback function is given it returns a Collection of words in the container otherwise calls the given callback function with each word of the given document, page, story, textFrame, paragraph or line.
  *
  * @cat Document
  * @subcat Multi-Getters
  * @method words
- * @param  {Document|Story|TextFrame|Paragraph|Line} item The document, story, text frame, paragraph or line instance
+ * @param  {Document|Page|Story|TextFrame|Paragraph|Line} container The document, page, story, textFrame, paragraph or line instance
  *                                                        to iterate the words in
  * @param  {Function} [cb] Optional: The callback function to call with each word. When this function returns false the loop stops. Passed arguments: word, loopCount
  * @return {Words[]} Array of Words.
  */
-pub.words = function(item, cb) {
+pub.words = function(container, cb) {
 
-  checkNull(item);
+  var legalContainers = "Document, Story, Page, TextFrame, Paragraph or Line.";
+  textCollection("words", legalContainers, container, cb);
 
-  if(!item.hasOwnProperty("contents")) error("b.words(), Wrong object type.");
-
-  if(arguments.length === 1) {
-    return item.words;
-  } else if (cb instanceof Function) {
-    if (item instanceof Document) {
-      return forEachStoryProperty(item, "words", cb);
-    } else {
-      return forEach(item.words, cb);
-    }
-  }
 };
 
 /**
- * If no callback function is given it returns a Collection of items otherwise calls the given callback function with each character of the given document, story, text frame, paragraph, line or word.
+ * If no callback function is given it returns a Collection of characters in the container otherwise calls the given callback function with each character of the given document, page, story, textFrame, paragraph, line or word.
  *
  * @cat Document
  * @subcat Multi-Getters
  * @method characters
- * @param  {Document|Story|TextFrame|Paragraph|Line|Word} item The document, story, text frame, paragraph, line or word instance to
+ * @param  {Document|Page|Story|TextFrame|Paragraph|Line|Word} container The document, page, story, textFrame, paragraph, line or word instance to
  *                                                    iterate the characters in
  * @param  {Function} [cb] Optional: The callback function to call with each character. When this function returns false the loop stops. Passed arguments: character, loopCount
  * @return {Characters} You can use it like an array.
  */
-pub.characters = function(item, cb) {
+pub.characters = function(container, cb) {
 
-  checkNull(item);
+  var legalContainers = "Document, Story, Page, TextFrame, Paragraph, Line or Word.";
+  textCollection("characters", legalContainers, container, cb);
 
-  if(!item.hasOwnProperty("contents")) error("b.characters(), Wrong object type.");
+};
 
-  if(arguments.length === 1) {
-    return item.characters;
-  } else if (cb instanceof Function) {
-    if (item instanceof Document) {
-      return forEachStoryProperty(item, "characters", cb);
+var textCollection = function(collection, legalContainers, container, cb) {
+
+  checkNull(container);
+
+  if(!(container.hasOwnProperty("contents") || container instanceof Document || container instanceof Page)) {
+    error("b." + collection + "(), wrong object type. Use: " + legalContainers);
+  }
+  if(arguments.length > 3 && !(cb instanceof Function)) {
+    error("b." + collection + "(), wrong function parameter. Use: container, cb. cb must be a function.");
+  }
+
+  if(cb) {
+    // callback function is passed
+    if (container instanceof Document || container instanceof Page) {
+      return forEachTextCollection(container, collection, cb);
     } else {
-      return forEach(item.characters, cb);
+      return forEach(container[collection], cb);
+    }
+  } else {
+    // no callback function is passed
+    if(container instanceof Document) {
+      return container.stories.everyItem()[collection];
+    } else if (container instanceof Page) {
+      return container.textFrames.everyItem()[collection];
+    } else {
+      return container[collection];
     }
   }
+}
+
+var forEachTextCollection = function(container, collection, cb) {
+  var collection;
+  if(container instanceof Document) {
+    collection = container.stories.everyItem()[collection];
+  } else if (container instanceof Page) {
+    collection = container.textFrames.everyItem()[collection];
+  } else {
+    collection = container[collection];
+  }
+
+  for (var i = 0; i < collection.length; i++) {
+    if(cb(collection[i], i) === false) {
+      return false;
+    }
+  }
+  return true;
 };
 
-var forEachStoryProperty = function(doc, property, cb) {
-  var loopCount = 0;
-  pub.stories(doc, function(story) {
-    var properties = story[property];
-    for (var i = 0, len = properties.length; i < len; i++) {
-      if(cb(properties[i], loopCount++) === false) {
-        return false;
-      }
-    }
-    return true;
-  });
-};
 
 /**
  * If no callback function is given it returns a Collection of items otherwise calls the given callback function for each of the PageItems in the given Document, Page, Layer or Group.

--- a/src/includes/structure.js
+++ b/src/includes/structure.js
@@ -49,7 +49,7 @@ pub.stories = function(doc, cb) {
 pub.paragraphs = function(container, cb) {
 
   var legalContainers = "Document, Story, Page or TextFrame.";
-  textCollection("paragraphs", legalContainers, container, cb);
+  return textCollection("paragraphs", legalContainers, container, cb);
 
 };
 
@@ -110,7 +110,7 @@ pub.paragraphs = function(container, cb) {
 pub.lines = function(container, cb) {
 
   var legalContainers = "Document, Story, Page, TextFrame or Paragraph.";
-  textCollection("lines", legalContainers, container, cb);
+  return textCollection("lines", legalContainers, container, cb);
 
 };
 
@@ -128,7 +128,7 @@ pub.lines = function(container, cb) {
 pub.words = function(container, cb) {
 
   var legalContainers = "Document, Story, Page, TextFrame, Paragraph or Line.";
-  textCollection("words", legalContainers, container, cb);
+  return textCollection("words", legalContainers, container, cb);
 
 };
 
@@ -146,7 +146,7 @@ pub.words = function(container, cb) {
 pub.characters = function(container, cb) {
 
   var legalContainers = "Document, Story, Page, TextFrame, Paragraph, Line or Word.";
-  textCollection("characters", legalContainers, container, cb);
+  return textCollection("characters", legalContainers, container, cb);
 
 };
 
@@ -157,11 +157,8 @@ var textCollection = function(collection, legalContainers, container, cb) {
   if(!(container.hasOwnProperty("contents") || container instanceof Document || container instanceof Page)) {
     error("b." + collection + "(), wrong object type. Use: " + legalContainers);
   }
-  if(arguments.length > 3 && !(cb instanceof Function)) {
-    error("b." + collection + "(), wrong function parameter. Use: container, cb. cb must be a function.");
-  }
 
-  if(cb) {
+  if(cb instanceof Function) {
     // callback function is passed
     if (container instanceof Document || container instanceof Page) {
       return forEachTextCollection(container, collection, cb);


### PR DESCRIPTION
To somewhat prove the point that I'm not only complaining and making up issues: Here's a bug fix. 😉

This fixes the bug with text collections when using a `document` as a container as described in #116. So stuff like `b.words(b.doc())` now works again.

Additionally I added `page` as a possible container.

Here is the changes I made:
- since all the textCollection functions were basically repetitive I created one generic helper function to handle all the functionality. The original textCollection functions now only pass the type of collection to this helper function. This is cleaner and will make future changes easier as we only have to change one function, not 5.
- in all the textCollection functions I renamed `item` to `container` for clarity.
- I replaced the function 'forEachStoryProperty()' with the simplified 'forEachTextCollection()' that also works with `page` as the container.
- I updated and improved the docs
- I created more meaningful error messages that state which containers are legal
- shortened the dummy text of the "forEach-loops.jsx" sample script (I used this script for testing and it runs ridiculously long with the original text, looping over all the characters).

I ran all tests, no fails. I also ran benchmarks, the new version is pretty much exactly as fast/slow as the old version.

This fixes #116.

Please review. 😎