### PR TITLE
b.SCRIPTNAME

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -337,16 +337,15 @@ pub.AFTER = LocationOptions.AFTER;
 pub.LOREM = "Lorem ipsum is dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
 
 /**
-* Used with b.go() to set Performance Mode. Disables ScreenRedraw during processing.
-* @property MODESILENT {String}
+* The name of the current script.
+* @property SCRIPTNAME {String}
 * @cat Environment
-* @subcat modes
 */
 var stackArray = $.stack.
             replace(/[\n]toString\(\)[\n]$/,'').
             replace(/[\[\]']+/g,'').
             split(/[\n]/);
-pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1].replace(/.[^.]+$/,'') : stackArray[0].replace(/.[^.]+$/,'');
+pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1] : stackArray[0];
 
 /**
 * Used with b.go() to set Performance Mode. Disables ScreenRedraw during processing.
@@ -904,7 +903,7 @@ var runSetup = function() {
     if (typeof glob.setup === "function") {
       glob.setup();
     }
-  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT);
+  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT, pub.SCRIPTNAME);
 };
 
 var runDrawOnce = function() {
@@ -912,7 +911,7 @@ var runDrawOnce = function() {
     if (typeof glob.draw === "function") {
       glob.draw();
     }
-  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT);
+  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT, pub.SCRIPTNAME);
 };
 
 var runDrawLoop = function() {
@@ -920,7 +919,7 @@ var runDrawLoop = function() {
     if (typeof glob.draw === "function") {
       glob.draw();
     }
-  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT);
+  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT, pub.SCRIPTNAME);
 };
 
 var welcome = function() {

--- a/basil.js
+++ b/basil.js
@@ -342,6 +342,18 @@ pub.LOREM = "Lorem ipsum is dolor sit amet, consectetur adipisicing elit, sed do
 * @cat Environment
 * @subcat modes
 */
+var stackArray = $.stack.
+            replace(/[\n]toString\(\)[\n]$/,'').
+            replace(/[\[\]']+/g,'').
+            split(/[\n]/);
+pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1].replace(/.[^.]+$/,'') : stackArray[0].replace(/.[^.]+$/,'');
+
+/**
+* Used with b.go() to set Performance Mode. Disables ScreenRedraw during processing.
+* @property MODESILENT {String}
+* @cat Environment
+* @subcat modes
+*/
 pub.MODESILENT = "ModeSilent";
 
 /**
@@ -913,7 +925,9 @@ var runDrawLoop = function() {
 
 var welcome = function() {
   clearConsole();
-  println("Using basil.js "
+  println("Running "
+      + pub.SCRIPTNAME
+      + " using basil.js "
       + pub.VERSION
       + " ...");
 };

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,8 @@ basil.js x.x.x DAY MONTH YEAR
   see examples/typography/styles.jsx
 + Added b.swatch()
   returns a color or gradient of a given name
++ Added b.SCRIPTNAME
+  holds the name of the current script
 
 * b.paragraphStyle(), b.characterStyle() and b.objectStyle() are expanded:
   They can now get an applied style from a text object/page item and can

--- a/src/includes/constants.js
+++ b/src/includes/constants.js
@@ -281,6 +281,18 @@ pub.LOREM = "Lorem ipsum is dolor sit amet, consectetur adipisicing elit, sed do
 * @cat Environment
 * @subcat modes
 */
+var stackArray = $.stack.
+            replace(/[\n]toString\(\)[\n]$/,'').
+            replace(/[\[\]']+/g,'').
+            split(/[\n]/);
+pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1].replace(/.[^.]+$/,'') : stackArray[0].replace(/.[^.]+$/,'');
+
+/**
+* Used with b.go() to set Performance Mode. Disables ScreenRedraw during processing.
+* @property MODESILENT {String}
+* @cat Environment
+* @subcat modes
+*/
 pub.MODESILENT = "ModeSilent";
 
 /**

--- a/src/includes/constants.js
+++ b/src/includes/constants.js
@@ -276,16 +276,15 @@ pub.AFTER = LocationOptions.AFTER;
 pub.LOREM = "Lorem ipsum is dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
 
 /**
-* Used with b.go() to set Performance Mode. Disables ScreenRedraw during processing.
-* @property MODESILENT {String}
+* The name of the current script.
+* @property SCRIPTNAME {String}
 * @cat Environment
-* @subcat modes
 */
 var stackArray = $.stack.
             replace(/[\n]toString\(\)[\n]$/,'').
             replace(/[\[\]']+/g,'').
             split(/[\n]/);
-pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1].replace(/.[^.]+$/,'') : stackArray[0].replace(/.[^.]+$/,'');
+pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1] : stackArray[0];
 
 /**
 * Used with b.go() to set Performance Mode. Disables ScreenRedraw during processing.

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -196,7 +196,9 @@ var runDrawLoop = function() {
 
 var welcome = function() {
   clearConsole();
-  println("Using basil.js "
+  println("Running "
+      + pub.SCRIPTNAME
+      + " using basil.js "
       + pub.VERSION
       + " ...");
 };

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -175,7 +175,7 @@ var runSetup = function() {
     if (typeof glob.setup === "function") {
       glob.setup();
     }
-  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT);
+  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT, pub.SCRIPTNAME);
 };
 
 var runDrawOnce = function() {
@@ -183,7 +183,7 @@ var runDrawOnce = function() {
     if (typeof glob.draw === "function") {
       glob.draw();
     }
-  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT);
+  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT, pub.SCRIPTNAME);
 };
 
 var runDrawLoop = function() {
@@ -191,7 +191,7 @@ var runDrawLoop = function() {
     if (typeof glob.draw === "function") {
       glob.draw();
     }
-  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT);
+  }, ScriptLanguage.javascript, undef, UndoModes.ENTIRE_SCRIPT, pub.SCRIPTNAME);
 };
 
 var welcome = function() {


### PR DESCRIPTION
As discussed in #123, this adds a constant `b.SCRIPTNAME` that holds the name of the script. This will change the welcome text from the current

```Running in basil.js 1.1.0 ...```
to
```Running ellipses.jsx using basil.js 1.1.0 ...```

Also, it will add the name of your script to the undo menu:

![bildschirmfoto 2017-08-13 um 15 38 04](https://user-images.githubusercontent.com/9803905/29250241-48f3e4a4-803f-11e7-978f-53bd5543e49b.png)

As you can see, I left the file extension in there, because I was trying it out a bit and it felt weird if it's missing:

![bildschirmfoto 2017-08-13 um 15 32 45](https://user-images.githubusercontent.com/9803905/29250247-722ee788-803f-11e7-98ba-dd5b048447ac.png)
![bildschirmfoto 2017-08-13 um 15 35 00](https://user-images.githubusercontent.com/9803905/29250251-7985c344-803f-11e7-9b51-fb49c1dba822.png)

I think it might not be obvious right away that his refers to a script named `ellipses`. As opposed to this:

![bildschirmfoto 2017-08-13 um 15 37 57](https://user-images.githubusercontent.com/9803905/29250255-9fa393d0-803f-11e7-9df6-ee85f06182ff.png)
![bildschirmfoto 2017-08-13 um 15 38 04](https://user-images.githubusercontent.com/9803905/29250256-a2226500-803f-11e7-9323-3b59ce9e8518.png)

I think here you understand much better that this refers to the script. Also, we can always use basil's own `b.split()` method to retrieve the script's name without extension:

```var scriptNameWithoutExtension = b.split(b.SCRIPTNAME, ".")[0]```

Let me know, if you disagree. 😃

If you look at the code, you can see that neither `$.filename` nor `app.activeScript` was used to retrieve the name, as they both did not return the script name, so I had to evaluate the stack trace, which is the only way I found to return the name reliably.

Please review. 🔍 🐛 