### PR TITLE
Rewrote b.text() so it won't stop a script anymore if font is missing

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -4964,7 +4964,7 @@ pub.textFont = function(fontName, fontStyle) {
   }
 
   if(app.fonts.itemByName(fontName).status !== FontStatus.INSTALLED) {
-    warning("b.textFont(), Font \"" + fontName + "\" not installed. Using current font instead.");
+    warning("b.textFont(), font \"" + fontName + "\" not installed. Using current font instead.");
   } else {
     currFont = fontName;
   }

--- a/basil.js
+++ b/basil.js
@@ -4954,12 +4954,21 @@ var isValid = function (item) {
  * @return {String} currFont The name of the current font
  */
 pub.textFont = function(fontName, fontStyle) {
-  if (arguments.length === 1) {
+
+  if (arguments.length === 2) {
+    fontName = fontName + "\t" + fontStyle;
+  } else if (arguments.length === 1) {
+    fontName = fontName + "\tRegular";
+  } else {
+    error("b.textFont(), wrong parameters. Use: fontName, fontStyle. fontStyle is optional.");
+  }
+
+  if(app.fonts.itemByName(fontName).status !== FontStatus.INSTALLED) {
+    warning("b.textFont(), Font \"" + fontName + "\" not installed. Using current font instead.");
+  } else {
     currFont = fontName;
   }
-  if (arguments.length === 2) {
-    currFont = fontName + "\t" + fontStyle;
-  }
+
   return currFont;
 };
 

--- a/basil.js
+++ b/basil.js
@@ -965,7 +965,7 @@ var setCurrDoc = function(doc) {
 //  currDoc.viewPreferences.horizontalMeasurementUnits = MeasurementUnits.millimeters;
 //  currDoc.viewPreferences.verticalMeasurementUnits = MeasurementUnits.millimeters;
 
-  currFont = currDoc.textDefaults.appliedFont.name;
+  currFont = currDoc.textDefaults.appliedFont;
   currFontSize = currDoc.textDefaults.pointSize;
   currAlign = currDoc.textDefaults.justification;
   currLeading = currDoc.textDefaults.leading;
@@ -4949,9 +4949,9 @@ var isValid = function (item) {
  *
  * @cat Typography
  * @method textFont
- * @param  {String} fontName The name of the font to set e.g. Helvetica
- * @param  {String} [fontStyle] The Font style e.g. Bold
- * @return {String} currFont The name of the current font
+ * @param  {String} [fontName] The name of the font to set e.g. Helvetica
+ * @param  {String} [fontStyle] The font style e.g. Bold
+ * @return {Font} The current font object
  */
 pub.textFont = function(fontName, fontStyle) {
 
@@ -4959,14 +4959,17 @@ pub.textFont = function(fontName, fontStyle) {
     fontName = fontName + "\t" + fontStyle;
   } else if (arguments.length === 1) {
     fontName = fontName + "\tRegular";
+  } else if (arguments.length === 0) {
+    return currFont;
   } else {
-    error("b.textFont(), wrong parameters. Use: fontName, fontStyle. fontStyle is optional.");
+    error("b.textFont(), wrong parameters. To set font use: fontName, fontStyle. fontStyle is optional.");
   }
 
   if(app.fonts.itemByName(fontName).status !== FontStatus.INSTALLED) {
-    warning("b.textFont(), font \"" + fontName + "\" not installed. Using current font instead.");
+    warning("b.textFont(), font \"" + fontName.replace("\t", " ") + "\" not installed. "
+      + "Using current font \"" + currFont.fontFamily + " " + currFont.fontStyleName + "\" instead.");
   } else {
-    currFont = fontName;
+    currFont = app.fonts.itemByName(fontName);
   }
 
   return currFont;

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ basil.js x.x.x DAY MONTH YEAR
   Option to show only certain properties.
   Lots of minor fixes.
 * Improved the speed of b.clear() considerably
+* b.textFont() does no longer stop the script if a font is missing, but gives a console warning instead
 * b.isText() now correctly identifies collections of multiple text objects as text
   (Characters, Words, Lines etc.)
 * Changed all include/includepath/targetengine statements from # to //@

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -248,7 +248,7 @@ var setCurrDoc = function(doc) {
 //  currDoc.viewPreferences.horizontalMeasurementUnits = MeasurementUnits.millimeters;
 //  currDoc.viewPreferences.verticalMeasurementUnits = MeasurementUnits.millimeters;
 
-  currFont = currDoc.textDefaults.appliedFont.name;
+  currFont = currDoc.textDefaults.appliedFont;
   currFontSize = currDoc.textDefaults.pointSize;
   currAlign = currDoc.textDefaults.justification;
   currLeading = currDoc.textDefaults.leading;

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -162,7 +162,7 @@ pub.textFont = function(fontName, fontStyle) {
   }
 
   if(app.fonts.itemByName(fontName).status !== FontStatus.INSTALLED) {
-    warning("b.textFont(), Font \"" + fontName + "\" not installed. Using current font instead.");
+    warning("b.textFont(), font \"" + fontName + "\" not installed. Using current font instead.");
   } else {
     currFont = fontName;
   }

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -147,9 +147,9 @@ var isValid = function (item) {
  *
  * @cat Typography
  * @method textFont
- * @param  {String} fontName The name of the font to set e.g. Helvetica
- * @param  {String} [fontStyle] The Font style e.g. Bold
- * @return {String} currFont The name of the current font
+ * @param  {String} [fontName] The name of the font to set e.g. Helvetica
+ * @param  {String} [fontStyle] The font style e.g. Bold
+ * @return {Font} The current font object
  */
 pub.textFont = function(fontName, fontStyle) {
 
@@ -157,14 +157,17 @@ pub.textFont = function(fontName, fontStyle) {
     fontName = fontName + "\t" + fontStyle;
   } else if (arguments.length === 1) {
     fontName = fontName + "\tRegular";
+  } else if (arguments.length === 0) {
+    return currFont;
   } else {
-    error("b.textFont(), wrong parameters. Use: fontName, fontStyle. fontStyle is optional.");
+    error("b.textFont(), wrong parameters. To set font use: fontName, fontStyle. fontStyle is optional.");
   }
 
   if(app.fonts.itemByName(fontName).status !== FontStatus.INSTALLED) {
-    warning("b.textFont(), font \"" + fontName + "\" not installed. Using current font instead.");
+    warning("b.textFont(), font \"" + fontName.replace("\t", " ") + "\" not installed. "
+      + "Using current font \"" + currFont.fontFamily + " " + currFont.fontStyleName + "\" instead.");
   } else {
-    currFont = fontName;
+    currFont = app.fonts.itemByName(fontName);
   }
 
   return currFont;

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -152,12 +152,21 @@ var isValid = function (item) {
  * @return {String} currFont The name of the current font
  */
 pub.textFont = function(fontName, fontStyle) {
-  if (arguments.length === 1) {
+
+  if (arguments.length === 2) {
+    fontName = fontName + "\t" + fontStyle;
+  } else if (arguments.length === 1) {
+    fontName = fontName + "\tRegular";
+  } else {
+    error("b.textFont(), wrong parameters. Use: fontName, fontStyle. fontStyle is optional.");
+  }
+
+  if(app.fonts.itemByName(fontName).status !== FontStatus.INSTALLED) {
+    warning("b.textFont(), Font \"" + fontName + "\" not installed. Using current font instead.");
+  } else {
     currFont = fontName;
   }
-  if (arguments.length === 2) {
-    currFont = fontName + "\t" + fontStyle;
-  }
+
   return currFont;
 };
 

--- a/test/typography-tests.jsx
+++ b/test/typography-tests.jsx
@@ -115,6 +115,25 @@ b.test("TypographyTests", {
     });
   },
 
+  testApplyingTextFonts: function(b) {
+    b.doc(this.doc);
+    var textFrame = b.text(b.LOREM, 0, 0, 100, 100);
+    var currentFont = textFrame.parentStory.appliedFont;
+
+    b.textFont("someNonInstalledFont");
+    var textFrameNonInstalled = b.text(b.LOREM, 100, 100, 100, 100);
+    assert(textFrameNonInstalled.parentStory.appliedFont === currentFont);
+
+    b.textFont("Helvetica");
+    var textFrameHelvetica = b.text(b.LOREM, 200, 200, 100, 100);
+    assert(textFrameHelvetica.parentStory.appliedFont.fontFamily === "Helvetica");
+
+    b.textFont("Helvetica", "Bold");
+    var textFrameHelveticaBold = b.text(b.LOREM, 300, 300, 100, 100);
+    assert(textFrameHelveticaBold.parentStory.appliedFont.fontFamily === "Helvetica");
+    assert(textFrameHelveticaBold.parentStory.appliedFont.fontStyleName === "Bold");
+  },
+
   testCreateEmptyStyles: function(b) {
     b.doc(this.doc);
 


### PR DESCRIPTION
As discussed in #119, `b.textFont()` does no longer stop the script if a font is missing, but gives a warning instead.

It looks like this:

```js
b.textFont("myFont", "Bold"); // ### Basil Warning -> b.textFont(), font "myFont  Bold" not installed. Using current font instead.
```

It handles cases where a font *is* installed, but does not have any default font style (Regular/Normal/Roman/Book), like this:

```js
b.textFont("Erbar"); // ### Basil Warning -> b.textFont(), font "Erbar  Regular" not installed. Using current font instead.
```

If it does not find the font, it will use the current font instead, which is either the default font or the most recently applied font (if a font has previously been set successfully).

Btw., although it might not look like it from the code, this *does* work for fonts whose default font style is not called `Regular`. So, if I have for example `Arnhem`, whose default style is called `Normal`, this will apply that default style as expected:

```js
b.textFont("Arnhem");
```
Added tests as well, clears all other tests.

Please review! 🔍 🐛 😎 

This closes #119.