### PR TITLE
b.isText() fix to correctly identify multiple text objects

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -3083,8 +3083,7 @@ var isText = pub.isText = function(obj) {
          obj.constructor.name === "Lines" ||
          obj.constructor.name === "TextStyleRanges" ||
          obj.constructor.name === "Paragraphs" ||
-         obj.constructor.name === "TextColumns" ||
-         obj.constructor.name === "Texts";
+         obj.constructor.name === "TextColumns";
 };
 
 

--- a/basil.js
+++ b/basil.js
@@ -3070,12 +3070,20 @@ var isString = pub.isString = function(str) {
 var isText = pub.isText = function(obj) {
   return obj instanceof Character ||
          obj instanceof InsertionPoint ||
+         obj instanceof Word ||
          obj instanceof Line ||
+         obj instanceof TextStyleRange ||
          obj instanceof Paragraph ||
          obj instanceof TextColumn ||
-         obj instanceof TextStyleRange ||
          obj instanceof Text ||
-         obj instanceof Word;
+         obj instanceof Characters ||
+         obj instanceof InsertionPoints ||
+         obj instanceof Words ||
+         obj instanceof Lines ||
+         obj instanceof TextStyleRanges ||
+         obj instanceof Paragraphs ||
+         obj instanceof TextColumns ||
+         obj instanceof Texts;
 };
 
 

--- a/basil.js
+++ b/basil.js
@@ -3068,6 +3068,7 @@ var isString = pub.isString = function(str) {
  * @return {Boolean} returns true if this is the case
  */
 var isText = pub.isText = function(obj) {
+
   return obj instanceof Character ||
          obj instanceof InsertionPoint ||
          obj instanceof Word ||
@@ -3076,14 +3077,14 @@ var isText = pub.isText = function(obj) {
          obj instanceof Paragraph ||
          obj instanceof TextColumn ||
          obj instanceof Text ||
-         obj instanceof Characters ||
-         obj instanceof InsertionPoints ||
-         obj instanceof Words ||
-         obj instanceof Lines ||
-         obj instanceof TextStyleRanges ||
-         obj instanceof Paragraphs ||
-         obj instanceof TextColumns ||
-         obj instanceof Texts;
+         obj.constructor.name === "Characters" ||
+         obj.constructor.name === "InsertionPoints" ||
+         obj.constructor.name === "Words" ||
+         obj.constructor.name === "Lines" ||
+         obj.constructor.name === "TextStyleRanges" ||
+         obj.constructor.name === "Paragraphs" ||
+         obj.constructor.name === "TextColumns" ||
+         obj.constructor.name === "Texts";
 };
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,11 +14,13 @@ basil.js x.x.x DAY MONTH YEAR
   make use of an optional object with property name/value pairs to set
   the properties of the style.
 * Improved the speed of b.clear() considerably
+* b.isText() now correctly identifies collections of multiple text objects as text
+  (Characters, Words, Lines etc.)
 * Changed all include/includepath/targetengine statements from # to //@
   This allows linting with eslint of all files
 * Linted all the test files
-* Changed the location of the basil.js library from `~/Documents/basiljs/bundle/basil.js` to `~/Documents/basiljs/basil.js` in all the example files. 
-The user is allowed to have his files whereever he wants.  
+* Changed the location of the basil.js library from `~/Documents/basiljs/bundle/basil.js` to `~/Documents/basiljs/basil.js` in all the example files.
+The user is allowed to have his files whereever he wants.
 
 ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-
 basil.js 1.1.0 - 11 November 2016

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -718,8 +718,7 @@ var isText = pub.isText = function(obj) {
          obj.constructor.name === "Lines" ||
          obj.constructor.name === "TextStyleRanges" ||
          obj.constructor.name === "Paragraphs" ||
-         obj.constructor.name === "TextColumns" ||
-         obj.constructor.name === "Texts";
+         obj.constructor.name === "TextColumns";
 };
 
 

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -705,12 +705,20 @@ var isString = pub.isString = function(str) {
 var isText = pub.isText = function(obj) {
   return obj instanceof Character ||
          obj instanceof InsertionPoint ||
+         obj instanceof Word ||
          obj instanceof Line ||
+         obj instanceof TextStyleRange ||
          obj instanceof Paragraph ||
          obj instanceof TextColumn ||
-         obj instanceof TextStyleRange ||
          obj instanceof Text ||
-         obj instanceof Word;
+         obj instanceof Characters ||
+         obj instanceof InsertionPoints ||
+         obj instanceof Words ||
+         obj instanceof Lines ||
+         obj instanceof TextStyleRanges ||
+         obj instanceof Paragraphs ||
+         obj instanceof TextColumns ||
+         obj instanceof Texts;
 };
 
 

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -703,6 +703,7 @@ var isString = pub.isString = function(str) {
  * @return {Boolean} returns true if this is the case
  */
 var isText = pub.isText = function(obj) {
+
   return obj instanceof Character ||
          obj instanceof InsertionPoint ||
          obj instanceof Word ||
@@ -711,14 +712,14 @@ var isText = pub.isText = function(obj) {
          obj instanceof Paragraph ||
          obj instanceof TextColumn ||
          obj instanceof Text ||
-         obj instanceof Characters ||
-         obj instanceof InsertionPoints ||
-         obj instanceof Words ||
-         obj instanceof Lines ||
-         obj instanceof TextStyleRanges ||
-         obj instanceof Paragraphs ||
-         obj instanceof TextColumns ||
-         obj instanceof Texts;
+         obj.constructor.name === "Characters" ||
+         obj.constructor.name === "InsertionPoints" ||
+         obj.constructor.name === "Words" ||
+         obj.constructor.name === "Lines" ||
+         obj.constructor.name === "TextStyleRanges" ||
+         obj.constructor.name === "Paragraphs" ||
+         obj.constructor.name === "TextColumns" ||
+         obj.constructor.name === "Texts";
 };
 
 

--- a/test/data-tests.jsx
+++ b/test/data-tests.jsx
@@ -8,6 +8,10 @@ if (typeof b.test === "undefined") {
 
 b.test("DataTests", {
 
+  tearDown: function(b) {
+    b.close(SaveOptions.no);
+  },
+
   testHashList: function(b) {
 
     var hash = new HashList();
@@ -108,6 +112,36 @@ b.test("DataTests", {
     // TODO: initial function removal in items?
 
 
+  },
+
+  testIsText: function(b) {
+    var doc = b.doc();
+
+    var tf = b.text(b.LOREM, 0, 0, 200, 200);
+
+    assert(b.isText(b.characters(tf)));
+    assert(b.isText(b.characters(tf)[0]));
+
+    assert(b.isText(tf.insertionPoints));
+    assert(b.isText(tf.insertionPoints.firstItem()));
+
+    assert(b.isText(b.words(tf)));
+    assert(b.isText(b.words(tf).firstItem()));
+
+    assert(b.isText(b.lines(tf)));
+    assert(b.isText(b.lines(tf).firstItem()));
+
+    assert(b.isText(tf.textStyleRanges));
+    assert(b.isText(tf.textStyleRanges.firstItem()));
+
+    assert(b.isText(b.paragraphs(tf)));
+    assert(b.isText(b.paragraphs(tf).firstItem()));
+
+    assert(b.isText(tf.textColumns));
+    assert(b.isText(tf.textColumns.firstItem()));
+
+    // anyone know if and how an [object Texts] can be created?
+    assert(b.isText(tf.characters.itemByRange(0, 2))); // [object Text]
   }
 
 });

--- a/test/data-tests.jsx
+++ b/test/data-tests.jsx
@@ -140,7 +140,6 @@ b.test("DataTests", {
     assert(b.isText(tf.textColumns));
     assert(b.isText(tf.textColumns.firstItem()));
 
-    // anyone know if and how an [object Texts] can be created?
     assert(b.isText(tf.characters.itemByRange(0, 2))); // [object Text]
   }
 


### PR DESCRIPTION
During working on another function I noticed that instances of multiple text objects (`Characters`, `Words`, `Lines`) are not recognized by `b.isText()`.

This means that until now this happened:

```js
var tf = b.text(b.LOREM, 0, 0, 200, 200);
var w = b.words(tf);
b.println(w); // --> [object Words]
b.println(b.isText(w)); // --> false
```

This PR fixes this, so collections of multiple Word objects evaluate to true with `b.text()`.

The reason this needs to be evaluated via `obj.constructor.name` instead of `obj instanceof` is that `obj instanceof Characters` etc. throws a reference error if there was not yet an `[object Characters]` defined during script execution.

The order of the checks was slightly altered to improve performance.

Tests for all possible cases were added. It also passes all other tests.

Please review! :)