### PR TITLE
Speeding up b.clear()

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.0.10 2016.11.13-01:44:57 */
+
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -1418,7 +1418,7 @@ pub.items = function(container, cb) {
 
 
 /**
- * Removes all PageItems in the given Document, Page, Layer or Group.
+ * Removes all PageItems (including locked ones) in the given Document, Page, Layer or Group. If the selected container is a Group, the Group itself will be removed as well.
  *
  * @cat Document
  * @method clear

--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.0.10 2016.11.07-17:50:59 */
+/* Basil.js v1.0.10 2016.11.13-01:44:57 */
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -1437,20 +1437,18 @@ pub.clear = function(container) {
 
   if (container instanceof Document
     || container instanceof Page
-    || container instanceof Layer
-    || container instanceof Group) {
+    || container instanceof Layer) {
 
-    return forEach(container.allPageItems, function(item, n) {
-        // Groups have to be avoided for deletion
-        // otherwise deletion process is confused
-      if(item !== null && !(item instanceof Group)) {
-        if(item.locked) error("b.clear(), some items are locked. Please unlock them first and sue then b.clear().");
-        item.remove();
-      }
-    });
+    container.pageItems.everyItem().locked = false;
+    container.pageItems.everyItem().remove();
+
+  } else if (container instanceof Group) {
+
+    container.locked = false;
+    container.remove();
 
   } else {
-    return false;
+    error("b.clear(), not a valid container! Use: Document, Page, Layer or Group.");
   }
 };
 

--- a/src/includes/structure.js
+++ b/src/includes/structure.js
@@ -223,7 +223,7 @@ pub.items = function(container, cb) {
 
 
 /**
- * Removes all PageItems in the given Document, Page, Layer or Group.
+ * Removes all PageItems (including locked ones) in the given Document, Page, Layer or Group. If the selected container is a Group, the Group itself will be removed as well.
  *
  * @cat Document
  * @method clear

--- a/src/includes/structure.js
+++ b/src/includes/structure.js
@@ -242,20 +242,18 @@ pub.clear = function(container) {
 
   if (container instanceof Document
     || container instanceof Page
-    || container instanceof Layer
-    || container instanceof Group) {
+    || container instanceof Layer) {
 
-    return forEach(container.allPageItems, function(item, n) {
-        // Groups have to be avoided for deletion
-        // otherwise deletion process is confused
-      if(item !== null && !(item instanceof Group)) {
-        if(item.locked) error("b.clear(), some items are locked. Please unlock them first and sue then b.clear().");
-        item.remove();
-      }
-    });
+    container.pageItems.everyItem().locked = false;
+    container.pageItems.everyItem().remove();
+
+  } else if (container instanceof Group) {
+
+    container.locked = false;
+    container.remove();
 
   } else {
-    return false;
+    error("b.clear(), not a valid container! Use: Document, Page, Layer or Group.");
   }
 };
 

--- a/test/benchmarks/clearItems.jsx
+++ b/test/benchmarks/clearItems.jsx
@@ -1,0 +1,51 @@
+﻿#includepath "~/Documents/;%USERPROFILE%Documents";
+#include "basiljs/bundle/basil.js";
+
+function draw() {
+
+  b.close(false);
+
+  var doc = b.doc();
+
+  b.noFill();
+  var x, y;
+
+  var count = 500;
+
+  for (var i = 0; i < count * 2; i += 1) {
+    x = b.random(b.width);
+    y = b.random(b.height);
+    b.ellipse(x, y, 50, 50);
+    if(i === count - 1) {
+      var layer = b.layer("Layer 2");
+    }
+  };
+
+  var page = b.addPage();
+  for (var i = 0; i < count * 2; i += 1) {
+    x = b.random(b.width);
+    y = b.random(b.height);
+    b.ellipse(x, y, 50, 50);
+    if(i === count - 1) {
+      var group = b.group(b.items(b.page()));
+    }
+  };
+
+  var time = b.millis();
+  b.clear(group);
+  b.println("Clearing " +  count + " grouped items: " + ((b.millis() - time)/1000) + " seconds.");
+
+  time = b.millis();
+  b.clear(page);
+  b.println("Clearing " +  count + " items on page: " + ((b.millis() - time)/1000) + " seconds.");
+
+  time = b.millis();
+  b.clear(layer);
+  b.println("Clearing " +  count + " items on layer: " + ((b.millis() - time)/1000) + " seconds.");
+
+  time = b.millis();
+  b.clear(doc);
+  b.println("Clearing " +  count + " items in document: " + ((b.millis() - time)/1000) + " seconds.");
+}
+
+b.go();

--- a/test/benchmarks/clearItems.jsx
+++ b/test/benchmarks/clearItems.jsx
@@ -39,6 +39,8 @@ function draw() {
   b.clear(page);
   b.println("Clearing " +  count + " items on page: " + ((b.millis() - time)/1000) + " seconds.");
 
+  b.page(1);
+
   time = b.millis();
   b.clear(layer);
   b.println("Clearing " +  count + " items on layer: " + ((b.millis() - time)/1000) + " seconds.");


### PR DESCRIPTION
This PR speeds up `b.clear()` by avoiding the internal use of `b.forEach()`. A benchmark script `clearItems.jsx` is added to `test/benchmarks/`.

On my system the benchmark gave these results:

```
Old b.clear():
Clearing 500 grouped items: 8.066 seconds.
Clearing 500 items on page: 4.259 seconds.
Clearing 500 items on layer: 6.324 seconds.
Clearing 500 items in document: 2.749 seconds.
```

```
New b.clear():
Clearing 500 grouped items: 0.275 seconds.
Clearing 500 items on page: 0.589 seconds.
Clearing 500 items on layer: 0.561 seconds.
Clearing 500 items in document: 0.453 seconds.
```

The more objects need to be deleted, the greater the speed difference. It is also greater if the objects are deleted from the active page as the page needs to be redrawn more often with the old `b.clear()`.

It passes all tests.