### PR TITLE
Fixing broken .eslintrc file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1311,5 +1311,4 @@
     "Vector": true,
     "forEach": true
   }
->>>>>>> develop
 }


### PR DESCRIPTION
This just removes a line that was accidentally left in .eslintrc and broke linting and will be merged right away.