### PR TITLE
Changed github names to real ones; logged b.clear() improvements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,11 @@
 - removed
 
 ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-
+basil.js x.x.x
+
+* Improved the speed of b.clear() considerably
+
+..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-
 basil.js 1.1.0 - 11 November 2016
 
 + Added b.size() to set and get the document size
@@ -30,7 +35,7 @@ basil.js 1.1.0 - 11 November 2016
 * Bugfix: b.words(), b.lines() etc. were broken
 * Bugfix: b.objectStyle(), b.characterStyle() and b.paragraphStyle() were broken
 
-Shout outs to @trych @fabianmoronzirfas!
+Shout outs to Timo Rychert and Fabian Morón Zirfas!
 This release is entirely based on your hard work!
 Many thanks for this massive contributions!
 


### PR DESCRIPTION
The switch from github names to real ones was only in master, therefore I recreated it in develop, so the branches are not out of sync.

Additionally I just started logging the changed features (well one, so far).

I think in the future we should make this a habit to always add the change to the changelog right away if we have a PR with a new feature. That way we don't have to collect every change before a release in a hurry next time. 😉