### PR TITLE
Added possibility to use a page size preset as argument for b.size()

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1494,44 +1494,56 @@ pub.doc = function(doc) {
 /**
  * Sets the size of the current document, if arguments are given.
  * If only one argument is given, both the width and the height are set to this value.
+ * Alternatively a string can be given as the only argument to apply an existing page size preset ("A4", "Letter" etc.).
  * If no argument is given, an object containing the current document's width and height is returned.
  *
  * @cat Document
  * @method size
- * @param  {Number} width The desired width of the current document.
+ * @param  {Number|String} widthOrPageSize The desired width of the current document or the name of a page size preset.
  * @param  {Number} [height] The desired height of the current document. If not provided the width will be used as the height.
  * @return {Object} if no argument is given it returns an object containing the current width and height of the document.
  *
  */
-pub.size = function(width, height) {
+pub.size = function(widthOrPageSize, height) {
   if(app.documents.length === 0) {
     // there are no documents
-    warning("b.size(width, height)", "You have no open document.");
+    warning("b.size()", "You have no open document.");
     return;
   }
   if (arguments.length === 0) {
     // no arguments given
-    // return the curent values
-    // warning('b.size(width, height)', 'no arguments given');
+    // return the current values
     return {width: pub.width, height: pub.height};
   }
 
-  if(arguments.length === 1) {
+  var doc = currentDoc();
+
+  if(arguments.length === 1 && typeof widthOrPageSize === "string") {
+
+    try {
+      doc.documentPreferences.pageSize = widthOrPageSize;
+    } catch (e) {
+      b.error("b.size(), could not find a page size preset named \"" + widthOrPageSize + "\".");
+    }
+    pub.height = doc.documentPreferences.pageHeight;
+    pub.width = doc.documentPreferences.pageWidth;
+    return {width: pub.width, height: pub.height};
+  } else if(arguments.length === 1) {
     // only one argument set the first to the secound
-    height = width;
+    height = widthOrPageSize;
   }
-  var doc = app.documents[0];
-    // set the documents pageHeiht and pageWidth
+  // set the document's pageHeight and pageWidth
   doc.properties = {
     documentPreferences: {
       pageHeight: height,
-      pageWidth: width
+      pageWidth: widthOrPageSize
     }
   };
   // set height and width
   pub.height = height;
-  pub.width = width;
+  pub.width = widthOrPageSize;
 
+  return {width: pub.width, height: pub.height};
 
 };
 

--- a/basil.js
+++ b/basil.js
@@ -330,6 +330,22 @@ pub.BEFORE = LocationOptions.BEFORE;
 pub.AFTER = LocationOptions.AFTER;
 
 /**
+ * Used with b.size() to set the orientation of a given page size to portrait.
+ * @property PORTRAIT {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.PORTRAIT = PageOrientation.PORTRAIT;
+
+/**
+ * Used with b.size() to set the orientation of a given page size to landscape.
+ * @property LANDSCAPE {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.LANDSCAPE = PageOrientation.LANDSCAPE;
+
+/**
  * Returns a Lorem ipsum string that can be used for testing.
  * @property LOREM {String}
  * @cat Typography
@@ -1494,17 +1510,29 @@ pub.doc = function(doc) {
 /**
  * Sets the size of the current document, if arguments are given.
  * If only one argument is given, both the width and the height are set to this value.
- * Alternatively a string can be given as the only argument to apply an existing page size preset ("A4", "Letter" etc.).
+ * Alternatively, a string can be given as the first argument to apply an existing page size preset ("A4", "Letter" etc.).
+ * In this case, either b.PORTRAIT or b.LANDSCAPE can be used as a second argument to determine the orientation of the page.
  * If no argument is given, an object containing the current document's width and height is returned.
  *
  * @cat Document
  * @method size
- * @param  {Number|String} widthOrPageSize The desired width of the current document or the name of a page size preset.
- * @param  {Number} [height] The desired height of the current document. If not provided the width will be used as the height.
- * @return {Object} if no argument is given it returns an object containing the current width and height of the document.
+ * @param  {Number|String} [widthOrPageSize] The desired width of the current document or the name of a page size preset.
+ * @param  {Number|String} [heightOrOrientation] The desired height of the current document. If not provided the width will be used as the height. If the first argument is a page size preset, the second argument can be used to set the orientation.
+ * @return {Object} Object containing the current <code>width</code> and <code>height</code> of the document.
  *
+ * @example <caption>Sets the document size to 70 x 100 units</caption>
+ * b.size(70, 100);
+ *
+ * @example <caption>Sets the document size to 70 x 70</caption>
+ * b.size(70);
+ *
+ * @example <caption>Sets the document size to A4, keeps the current orientation in place</caption>
+ * b.size("A4");
+ *
+ * @example <caption>Sets the document size to A4, set the orientation to landscape</caption>
+ * b.size("A4", b.LANDSCAPE);
  */
-pub.size = function(widthOrPageSize, height) {
+pub.size = function(widthOrPageSize, heightOrOrientation) {
   if(app.documents.length === 0) {
     // there are no documents
     warning("b.size()", "You have no open document.");
@@ -1518,29 +1546,32 @@ pub.size = function(widthOrPageSize, height) {
 
   var doc = currentDoc();
 
-  if(arguments.length === 1 && typeof widthOrPageSize === "string") {
+  if(typeof widthOrPageSize === "string") {
 
     try {
       doc.documentPreferences.pageSize = widthOrPageSize;
     } catch (e) {
       b.error("b.size(), could not find a page size preset named \"" + widthOrPageSize + "\".");
     }
+    if(heightOrOrientation === b.PORTRAIT || heightOrOrientation === b.LANDSCAPE) {
+      doc.documentPreferences.pageOrientation = heightOrOrientation;
+    }
     pub.height = doc.documentPreferences.pageHeight;
     pub.width = doc.documentPreferences.pageWidth;
     return {width: pub.width, height: pub.height};
   } else if(arguments.length === 1) {
     // only one argument set the first to the secound
-    height = widthOrPageSize;
+    heightOrOrientation = widthOrPageSize;
   }
   // set the document's pageHeight and pageWidth
   doc.properties = {
     documentPreferences: {
-      pageHeight: height,
+      pageHeight: heightOrOrientation,
       pageWidth: widthOrPageSize
     }
   };
   // set height and width
-  pub.height = height;
+  pub.height = heightOrOrientation;
   pub.width = widthOrPageSize;
 
   return {width: pub.width, height: pub.height};

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ basil.js x.x.x DAY MONTH YEAR
 * Improved the speed of b.clear() considerably
 * b.isText() now correctly identifies collections of multiple text objects as text
   (Characters, Words, Lines etc.)
+* b.size() now can use existing page size presets as a parameter
 * Changed all include/includepath/targetengine statements from # to //@
   This allows linting with eslint of all files
 * Linted all the test files

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,8 @@ basil.js x.x.x DAY MONTH YEAR
 * Improved the speed of b.clear() considerably
 * b.isText() now correctly identifies collections of multiple text objects as text
   (Characters, Words, Lines etc.)
-* b.size() now can use existing page size presets as a parameter
+* b.size() now can use existing page size presets as a parameter with an optional
+  second parameter for page orientation (introducing b.PORTRAIT and b.LANDSCAPE)
 * Changed all include/includepath/targetengine statements from # to //@
   This allows linting with eslint of all files
 * Linted all the test files

--- a/src/includes/constants.js
+++ b/src/includes/constants.js
@@ -269,6 +269,22 @@ pub.BEFORE = LocationOptions.BEFORE;
 pub.AFTER = LocationOptions.AFTER;
 
 /**
+ * Used with b.size() to set the orientation of a given page size to portrait.
+ * @property PORTRAIT {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.PORTRAIT = PageOrientation.PORTRAIT;
+
+/**
+ * Used with b.size() to set the orientation of a given page size to landscape.
+ * @property LANDSCAPE {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.LANDSCAPE = PageOrientation.LANDSCAPE;
+
+/**
  * Returns a Lorem ipsum string that can be used for testing.
  * @property LOREM {String}
  * @cat Typography

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -21,44 +21,56 @@ pub.doc = function(doc) {
 /**
  * Sets the size of the current document, if arguments are given.
  * If only one argument is given, both the width and the height are set to this value.
+ * Alternatively a string can be given as the only argument to apply an existing page size preset ("A4", "Letter" etc.).
  * If no argument is given, an object containing the current document's width and height is returned.
  *
  * @cat Document
  * @method size
- * @param  {Number} width The desired width of the current document.
+ * @param  {Number|String} widthOrPageSize The desired width of the current document or the name of a page size preset.
  * @param  {Number} [height] The desired height of the current document. If not provided the width will be used as the height.
  * @return {Object} if no argument is given it returns an object containing the current width and height of the document.
  *
  */
-pub.size = function(width, height) {
+pub.size = function(widthOrPageSize, height) {
   if(app.documents.length === 0) {
     // there are no documents
-    warning("b.size(width, height)", "You have no open document.");
+    warning("b.size()", "You have no open document.");
     return;
   }
   if (arguments.length === 0) {
     // no arguments given
-    // return the curent values
-    // warning('b.size(width, height)', 'no arguments given');
+    // return the current values
     return {width: pub.width, height: pub.height};
   }
 
-  if(arguments.length === 1) {
+  var doc = currentDoc();
+
+  if(arguments.length === 1 && typeof widthOrPageSize === "string") {
+
+    try {
+      doc.documentPreferences.pageSize = widthOrPageSize;
+    } catch (e) {
+      b.error("b.size(), could not find a page size preset named \"" + widthOrPageSize + "\".");
+    }
+    pub.height = doc.documentPreferences.pageHeight;
+    pub.width = doc.documentPreferences.pageWidth;
+    return {width: pub.width, height: pub.height};
+  } else if(arguments.length === 1) {
     // only one argument set the first to the secound
-    height = width;
+    height = widthOrPageSize;
   }
-  var doc = app.documents[0];
-    // set the documents pageHeiht and pageWidth
+  // set the document's pageHeight and pageWidth
   doc.properties = {
     documentPreferences: {
       pageHeight: height,
-      pageWidth: width
+      pageWidth: widthOrPageSize
     }
   };
   // set height and width
   pub.height = height;
-  pub.width = width;
+  pub.width = widthOrPageSize;
 
+  return {width: pub.width, height: pub.height};
 
 };
 

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -21,17 +21,29 @@ pub.doc = function(doc) {
 /**
  * Sets the size of the current document, if arguments are given.
  * If only one argument is given, both the width and the height are set to this value.
- * Alternatively a string can be given as the only argument to apply an existing page size preset ("A4", "Letter" etc.).
+ * Alternatively, a string can be given as the first argument to apply an existing page size preset ("A4", "Letter" etc.).
+ * In this case, either b.PORTRAIT or b.LANDSCAPE can be used as a second argument to determine the orientation of the page.
  * If no argument is given, an object containing the current document's width and height is returned.
  *
  * @cat Document
  * @method size
- * @param  {Number|String} widthOrPageSize The desired width of the current document or the name of a page size preset.
- * @param  {Number} [height] The desired height of the current document. If not provided the width will be used as the height.
- * @return {Object} if no argument is given it returns an object containing the current width and height of the document.
+ * @param  {Number|String} [widthOrPageSize] The desired width of the current document or the name of a page size preset.
+ * @param  {Number|String} [heightOrOrientation] The desired height of the current document. If not provided the width will be used as the height. If the first argument is a page size preset, the second argument can be used to set the orientation.
+ * @return {Object} Object containing the current <code>width</code> and <code>height</code> of the document.
  *
+ * @example <caption>Sets the document size to 70 x 100 units</caption>
+ * b.size(70, 100);
+ *
+ * @example <caption>Sets the document size to 70 x 70</caption>
+ * b.size(70);
+ *
+ * @example <caption>Sets the document size to A4, keeps the current orientation in place</caption>
+ * b.size("A4");
+ *
+ * @example <caption>Sets the document size to A4, set the orientation to landscape</caption>
+ * b.size("A4", b.LANDSCAPE);
  */
-pub.size = function(widthOrPageSize, height) {
+pub.size = function(widthOrPageSize, heightOrOrientation) {
   if(app.documents.length === 0) {
     // there are no documents
     warning("b.size()", "You have no open document.");
@@ -45,29 +57,32 @@ pub.size = function(widthOrPageSize, height) {
 
   var doc = currentDoc();
 
-  if(arguments.length === 1 && typeof widthOrPageSize === "string") {
+  if(typeof widthOrPageSize === "string") {
 
     try {
       doc.documentPreferences.pageSize = widthOrPageSize;
     } catch (e) {
       b.error("b.size(), could not find a page size preset named \"" + widthOrPageSize + "\".");
     }
+    if(heightOrOrientation === b.PORTRAIT || heightOrOrientation === b.LANDSCAPE) {
+      doc.documentPreferences.pageOrientation = heightOrOrientation;
+    }
     pub.height = doc.documentPreferences.pageHeight;
     pub.width = doc.documentPreferences.pageWidth;
     return {width: pub.width, height: pub.height};
   } else if(arguments.length === 1) {
     // only one argument set the first to the secound
-    height = widthOrPageSize;
+    heightOrOrientation = widthOrPageSize;
   }
   // set the document's pageHeight and pageWidth
   doc.properties = {
     documentPreferences: {
-      pageHeight: height,
+      pageHeight: heightOrOrientation,
       pageWidth: widthOrPageSize
     }
   };
   // set height and width
-  pub.height = height;
+  pub.height = heightOrOrientation;
   pub.width = widthOrPageSize;
 
   return {width: pub.width, height: pub.height};

--- a/test/environment-tests.jsx
+++ b/test/environment-tests.jsx
@@ -21,17 +21,43 @@ b.test("EnvironmentTests", {
     b.close(SaveOptions.no);
   },
 
-  testSizeAllArgs: function(b) {
+  testSizeAllNumberArgs: function(b) {
     var doc = app.documents.add();
     b.size(100, 200);
     assert(doc.documentPreferences.pageWidth === 100);
     assert(doc.documentPreferences.pageHeight === 200);
   },
-  testSizeOneArg: function(b) {
+  testSizeAllPageSizePresetArgs: function(b) {
+    var doc = app.documents.add();
+    b.units(b.PX);
+    doc.documentPreferences.pageWidth = 1000;
+    doc.documentPreferences.pageHeight = 500;
+
+    b.size("800 x 600", b.PORTRAIT);
+    assert(doc.documentPreferences.pageHeight > doc.documentPreferences.pageWidth);
+    assert(doc.documentPreferences.pageWidth === 600);
+    assert(doc.documentPreferences.pageHeight === 800);
+
+    b.size("1024 x 768", b.LANDSCAPE);
+    assert(doc.documentPreferences.pageHeight < doc.documentPreferences.pageWidth);
+    assert(doc.documentPreferences.pageWidth === 1024);
+    assert(doc.documentPreferences.pageHeight === 768);
+  },
+  testSizeOneNumberArg: function(b) {
     var doc = app.documents.add();
     b.size(100);
     assert(doc.documentPreferences.pageWidth === 100);
     assert(doc.documentPreferences.pageHeight === 100);
+  },
+  testSizeOnePageSizePresetArg: function(b) {
+    var doc = app.documents.add();
+    b.units(b.PX);
+    doc.documentPreferences.pageWidth = 1000;
+    doc.documentPreferences.pageHeight = 500;
+
+    b.size("800 x 600");
+    assert(doc.documentPreferences.pageWidth === 800);
+    assert(doc.documentPreferences.pageHeight === 600);
   },
   testSizeNoArg: function(b) {
     var doc = app.documents.add();


### PR DESCRIPTION
Hey there,
just had the idea that it would be nice if instead of using values to set the page size with `b.size()`, you could also set the size with the name of a page size preset like `"A4"` or `"Letter"`, etc.

Was easy to implement, so I decided to create a pull request right away. Hope the idea makes sense to you guys as well.

However, before anybody goes ahead to merge this, one question: Should we also allow yet another parameter to set the orientation? With the implementation I just did, it simply keeps the orientation. That means if I have a landscape `A4` document and set it to `iPhone` format via `b.size("iPhone")` I will get a landscape iPhone sized document automatically.

Should we allow an extra parameter like `b.PORTRAIT` and `b.LANDSCAPE` (in which case I would create a new pull request with that implemented)?

So usage would look like this:

`b.size("A3", b.LANDSCAPE);`