### PR TITLE
chore(bundling): add npm release task

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "bundle": "./node_modules/.bin/exsbundlr -i src/main.js -o basil.js -p '/* Basil.js v'${npm_package_version}' '$(date '+%Y.%m.%d-%H:%M:%S')' */'",
+    "bundle": "./node_modules/.bin/exsbundlr -i src/main.js -o basil.js",
+    "release": "./node_modules/.bin/exsbundlr -i src/main.js -o basil.js -p '/* Basil.js v'${npm_package_version}' '$(date '+%Y.%m.%d-%H:%M:%S')' */'",
     "watch":"./node_modules/.bin/watch 'npm run bundle' ./src"
   },
   "repository": {


### PR DESCRIPTION
This adds a new npm task called release which should be run on the master branch after merging the develop branch. It re-bundles the whole lib and adds a timestamp to it.

It fixes #126