### PR TITLE
.gitignore - Added user folders + minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,21 @@
 .DS_Store
 basil.sublime-workspace
-examples/image/*.indd
-lib/extendables/log/extendables.log
 *.idlk
-# test files
+
+# Test files
 test/download/data/
 test/download/lib/
 test/download/basil.js
 test/loop/basil.js
 test/loop/lib/
 
+# User directories
+libraries/
+sketches/
+
 # Dependency directories
-node_modules
+node_modules/
 # Logs
-logs
 *.log
 npm-debug.log*
 


### PR DESCRIPTION
This adds the user folders `libraries/` and `sketches/` to `.gitignore` as with basil.js's new location the developer's environment is now on the same directory level as the user's environment. (See #155)

+ Some minor cleanup, removal of obsolete paths and making syntax more consistent.