### PR TITLE
Expanding functionality of styles

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -4776,12 +4776,35 @@ pub.textTracking = function(tracking) {
  * @param  {String} name      The name of the character style to return.
  * @return {CharachterStyle}  The character style instance.
  */
-pub.characterStyle = function(name) {
+pub.characterStyle = function(textOrName, props) {
+  var styleErrorMsg = "b.characterStyles(), wrong parameters. Use: textObject|name and props. Props is optional.";
 
-  var style = findInStylesByName(currentDoc().allCharacterStyles, name);
-  if(!style) {
-    style = currentDoc().characterStyles.add({name: name});
+  if(!arguments || arguments.length > 2) {
+    error(styleErrorMsg);
   }
+
+  var style;
+  if(isText(textOrName)) {
+    // text object is given
+    style = textOrName.appliedCharacterStyle;
+  } else if(isString(textOrName)) {
+    // name is given
+    style = findInStylesByName(currentDoc().allCharacterStyles, textOrName);
+    if(!style) {
+      style = currentDoc().characterStyles.add({name: textOrName});
+    }
+  } else {
+    error(styleErrorMsg);
+  }
+
+  if(props) {
+    try {
+      style.properties = props;
+    } catch (e) {
+      error("b.characterStyles(), wrong props parameter. Use object of property name/value pairs.");
+    }
+  }
+
   return style;
 };
 
@@ -4793,11 +4816,35 @@ pub.characterStyle = function(name) {
  * @param  {String} name     The name of the paragraph style to return.
  * @return {ParagraphStyle}  The paragraph style instance.
  */
-pub.paragraphStyle = function(name) {
-  var style = findInStylesByName(currentDoc().allParagraphStyles, name);
-  if(!style) {
-    style = currentDoc().paragraphStyles.add({name: name});
+pub.paragraphStyle = function(textOrName, props) {
+  var styleErrorMsg = "b.paragraphStyles(), wrong parameters. Use: textObject|name and props. Props is optional.";
+
+  if(!arguments || arguments.length > 2) {
+    error(styleErrorMsg);
   }
+
+  var style;
+  if(isText(textOrName)) {
+    // text object is given
+    style = textOrName.appliedParagraphStyle;
+  } else if(isString(textOrName)) {
+    // name is given
+    style = findInStylesByName(currentDoc().allParagraphStyles, textOrName);
+    if(!style) {
+      style = currentDoc().paragraphStyles.add({name: textOrName});
+    }
+  } else {
+    error(styleErrorMsg);
+  }
+
+  if(props) {
+    try {
+      style.properties = props;
+    } catch (e) {
+      error("b.paragraphStyles(), wrong props parameter. Use object of property name/value pairs.");
+    }
+  }
+
   return style;
 };
 

--- a/basil.js
+++ b/basil.js
@@ -3946,11 +3946,14 @@ pub.strokeWeight = function (weight) {
 };
 
 /**
- * Returns the object style with the given name. If the style does not exist it gets created.
+ * Returns the object style of a given page item or the object style with the given name. If an
+ * object style of the given name does not exist, it gets created. Optionally a props object of
+ * property name/value pairs can be used to set the object style's properties.
  *
  * @cat Typography
  * @method objectStyle
- * @param  {String} name  The name of the object style to return.
+ * @param  {PageItem|String} pageItemOrName  A page item whose style to return or the name of the object style to return.
+ * @param {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
  * @return {ObjectStyle}  The object style instance.
  */
 pub.objectStyle = function(itemOrName, props) {
@@ -3962,7 +3965,7 @@ pub.objectStyle = function(itemOrName, props) {
 
   var style;
   if(itemOrName.hasOwnProperty("appliedObjectStyle")) {
-    // text object is given
+    // pageItem is given
     style = itemOrName.appliedObjectStyle;
   } else if(isString(itemOrName)) {
     // name is given
@@ -3985,6 +3988,35 @@ pub.objectStyle = function(itemOrName, props) {
   return style;
 };
 
+/**
+ * Applies an object style to the given page item. The object style can be given as
+ * name or as an object style instance.
+ *
+ * @cat Typography
+ * @method applyObjectStyle
+ * @param  {PageItem} item  The page item to apply the style to.
+ * @param {ObjectStyle|String} style  An object style instance or the name of the object style to apply.
+ * @return {PageItem}  The page item that the style was applied to.
+ */
+
+pub.applyObjectStyle = function(item, style) {
+
+  if(isString(style)) {
+    var name = style;
+    style = findInStylesByName(currentDoc().allObjectStyles, name);
+    if(!style) {
+      error("b.applyObjectStyle(), an object style named \"" + name + "\" does not exist.");
+    }
+  }
+
+  if(!(item.hasOwnProperty("appliedObjectStyle")) || !(style instanceof ObjectStyle)) {
+    error("b.applyObjectStyle(), wrong parameters. Use: pageItem, objectStyle|name");
+  }
+
+  item.appliedObjectStyle = style;
+
+  return item;
+};
 
 /**
  * Duplicates the given page after the current page or the given pageitem to the current page and layer. Use b.rectMode() to set center point.
@@ -4792,12 +4824,15 @@ pub.textTracking = function(tracking) {
 };
 
 /**
- * Returns the character style with the given name. If the style does not exist it gets created.
+ * Returns the character style of a given text object or the character style with the given name. If a
+ * character style of the given name does not exist, it gets created. Optionally a props object of
+ * property name/value pairs can be used to set the character style's properties.
  *
  * @cat Typography
  * @method characterStyle
- * @param  {String} name      The name of the character style to return.
- * @return {CharachterStyle}  The character style instance.
+ * @param  {Text|String} textOrName  A text object whose style to return or the name of the character style to return.
+ * @param {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
+ * @return {CharacterStyle}  The character style instance.
  */
 pub.characterStyle = function(textOrName, props) {
   var styleErrorMsg = "b.characterStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
@@ -4832,11 +4867,48 @@ pub.characterStyle = function(textOrName, props) {
 };
 
 /**
- * Returns the paragraph style with the given name. If the style does not exist it gets created.
+ * Applies a character style to the given text object, text frame or story. The character style
+ * can be given as name or as character style instance.
+ *
+ * @cat Typography
+ * @method applyCharacterStyle
+ * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
+ * @param {CharacterStyle|String} style  A character style instance or the name of the character style to apply.
+ * @return {Text}  The text that the style was applied to.
+ */
+
+pub.applyCharacterStyle = function(text, style) {
+
+  if(isString(style)) {
+    var name = style;
+    style = findInStylesByName(currentDoc().allCharacterStyles, name);
+    if(!style) {
+      error("b.applyCharacterStyle(), a character style named \"" + name + "\" does not exist.");
+    }
+  }
+
+  if(!(pub.isText(text) || text instanceof TextFrame || text instanceof Story) || !(style instanceof CharacterStyle)) {
+    error("b.applyCharacterStyle(), wrong parameters. Use: textObject|textFrame|story, characterStyle|name");
+  }
+
+  if(text instanceof TextFrame) {
+    text = text.characters.everyItem();
+  }
+
+  text.appliedCharacterStyle = style;
+
+  return text;
+};
+
+/**
+ * Returns the paragraph style of a given text object or the paragraph style with the given name. If a
+ * paragraph style of the given name does not exist, it gets created. Optionally a props object of
+ * property name/value pairs can be used to set the paragraph style's properties.
  *
  * @cat Typography
  * @method paragraphStyle
- * @param  {String} name     The name of the paragraph style to return.
+ * @param  {Text|String} textOrName  A text object whose style to return or the name of the paragraph style to return.
+ * @param {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
  * @return {ParagraphStyle}  The paragraph style instance.
  */
 pub.paragraphStyle = function(textOrName, props) {
@@ -4869,6 +4941,40 @@ pub.paragraphStyle = function(textOrName, props) {
   }
 
   return style;
+};
+
+/**
+ * Applies a paragraph style to the given text object, text frame or story. The paragraph style
+ * can be given as name or as paragraph style instance.
+ *
+ * @cat Typography
+ * @method applyParagraphStyle
+ * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
+ * @param {ParagraphStyle|String} style  A paragraph style instance or the name of the paragraph style to apply.
+ * @return {Text}  The text that the style was applied to.
+ */
+
+pub.applyParagraphStyle = function(text, style) {
+
+  if(isString(style)) {
+    var name = style;
+    style = findInStylesByName(currentDoc().allParagraphStyles, name);
+    if(!style) {
+      error("b.applyParagraphStyle(), a paragraph style named \"" + name + "\" does not exist.");
+    }
+  }
+
+  if(!(pub.isText(text) || text instanceof TextFrame || text instanceof Story) || !(style instanceof ParagraphStyle)) {
+    error("b.applyParagraphStyle(), wrong parameters. Use: textObject|textFrame|story, paragraphStyle|name");
+  }
+
+  if(text instanceof TextFrame) {
+    text = text.paragraphs.everyItem();
+  }
+
+  text.appliedParagraphStyle = style;
+
+  return text;
 };
 
 /**

--- a/basil.js
+++ b/basil.js
@@ -3953,12 +3953,35 @@ pub.strokeWeight = function (weight) {
  * @param  {String} name  The name of the object style to return.
  * @return {ObjectStyle}  The object style instance.
  */
-pub.objectStyle = function(name) {
+pub.objectStyle = function(itemOrName, props) {
+  var styleErrorMsg = "b.objectStyle(), wrong parameters. Use: pageItem|name and props. Props is optional.";
 
-  var style = findInStylesByName(currentDoc().allObjectStyles, name);
-  if(!style) {
-    style = currentDoc().objectStyles.add({name: name});
+  if(!arguments || arguments.length > 2) {
+    error(styleErrorMsg);
   }
+
+  var style;
+  if(itemOrName.hasOwnProperty("appliedObjectStyle")) {
+    // text object is given
+    style = itemOrName.appliedObjectStyle;
+  } else if(isString(itemOrName)) {
+    // name is given
+    style = findInStylesByName(currentDoc().allObjectStyles, itemOrName);
+    if(!style) {
+      style = currentDoc().objectStyles.add({name: itemOrName});
+    }
+  } else {
+    error(styleErrorMsg);
+  }
+
+  if(props) {
+    try {
+      style.properties = props;
+    } catch (e) {
+      error("b.objectStyle(), wrong props parameter. Use object of property name/value pairs.");
+    }
+  }
+
   return style;
 };
 
@@ -4777,7 +4800,7 @@ pub.textTracking = function(tracking) {
  * @return {CharachterStyle}  The character style instance.
  */
 pub.characterStyle = function(textOrName, props) {
-  var styleErrorMsg = "b.characterStyles(), wrong parameters. Use: textObject|name and props. Props is optional.";
+  var styleErrorMsg = "b.characterStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
 
   if(!arguments || arguments.length > 2) {
     error(styleErrorMsg);
@@ -4801,7 +4824,7 @@ pub.characterStyle = function(textOrName, props) {
     try {
       style.properties = props;
     } catch (e) {
-      error("b.characterStyles(), wrong props parameter. Use object of property name/value pairs.");
+      error("b.characterStyle(), wrong props parameter. Use object of property name/value pairs.");
     }
   }
 
@@ -4817,7 +4840,7 @@ pub.characterStyle = function(textOrName, props) {
  * @return {ParagraphStyle}  The paragraph style instance.
  */
 pub.paragraphStyle = function(textOrName, props) {
-  var styleErrorMsg = "b.paragraphStyles(), wrong parameters. Use: textObject|name and props. Props is optional.";
+  var styleErrorMsg = "b.paragraphStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
 
   if(!arguments || arguments.length > 2) {
     error(styleErrorMsg);
@@ -4841,7 +4864,7 @@ pub.paragraphStyle = function(textOrName, props) {
     try {
       style.properties = props;
     } catch (e) {
-      error("b.paragraphStyles(), wrong props parameter. Use object of property name/value pairs.");
+      error("b.paragraphStyle(), wrong props parameter. Use object of property name/value pairs.");
     }
   }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,14 @@
 ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-
 basil.js x.x.x
 
++ Added b.applyParagraphStyle(), b.applyCharacterStyle(), b.applyObjectStyle(),
+  set the style of a text object/page item.
+  see examples/typography/styles.jsx
+
+* b.paragraphStyle(), b.characterStyle() and b.objectStyle() are expanded:
+  They can now get an applied style from a text object/page item and can
+  make use of an optional object with property name/value pairs to set
+  the properties of the style.
 * Improved the speed of b.clear() considerably
 
 ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-

--- a/scripts/examples/typography/styles.jsx
+++ b/scripts/examples/typography/styles.jsx
@@ -1,0 +1,65 @@
+#includepath "~/Documents/;%USERPROFILE%Documents";
+#include "basiljs/bundle/basil.js";
+
+function draw() {
+
+  b.units(b.MM);
+  var tf = b.text("", b.width / 2 - 60, b.height / 2 - 100, 120, 200);
+  b.placeholder(tf);
+
+
+  // create a new style by name
+  b.paragraphStyle("emptyStyle");
+
+
+  // create styles by name with custom properties
+  var redProps = {
+    fillColor: b.color(255, 0, 0),
+    pointSize: 14,
+    skew: 15
+  };
+  var redStyle = b.paragraphStyle("red", redProps);
+
+  var greenProps = {
+    fillColor: b.color(0, 255, 0),
+    pointSize: 18,
+    skew: -15
+  };
+  var greenStyle = b.characterStyle("green", greenProps);
+
+
+  // apply styles
+  b.applyParagraphStyle(tf, "red");
+
+  var words = b.words(tf);
+  for (var i = 0; i < words.length; i += 5) {
+    b.applyCharacterStyle(words[i], greenStyle);
+  }
+
+
+  b.delay(1000);
+
+
+  // update style with new properties
+  b.characterStyle("green", {fillColor: b.color(0, 0, 255), name: "blue"});
+
+
+  // creating an objectStyle by name with custom properties
+  var objectProps = {
+    topLeftCornerOption: CornerOptions.ROUNDED_CORNER,
+    topLeftCornerRadius: 20,
+    bottomRightCornerOption: CornerOptions.FANCY_CORNER,
+    bottomRightCornerRadius: 20,
+    fillColor: b.gradient(b.color(255, 255, 220), b.color(200, 255, 255)),
+    gradientFillAngle: 45
+  };
+  b.objectStyle("cornerStyle", objectProps);
+  b.applyObjectStyle(tf, "cornerStyle");
+
+
+  // get style from text object
+  var parStyle = b.characterStyle(tf.characters[10]);
+  b.println("Received character style \"" + parStyle.name + "\".");
+}
+
+b.go();

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -508,12 +508,35 @@ pub.strokeWeight = function (weight) {
  * @param  {String} name  The name of the object style to return.
  * @return {ObjectStyle}  The object style instance.
  */
-pub.objectStyle = function(name) {
+pub.objectStyle = function(itemOrName, props) {
+  var styleErrorMsg = "b.objectStyle(), wrong parameters. Use: pageItem|name and props. Props is optional.";
 
-  var style = findInStylesByName(currentDoc().allObjectStyles, name);
-  if(!style) {
-    style = currentDoc().objectStyles.add({name: name});
+  if(!arguments || arguments.length > 2) {
+    error(styleErrorMsg);
   }
+
+  var style;
+  if(itemOrName.hasOwnProperty("appliedObjectStyle")) {
+    // text object is given
+    style = itemOrName.appliedObjectStyle;
+  } else if(isString(itemOrName)) {
+    // name is given
+    style = findInStylesByName(currentDoc().allObjectStyles, itemOrName);
+    if(!style) {
+      style = currentDoc().objectStyles.add({name: itemOrName});
+    }
+  } else {
+    error(styleErrorMsg);
+  }
+
+  if(props) {
+    try {
+      style.properties = props;
+    } catch (e) {
+      error("b.objectStyle(), wrong props parameter. Use object of property name/value pairs.");
+    }
+  }
+
   return style;
 };
 

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -543,6 +543,24 @@ pub.objectStyle = function(itemOrName, props) {
   return style;
 };
 
+pub.applyObjectStyle = function(item, style) {
+
+  if(isString(style)) {
+    var name = style;
+    style = findInStylesByName(currentDoc().allObjectStyles, name);
+    if(!style) {
+      error("b.applyObjectStyle(), an object style named \"" + name + "\" does not exist.");
+    }
+  }
+
+  if(!(item.hasOwnProperty("appliedObjectStyle")) || !(style instanceof ObjectStyle)) {
+    error("b.applyObjectStyle(), wrong parameters. Use: pageItem, objectStyle|name");
+  }
+
+  item.appliedObjectStyle = style;
+
+  return item;
+};
 
 /**
  * Duplicates the given page after the current page or the given pageitem to the current page and layer. Use b.rectMode() to set center point.

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -501,11 +501,14 @@ pub.strokeWeight = function (weight) {
 };
 
 /**
- * Returns the object style with the given name. If the style does not exist it gets created.
+ * Returns the object style of a given page item or the object style with the given name. If an
+ * object style of the given name does not exist, it gets created. Optionally a props object of
+ * property name/value pairs can be used to set the object style's properties.
  *
  * @cat Typography
  * @method objectStyle
- * @param  {String} name  The name of the object style to return.
+ * @param  {PageItem|String} pageItemOrName  A page item whose style to return or the name of the object style to return.
+ * @param {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
  * @return {ObjectStyle}  The object style instance.
  */
 pub.objectStyle = function(itemOrName, props) {
@@ -517,7 +520,7 @@ pub.objectStyle = function(itemOrName, props) {
 
   var style;
   if(itemOrName.hasOwnProperty("appliedObjectStyle")) {
-    // text object is given
+    // pageItem is given
     style = itemOrName.appliedObjectStyle;
   } else if(isString(itemOrName)) {
     // name is given

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -543,6 +543,17 @@ pub.objectStyle = function(itemOrName, props) {
   return style;
 };
 
+/**
+ * Applies an object style to the given page item. The object style can be given as
+ * name or as an object style instance.
+ *
+ * @cat Typography
+ * @method applyObjectStyle
+ * @param  {PageItem} item  The page item to apply the style to.
+ * @param {ObjectStyle|String} style  An object style instance or the name of the object style to apply.
+ * @return {PageItem}  The page item that the style was applied to.
+ */
+
 pub.applyObjectStyle = function(item, style) {
 
   if(isString(style)) {

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -287,6 +287,29 @@ pub.characterStyle = function(textOrName, props) {
   return style;
 };
 
+pub.applyCharacterStyle = function(text, style) {
+
+  if(isString(style)) {
+    var name = style;
+    style = findInStylesByName(currentDoc().allCharacterStyles, name);
+    if(!style) {
+      error("b.applyCharacterStyle(), a character style named \"" + name + "\" does not exist.");
+    }
+  }
+
+  if(!(pub.isText(text) || text instanceof TextFrame || text instanceof Story) || !(style instanceof CharacterStyle)) {
+    error("b.applyCharacterStyle(), wrong parameters. Use: textObject|textFrame|story, characterStyle|name");
+  }
+
+  if(text instanceof TextFrame) {
+    text = text.characters.everyItem();
+  }
+
+  text.appliedCharacterStyle = style;
+
+  return text;
+};
+
 /**
  * Returns the paragraph style of a given text object or the paragraph style with the given name. If a
  * paragraph style of the given name does not exist, it gets created. Optionally a props object of
@@ -328,6 +351,29 @@ pub.paragraphStyle = function(textOrName, props) {
   }
 
   return style;
+};
+
+pub.applyParagraphStyle = function(text, style) {
+
+  if(isString(style)) {
+    var name = style;
+    style = findInStylesByName(currentDoc().allParagraphStyles, name);
+    if(!style) {
+      error("b.applyParagraphStyle(), a paragraph style named \"" + name + "\" does not exist.");
+    }
+  }
+
+  if(!(pub.isText(text) || text instanceof TextFrame || text instanceof Story) || !(style instanceof ParagraphStyle)) {
+    error("b.applyParagraphStyle(), wrong parameters. Use: textObject|textFrame|story, paragraphStyle|name");
+  }
+
+  if(text instanceof TextFrame) {
+    text = text.paragraphs.everyItem();
+  }
+
+  text.appliedParagraphStyle = style;
+
+  return text;
 };
 
 /**

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -253,7 +253,7 @@ pub.textTracking = function(tracking) {
  * @return {CharachterStyle}  The character style instance.
  */
 pub.characterStyle = function(textOrName, props) {
-  var styleErrorMsg = "b.characterStyles(), wrong parameters. Use: textObject|name and props. Props is optional.";
+  var styleErrorMsg = "b.characterStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
 
   if(!arguments || arguments.length > 2) {
     error(styleErrorMsg);
@@ -277,7 +277,7 @@ pub.characterStyle = function(textOrName, props) {
     try {
       style.properties = props;
     } catch (e) {
-      error("b.characterStyles(), wrong props parameter. Use object of property name/value pairs.");
+      error("b.characterStyle(), wrong props parameter. Use object of property name/value pairs.");
     }
   }
 
@@ -293,7 +293,7 @@ pub.characterStyle = function(textOrName, props) {
  * @return {ParagraphStyle}  The paragraph style instance.
  */
 pub.paragraphStyle = function(textOrName, props) {
-  var styleErrorMsg = "b.paragraphStyles(), wrong parameters. Use: textObject|name and props. Props is optional.";
+  var styleErrorMsg = "b.paragraphStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
 
   if(!arguments || arguments.length > 2) {
     error(styleErrorMsg);
@@ -317,7 +317,7 @@ pub.paragraphStyle = function(textOrName, props) {
     try {
       style.properties = props;
     } catch (e) {
-      error("b.paragraphStyles(), wrong props parameter. Use object of property name/value pairs.");
+      error("b.paragraphStyle(), wrong props parameter. Use object of property name/value pairs.");
     }
   }
 

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -245,12 +245,15 @@ pub.textTracking = function(tracking) {
 };
 
 /**
- * Returns the character style with the given name. If the style does not exist it gets created.
+ * Returns the character style of a given text object or the character style with the given name. If a
+ * character style of the given name does not exist, it gets created. Optionally a props object of
+ * property name/value pairs can be used to set the character style's properties.
  *
  * @cat Typography
  * @method characterStyle
- * @param  {String} name      The name of the character style to return.
- * @return {CharachterStyle}  The character style instance.
+ * @param  {Text|String} textOrName  A text object whose style to return or the name of the character style to return.
+ * @param {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
+ * @return {CharacterStyle}  The character style instance.
  */
 pub.characterStyle = function(textOrName, props) {
   var styleErrorMsg = "b.characterStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
@@ -285,11 +288,14 @@ pub.characterStyle = function(textOrName, props) {
 };
 
 /**
- * Returns the paragraph style with the given name. If the style does not exist it gets created.
+ * Returns the paragraph style of a given text object or the paragraph style with the given name. If a
+ * paragraph style of the given name does not exist, it gets created. Optionally a props object of
+ * property name/value pairs can be used to set the paragraph style's properties.
  *
  * @cat Typography
  * @method paragraphStyle
- * @param  {String} name     The name of the paragraph style to return.
+ * @param  {Text|String} textOrName  A text object whose style to return or the name of the paragraph style to return.
+ * @param {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
  * @return {ParagraphStyle}  The paragraph style instance.
  */
 pub.paragraphStyle = function(textOrName, props) {

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -287,6 +287,17 @@ pub.characterStyle = function(textOrName, props) {
   return style;
 };
 
+/**
+ * Applies a character style to the given text object, text frame or story. The character style
+ * can be given as name or as character style instance.
+ *
+ * @cat Typography
+ * @method applyCharacterStyle
+ * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
+ * @param {CharacterStyle|String} style  A character style instance or the name of the character style to apply.
+ * @return {Text}  The text that the style was applied to.
+ */
+
 pub.applyCharacterStyle = function(text, style) {
 
   if(isString(style)) {
@@ -352,6 +363,17 @@ pub.paragraphStyle = function(textOrName, props) {
 
   return style;
 };
+
+/**
+ * Applies a paragraph style to the given text object, text frame or story. The paragraph style
+ * can be given as name or as paragraph style instance.
+ *
+ * @cat Typography
+ * @method applyParagraphStyle
+ * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
+ * @param {ParagraphStyle|String} style  A paragraph style instance or the name of the paragraph style to apply.
+ * @return {Text}  The text that the style was applied to.
+ */
 
 pub.applyParagraphStyle = function(text, style) {
 

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -252,12 +252,35 @@ pub.textTracking = function(tracking) {
  * @param  {String} name      The name of the character style to return.
  * @return {CharachterStyle}  The character style instance.
  */
-pub.characterStyle = function(name) {
+pub.characterStyle = function(textOrName, props) {
+  var styleErrorMsg = "b.characterStyles(), wrong parameters. Use: textObject|name and props. Props is optional.";
 
-  var style = findInStylesByName(currentDoc().allCharacterStyles, name);
-  if(!style) {
-    style = currentDoc().characterStyles.add({name: name});
+  if(!arguments || arguments.length > 2) {
+    error(styleErrorMsg);
   }
+
+  var style;
+  if(isText(textOrName)) {
+    // text object is given
+    style = textOrName.appliedCharacterStyle;
+  } else if(isString(textOrName)) {
+    // name is given
+    style = findInStylesByName(currentDoc().allCharacterStyles, textOrName);
+    if(!style) {
+      style = currentDoc().characterStyles.add({name: textOrName});
+    }
+  } else {
+    error(styleErrorMsg);
+  }
+
+  if(props) {
+    try {
+      style.properties = props;
+    } catch (e) {
+      error("b.characterStyles(), wrong props parameter. Use object of property name/value pairs.");
+    }
+  }
+
   return style;
 };
 
@@ -269,11 +292,35 @@ pub.characterStyle = function(name) {
  * @param  {String} name     The name of the paragraph style to return.
  * @return {ParagraphStyle}  The paragraph style instance.
  */
-pub.paragraphStyle = function(name) {
-  var style = findInStylesByName(currentDoc().allParagraphStyles, name);
-  if(!style) {
-    style = currentDoc().paragraphStyles.add({name: name});
+pub.paragraphStyle = function(textOrName, props) {
+  var styleErrorMsg = "b.paragraphStyles(), wrong parameters. Use: textObject|name and props. Props is optional.";
+
+  if(!arguments || arguments.length > 2) {
+    error(styleErrorMsg);
   }
+
+  var style;
+  if(isText(textOrName)) {
+    // text object is given
+    style = textOrName.appliedParagraphStyle;
+  } else if(isString(textOrName)) {
+    // name is given
+    style = findInStylesByName(currentDoc().allParagraphStyles, textOrName);
+    if(!style) {
+      style = currentDoc().paragraphStyles.add({name: textOrName});
+    }
+  } else {
+    error(styleErrorMsg);
+  }
+
+  if(props) {
+    try {
+      style.properties = props;
+    } catch (e) {
+      error("b.paragraphStyles(), wrong props parameter. Use object of property name/value pairs.");
+    }
+  }
+
   return style;
 };
 

--- a/test/typography-tests.jsx
+++ b/test/typography-tests.jsx
@@ -1,11 +1,11 @@
-﻿if (typeof b === 'undefined') {
-  // @include "../basil.js";
+﻿if (typeof b === "undefined") {
+  #include "../basil.js";
 }
-if (typeof b.test === 'undefined') {
-  //include "../lib/basil.test.js";
+if (typeof b.test === "undefined") {
+  #include "../lib/basil.test.js";
 }
 
-b.test('TypographyTests', {
+b.test("TypographyTests", {
   doc: null,
   layer: null,
 
@@ -19,7 +19,7 @@ b.test('TypographyTests', {
 
   setUp: function(b) {
     doc = b.doc();
-    layer = doc.layers.add({name: 'test layer'});
+    layer = doc.layers.add({name: "test layer"});
   },
 
   tearDown: function(b) {
@@ -27,7 +27,7 @@ b.test('TypographyTests', {
   },
 
   testWriteText: function(b) {
-    var contents = 'foo bar';
+    var contents = "foo bar";
 
     b.doc(doc);
     b.page(0);
@@ -39,8 +39,8 @@ b.test('TypographyTests', {
   },
 
   testCreateMultipleTextFrames: function(b) {
-    var contents1 = 'foo bar',
-      contents2 = 'bar foo';
+    var contents1 = "foo bar",
+      contents2 = "bar foo";
 
     b.doc(doc);
     b.page(0);
@@ -55,7 +55,7 @@ b.test('TypographyTests', {
   },
 
   testWriteTextWithSpecialCharacters: function(b) {
-    var contents = 'Copyright: ©, Euro: €';
+    var contents = "Copyright: ©, Euro: €";
 
     b.doc(doc);
     b.page(0);
@@ -67,7 +67,7 @@ b.test('TypographyTests', {
   },
 
   testWriteTextWithCarriageReturns: function(b) {
-    var contents = 'foo\rbar\rfoobar';
+    var contents = "foo\rbar\rfoobar";
 
     b.doc(doc);
     b.page(0);
@@ -76,14 +76,14 @@ b.test('TypographyTests', {
 
     assert(layer.textFrames.length === 1);
     assert(layer.textFrames[0].contents === contents);
-    assert(layer.textFrames[0].contents.split('\r').length === 3);
+    assert(layer.textFrames[0].contents.split("\r").length === 3);
   },
 
   testGetAppliedFontFromTextFrame: function(b) {
     b.doc(doc);
-    var textFrame = b.text('foo', 0, 0, 100, 100);
+    var textFrame = b.text("foo", 0, 0, 100, 100);
 
-    var font = b.typo(textFrame, 'appliedFont');
+    var font = b.typo(textFrame, "appliedFont");
 
     assert(font.length === 1);
     assert(font[0] instanceof Font);
@@ -91,24 +91,24 @@ b.test('TypographyTests', {
 
   testSetPointSizeInTextFrame: function(b) {
     b.doc(doc);
-    var textFrame = b.text('foo', 0, 0, 100, 100),
+    var textFrame = b.text("foo", 0, 0, 100, 100),
       size = 36;
 
-    b.typo(textFrame, 'pointSize', size);
+    b.typo(textFrame, "pointSize", size);
 
-    var currSize = b.typo(textFrame, 'pointSize');
+    var currSize = b.typo(textFrame, "pointSize");
     assert(currSize.length === 1);
     assert(currSize[0] === size);
   },
 
   testSetPointSizeInOverlownPara: function(b) {
     b.doc(doc);
-    var textFrame = b.text('lorem ipsum dolor sit amet\rlorem ipsum dolor sit amet', 0, 0, 100, 30),
+    var textFrame = b.text("lorem ipsum dolor sit amet\rlorem ipsum dolor sit amet", 0, 0, 100, 30),
       size = 30;
 
-    b.typo(textFrame, 'pointSize', size);
+    b.typo(textFrame, "pointSize", size);
 
-    var currSize = b.typo(textFrame, 'pointSize');
+    var currSize = b.typo(textFrame, "pointSize");
     forEach(currSize, function(s) {
       assert(s === size);
     });

--- a/test/typography-tests.jsx
+++ b/test/typography-tests.jsx
@@ -1,14 +1,14 @@
 ﻿if (typeof b === 'undefined') {
-  #include "../basil.js";
+  // @include "../basil.js";
 }
 if (typeof b.test === 'undefined') {
-  #include "../lib/basil.test.js";  
+  //include "../lib/basil.test.js";
 }
 
 b.test('TypographyTests', {
-  doc: null, 
+  doc: null,
   layer: null,
-  
+
   setUpTest: function(b) {
     doc = app.documents.add();
   },
@@ -18,21 +18,22 @@ b.test('TypographyTests', {
   },
 
   setUp: function(b) {
+    doc = b.doc();
     layer = doc.layers.add({name: 'test layer'});
   },
 
   tearDown: function(b) {
-    layer.remove();
+    b.close(SaveOptions.no);
   },
 
   testWriteText: function(b) {
     var contents = 'foo bar';
-    
+
     b.doc(doc);
     b.page(0);
     b.layer(layer);
     b.text(contents, 0, 0, 300, 300);
-        
+
     assert(layer.textFrames.length === 1);
     assert(layer.textFrames[0].contents === contents);
   },
@@ -40,13 +41,13 @@ b.test('TypographyTests', {
   testCreateMultipleTextFrames: function(b) {
     var contents1 = 'foo bar',
       contents2 = 'bar foo';
-      
+
     b.doc(doc);
     b.page(0);
     b.layer(layer);
     b.text(contents1, 0, 0, 300, 300);
     b.text(contents2, 50, 50, 300, 300);
-        
+
     assert(layer.textFrames.length === 2);
     assert(layer.textFrames[0].contents !== layer.textFrames[1].contents);
     assert(layer.textFrames[0].contents === contents1 || contents2);
@@ -55,24 +56,24 @@ b.test('TypographyTests', {
 
   testWriteTextWithSpecialCharacters: function(b) {
     var contents = 'Copyright: ©, Euro: €';
-    
+
     b.doc(doc);
     b.page(0);
     b.layer(layer);
     b.text(contents, 0, 0, 300, 300);
-        
+
     assert(layer.textFrames.length === 1);
     assert(layer.textFrames[0].contents === contents);
   },
 
   testWriteTextWithCarriageReturns: function(b) {
     var contents = 'foo\rbar\rfoobar';
-    
+
     b.doc(doc);
     b.page(0);
     b.layer(layer);
     b.text(contents, 0, 0, 300, 300);
-        
+
     assert(layer.textFrames.length === 1);
     assert(layer.textFrames[0].contents === contents);
     assert(layer.textFrames[0].contents.split('\r').length === 3);
@@ -83,7 +84,7 @@ b.test('TypographyTests', {
     var textFrame = b.text('foo', 0, 0, 100, 100);
 
     var font = b.typo(textFrame, 'appliedFont');
-    
+
     assert(font.length === 1);
     assert(font[0] instanceof Font);
   },
@@ -94,7 +95,7 @@ b.test('TypographyTests', {
       size = 36;
 
     b.typo(textFrame, 'pointSize', size);
-    
+
     var currSize = b.typo(textFrame, 'pointSize');
     assert(currSize.length === 1);
     assert(currSize[0] === size);
@@ -106,12 +107,205 @@ b.test('TypographyTests', {
       size = 30;
 
     b.typo(textFrame, 'pointSize', size);
-    
+
     var currSize = b.typo(textFrame, 'pointSize');
     forEach(currSize, function(s) {
       assert(s === size);
     });
+  },
+
+  testCreateEmptyStyles: function(b) {
+    b.doc(doc);
+
+    var paraStyleCount = doc.paragraphStyles.length;
+    var charStyleCount = doc.characterStyles.length;
+    var objStyleCount = doc.objectStyles.length;
+
+    var paragraphStyle = b.paragraphStyle("emptyParagraphStyle");
+    var characterStyle = b.characterStyle("emptyCharacterStyle");
+    var objectStyle = b.objectStyle("emptyObjectStyle");
+
+    assert(paraStyleCount + 1 === doc.paragraphStyles.length);
+    assert(charStyleCount + 1 === doc.characterStyles.length);
+    assert(objStyleCount + 1 === doc.objectStyles.length);
+
+    assert(paragraphStyle instanceof ParagraphStyle);
+    assert(characterStyle instanceof CharacterStyle);
+    assert(objectStyle instanceof ObjectStyle);
+
+    assert(doc.paragraphStyles.itemByName("emptyParagraphStyle").isValid);
+    assert(doc.characterStyles.itemByName("emptyCharacterStyle").isValid);
+    assert(doc.objectStyles.itemByName("emptyObjectStyle").isValid);
+  },
+
+  testReturnExistingStyles: function(b) {
+    b.doc(doc);
+
+    // create empty styles on top level
+    b.paragraphStyle("topParagraphStyle");
+    b.characterStyle("topCharacterStyle");
+    b.objectStyle("topObjectStyle");
+
+    // create styles nested in groups
+    doc.paragraphStyleGroups.add({name: "paraGroup"}).paragraphStyles.add({name: "nestedParagraphStyle"});
+    doc.characterStyleGroups.add({name: "charGroup"}).characterStyles.add({name: "nestedCharacterStyle"});
+    doc.objectStyleGroups.add({name: "objGroup"}).objectStyles.add({name: "nestedObjectStyle"});
+
+    // get styles
+    var topPara = b.paragraphStyle("topParagraphStyle");
+    var topChar = b.characterStyle("topCharacterStyle");
+    var topObj = b.objectStyle("topObjectStyle");
+    var nestedPara = b.paragraphStyle("nestedParagraphStyle");
+    var nestedChar = b.characterStyle("nestedCharacterStyle");
+    var nestedObj = b.objectStyle("nestedObjectStyle");
+
+    assert(topPara instanceof ParagraphStyle);
+    assert(topChar instanceof CharacterStyle);
+    assert(topObj instanceof ObjectStyle);
+    assert(nestedPara instanceof ParagraphStyle);
+    assert(nestedChar instanceof CharacterStyle);
+    assert(nestedObj instanceof ObjectStyle);
+
+    assert(topPara.name === "topParagraphStyle");
+    assert(topChar.name === "topCharacterStyle");
+    assert(topObj.name === "topObjectStyle");
+    assert(nestedPara.name === "nestedParagraphStyle");
+    assert(nestedChar.name === "nestedCharacterStyle");
+    assert(nestedObj.name === "nestedObjectStyle");
+  },
+
+  testCreateStylesWithProps: function(b) {
+    b.doc(doc);
+
+    var paraCharProps = {
+      baselineShift: 5,
+      strikeThru: true,
+      capitalization: Capitalization.ALL_CAPS
+    };
+
+    var objProps = {
+      strokeWeight: 5,
+      nonprinting: true,
+      topLeftCornerOption: CornerOptions.ROUNDED_CORNER
+    };
+
+    var paraStyle = b.paragraphStyle("paragraphStyle", paraCharProps);
+    var charStyle = b.characterStyle("characterStyle", paraCharProps);
+    var objStyle = b.objectStyle("objectStyle", objProps);
+
+    assert(paraStyle instanceof ParagraphStyle);
+    assert(charStyle instanceof CharacterStyle);
+    assert(objStyle instanceof ObjectStyle);
+
+    assert(paraStyle.baselineShift === 5 && paraStyle.strikeThru === true && paraStyle.capitalization === Capitalization.ALL_CAPS);
+    assert(charStyle.baselineShift === 5 && charStyle.strikeThru === true && charStyle.capitalization === Capitalization.ALL_CAPS);
+    assert(objStyle.strokeWeight === 5 && objStyle.nonprinting === true && objStyle.topLeftCornerOption === CornerOptions.ROUNDED_CORNER);
+  },
+
+  testUpdatePropsOfExistingStyles: function(b) {
+    b.doc(doc);
+
+    var paraCharProps = {
+      baselineShift: 5,
+      strikeThru: true,
+      capitalization: Capitalization.ALL_CAPS
+    };
+
+    var objProps = {
+      strokeWeight: 5,
+      nonprinting: true,
+      topLeftCornerOption: CornerOptions.ROUNDED_CORNER
+    };
+
+    var paraStyle = b.paragraphStyle("paragraphStyle", paraCharProps);
+    var charStyle = b.characterStyle("characterStyle", paraCharProps);
+    var objStyle = b.objectStyle("objectStyle", objProps);
+
+    var newParaCharProps = {
+      name: "newStyle",
+      baselineShift: 20,
+      strikeThru: false,
+      capitalization: Capitalization.SMALL_CAPS
+    };
+
+    var newObjProps = {
+      name: "newStyle",
+      strokeWeight: 20,
+      nonprinting: false,
+      topLeftCornerOption: CornerOptions.FANCY_CORNER
+    };
+
+    b.paragraphStyle("paragraphStyle", newParaCharProps);
+    b.characterStyle("characterStyle", newParaCharProps);
+    b.objectStyle("objectStyle", newObjProps);
+
+    assert(paraStyle.baselineShift === 20 && paraStyle.strikeThru === false && paraStyle.capitalization === Capitalization.SMALL_CAPS);
+    assert(charStyle.baselineShift === 20 && charStyle.strikeThru === false && charStyle.capitalization === Capitalization.SMALL_CAPS);
+    assert(objStyle.strokeWeight === 20 && objStyle.nonprinting === false && objStyle.topLeftCornerOption === CornerOptions.FANCY_CORNER);
+
+    assert(doc.paragraphStyles.item("newStyle").isValid);
+    assert(doc.characterStyles.item("newStyle").isValid);
+    assert(doc.objectStyles.item("newStyle").isValid);
+
+    assert(doc.paragraphStyles.item("paragraphStyle").isValid === false);
+    assert(doc.characterStyles.item("characterStyle").isValid === false);
+    assert(doc.objectStyles.item("objectStyle").isValid === false);
+  },
+
+  testApplyStyles: function(b) {
+    b.doc(doc);
+
+    // create linked text frames
+    var textFrame1 = b.text(b.LOREM + "\r" + b.LOREM, 0, 0, 300, 300);
+    textFrame1.insertionPoints[-1].contents = SpecialCharacters.FRAME_BREAK;
+    var textFrame2 = b.text(b.LOREM + "\r" + b.LOREM, 0, 0, 300, 300);
+    textFrame2.insertionPoints[-1].contents = SpecialCharacters.FRAME_BREAK;
+    var textFrame3 = b.text(b.LOREM + "\r" + b.LOREM, 0, 0, 300, 300);
+    b.linkTextFrames(textFrame1, textFrame2);
+    b.linkTextFrames(textFrame2, textFrame3);
+    var defaultParaStyle = textFrame1.parentStory.appliedParagraphStyle;
+    var defaultCharStyle = textFrame1.parentStory.appliedCharacterStyle;
+
+    var rect = b.rect(0, 0, 100, 100);
+
+    var paraStyle = b.paragraphStyle("paragraphStyle", {baselineShift: 5});
+    var charStyle = b.characterStyle("characterStyle", {baselineShift: 20});
+    var objStyle = b.objectStyle("objectStyle", {topLeftCornerOption: CornerOptions.ROUNDED_CORNER});
+
+    // apply styles to text instances
+    b.applyParagraphStyle(textFrame1.paragraphs[0], paraStyle);
+    b.applyCharacterStyle(textFrame1.words[0], charStyle);
+
+    assert(textFrame1.paragraphs[0].appliedParagraphStyle === paraStyle);
+    assert(textFrame1.paragraphs[1].appliedParagraphStyle === defaultParaStyle);
+    assert(textFrame1.words[0].appliedCharacterStyle === charStyle);
+    assert(textFrame1.words[1].appliedCharacterStyle === defaultCharStyle);
+    assert(textFrame1.words[0].baselineShift === 20);
+    assert(textFrame1.words[1].baselineShift === 5);
+
+    // apply styles to text frames
+    b.applyParagraphStyle(textFrame2, paraStyle);
+    b.applyCharacterStyle(textFrame2, charStyle);
+
+    assert(textFrame2.paragraphs[-1].appliedParagraphStyle === paraStyle);
+    assert(textFrame3.paragraphs[0].appliedParagraphStyle === defaultParaStyle);
+    assert(textFrame2.characters[-1].appliedCharacterStyle === charStyle);
+    assert(textFrame3.characters[0].appliedCharacterStyle === defaultCharStyle);
+
+    // apply styles to story
+    b.applyParagraphStyle(textFrame1.parentStory, paraStyle);
+    b.applyCharacterStyle(textFrame1.parentStory, charStyle);
+
+    assert(textFrame3.paragraphs[-1].appliedParagraphStyle === paraStyle);
+    assert(textFrame3.characters[-1].appliedCharacterStyle === charStyle);
+
+    // apply style to object
+    b.applyObjectStyle(rect, objStyle);
+
+    assert(rect.appliedObjectStyle === objStyle);
+    assert(rect.topLeftCornerOption === CornerOptions.ROUNDED_CORNER);
   }
+
 });
 
 // print collected test results


### PR DESCRIPTION
This greatly improves working with styles in basil.js.

1) All existing style functions (`b.paragraphStyle()`, `b.characterStyle()`, `b.objectStyle()`) are updated:

  * They can now either get a style by name or the applied style of a given textObject/pageItem. If a style of a give name does not exist, it gets created. Additionally a properties name/value pairs object can be used to set the new style's properties or to update an existing style's properties.

2) The new functions `b.applyParagraphStyle()`, `b.applyCharacterStyle()` and `b.applyObjectStyle()` are added. They take a textObject|textFrame|Story/pageItem and apply the given style to it. The style can be given as style instance or by name.

3) The example script `styles.jsx` is added to demonstrate how to use the style functions.

This passes all tests, please review. 🔍