### PR TITLE
found a TODO made it a `@todo`

### DIFF
--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -179,8 +179,7 @@ pub.vertex = function() {
  *
  * @return {GraphicLine|Polygon} The resulting GraphicLine or Polygon object (in InDesign Scripting terms the corresponding type is GraphicLine or Polygon, not Arc).
  *
- * TODO(S)
- * - fix overlapping points bug
+ * @todo fix overlapping points bug
  */
 pub.arc = function(cx, cy, w, h, startAngle, endAngle, mode) {
   if (w <= 0 || endAngle < startAngle) {


### PR DESCRIPTION
minor change. Only for the beauty of the docs.  

![bildschirmfoto 2017-05-13 um 20 57 46](https://cloud.githubusercontent.com/assets/315106/26028347/f4ef71ba-381e-11e7-97fd-a0a204d1715e.png)

## VS

![bildschirmfoto 2017-05-13 um 20 58 22](https://cloud.githubusercontent.com/assets/315106/26028348/f62de75a-381e-11e7-9182-62f4b8369094.png)


(Did you know there is a user called `@todo`?)