### PR TITLE
Adding b.revert()

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1457,29 +1457,6 @@ pub.clear = function(container) {
 };
 
 /**
- * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
- *
- * @cat Document
- * @method revert
- * @return {Document} The reverted document.
- */
-pub.revert = function() {
-
-  if(currDoc.saved && currDoc.modified) {
-    var currFile = currDoc.fullName;
-    currDoc.close(SaveOptions.NO);
-    app.open(File(currFile));
-    resetCurrDoc();
-  } else if(!currDoc.saved) {
-    currDoc.close(SaveOptions.NO);
-    resetCurrDoc();
-    currentDoc();
-  }
-
-  return currDoc;
-};
-
-/**
  * @description Removes the provided Page, Layer, PageItem, Swatch, etc.
  *
  * @cat Document

--- a/basil.js
+++ b/basil.js
@@ -919,7 +919,7 @@ var welcome = function() {
 };
 
 var currentDoc = function (mode) {
-  if (!currDoc) {
+  if (currDoc === null || !currDoc) {
     var stack = $.stack;
     if (!(stack.match(/go\(.*\)/) || stack.match(/loop\(.*\)/))) {
       warning("Do not initialize Variables with dependency to b outside the setup() or the draw() function. If you do so, basil will not be able to run in performance optimized Modes! If you really need them globally we recommend to only declare them gobally but initialize them in setup()! Current Stack is " + stack);
@@ -1034,24 +1034,25 @@ var resetCurrDoc = function() {
 };
 
 var currentLayer = function() {
-  if (!currLayer) {
+  if (currLayer === null || !currLayer) {
     currentDoc();
-    if (currDoc.windows.length)
+    if (currDoc.windows.length) {
       currLayer = app.activeDocument.activeLayer;
-    else
+    } else {
       currLayer = currDoc.layers[0];
-
+    }
   }
   return currLayer;
 };
 
 var currentPage = function() {
-  if (!currPage) {
+  if (currPage === null || !currPage) {
     currentDoc();
-    if (currDoc.windows.length)
+    if (currDoc.windows.length) {
       currPage = app.activeWindow.activePage;
-    else
-        currPage = currDoc.pages[0];
+    } else {
+      currPage = currDoc.pages[0];
+    }
   }
   return currPage;
 };
@@ -1456,6 +1457,29 @@ pub.clear = function(container) {
 };
 
 /**
+ * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
+ *
+ * @cat Document
+ * @method revert
+ * @return {Document} The reverted document.
+ */
+pub.revert = function() {
+
+  if(currDoc.saved && currDoc.modified) {
+    var currFile = currDoc.fullName;
+    currDoc.close(SaveOptions.NO);
+    app.open(File(currFile));
+    resetCurrDoc();
+  } else if(!currDoc.saved) {
+    currDoc.close(SaveOptions.NO);
+    resetCurrDoc();
+    currentDoc();
+  }
+
+  return currDoc;
+};
+
+/**
  * @description Removes the provided Page, Layer, PageItem, Swatch, etc.
  *
  * @cat Document
@@ -1557,6 +1581,28 @@ pub.close = function(saveOptions, file) {
   }
 };
 
+/**
+ * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
+ *
+ * @cat Document
+ * @method revert
+ * @return {Document} The reverted document.
+ */
+pub.revert = function() {
+
+  if(currDoc.saved && currDoc.modified) {
+    var currFile = currDoc.fullName;
+    currDoc.close(SaveOptions.NO);
+    app.open(File(currFile));
+    resetCurrDoc();
+  } else if(!currDoc.saved) {
+    currDoc.close(SaveOptions.NO);
+    resetCurrDoc();
+    currentDoc();
+  }
+
+  return currDoc;
+};
 
 /**
  * Use this to set the dimensions of the canvas. Choose between b.PAGE (default), b.MARGIN, b.BLEED resp. b.FACING_PAGES, b.FACING_MARGINS and b.FACING_BLEEDS for book setups with facing page. Please note: Setups with more than two facing pages are not yet supported.

--- a/basil.js
+++ b/basil.js
@@ -1588,6 +1588,7 @@ pub.revert = function() {
   } else if(!currDoc.saved) {
     currDoc.close(SaveOptions.NO);
     resetCurrDoc();
+    app.documents.add();
     currentDoc();
   }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,8 @@ basil.js x.x.x DAY MONTH YEAR
   see examples/typography/styles.jsx
 + Added b.swatch()
   returns a color or gradient of a given name
++ Added b.revert()
+  reverts the document to a fresh state
 
 * b.paragraphStyle(), b.characterStyle() and b.objectStyle() are expanded:
   They can now get an applied style from a text object/page item and can

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -202,7 +202,7 @@ var welcome = function() {
 };
 
 var currentDoc = function (mode) {
-  if (!currDoc) {
+  if (currDoc === null || !currDoc) {
     var stack = $.stack;
     if (!(stack.match(/go\(.*\)/) || stack.match(/loop\(.*\)/))) {
       warning("Do not initialize Variables with dependency to b outside the setup() or the draw() function. If you do so, basil will not be able to run in performance optimized Modes! If you really need them globally we recommend to only declare them gobally but initialize them in setup()! Current Stack is " + stack);
@@ -317,24 +317,25 @@ var resetCurrDoc = function() {
 };
 
 var currentLayer = function() {
-  if (!currLayer) {
+  if (currLayer === null || !currLayer) {
     currentDoc();
-    if (currDoc.windows.length)
+    if (currDoc.windows.length) {
       currLayer = app.activeDocument.activeLayer;
-    else
+    } else {
       currLayer = currDoc.layers[0];
-
+    }
   }
   return currLayer;
 };
 
 var currentPage = function() {
-  if (!currPage) {
+  if (currPage === null || !currPage) {
     currentDoc();
-    if (currDoc.windows.length)
+    if (currDoc.windows.length) {
       currPage = app.activeWindow.activePage;
-    else
-        currPage = currDoc.pages[0];
+    } else {
+      currPage = currDoc.pages[0];
+    }
   }
   return currPage;
 };

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -84,6 +84,28 @@ pub.close = function(saveOptions, file) {
   }
 };
 
+/**
+ * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
+ *
+ * @cat Document
+ * @method revert
+ * @return {Document} The reverted document.
+ */
+pub.revert = function() {
+
+  if(currDoc.saved && currDoc.modified) {
+    var currFile = currDoc.fullName;
+    currDoc.close(SaveOptions.NO);
+    app.open(File(currFile));
+    resetCurrDoc();
+  } else if(!currDoc.saved) {
+    currDoc.close(SaveOptions.NO);
+    resetCurrDoc();
+    currentDoc();
+  }
+
+  return currDoc;
+};
 
 /**
  * Use this to set the dimensions of the canvas. Choose between b.PAGE (default), b.MARGIN, b.BLEED resp. b.FACING_PAGES, b.FACING_MARGINS and b.FACING_BLEEDS for book setups with facing page. Please note: Setups with more than two facing pages are not yet supported.

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -101,6 +101,7 @@ pub.revert = function() {
   } else if(!currDoc.saved) {
     currDoc.close(SaveOptions.NO);
     resetCurrDoc();
+    app.documents.add();
     currentDoc();
   }
 

--- a/src/includes/structure.js
+++ b/src/includes/structure.js
@@ -251,29 +251,6 @@ pub.clear = function(container) {
 };
 
 /**
- * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
- *
- * @cat Document
- * @method revert
- * @return {Document} The reverted document.
- */
-pub.revert = function() {
-
-  if(currDoc.saved && currDoc.modified) {
-    var currFile = currDoc.fullName;
-    currDoc.close(SaveOptions.NO);
-    app.open(File(currFile));
-    resetCurrDoc();
-  } else if(!currDoc.saved) {
-    currDoc.close(SaveOptions.NO);
-    resetCurrDoc();
-    currentDoc();
-  }
-
-  return currDoc;
-};
-
-/**
  * @description Removes the provided Page, Layer, PageItem, Swatch, etc.
  *
  * @cat Document

--- a/src/includes/structure.js
+++ b/src/includes/structure.js
@@ -251,6 +251,29 @@ pub.clear = function(container) {
 };
 
 /**
+ * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
+ *
+ * @cat Document
+ * @method revert
+ * @return {Document} The reverted document.
+ */
+pub.revert = function() {
+
+  if(currDoc.saved && currDoc.modified) {
+    var currFile = currDoc.fullName;
+    currDoc.close(SaveOptions.NO);
+    app.open(File(currFile));
+    resetCurrDoc();
+  } else if(!currDoc.saved) {
+    currDoc.close(SaveOptions.NO);
+    resetCurrDoc();
+    currentDoc();
+  }
+
+  return currDoc;
+};
+
+/**
  * @description Removes the provided Page, Layer, PageItem, Swatch, etc.
  *
  * @cat Document

--- a/test/environment-tests.jsx
+++ b/test/environment-tests.jsx
@@ -313,6 +313,39 @@ b.test("EnvironmentTests", {
     });
     assert(counter === 1);
 
+  },
+
+  testRevertSavedDoc: function (b) {
+
+     var doc = app.documents.add();
+     var docCount = app.documents.length;
+
+     var testFile = File("~/Desktop/basil_testingRevert_temp.indd");
+     doc.save(testFile);
+
+     b.ellipse(20, 20, 20, 20);
+     b.revert();
+
+     assert(app.documents.length === docCount);
+     assert(app.activeDocument.name === "basil_testingRevert_temp.indd");
+     assert(app.activeDocument.modified === false);
+     assert(app.activeDocument.pageItems.length === 0);
+
+     // removing the temp document
+     testFile.remove();
+  },
+
+  testRevertUnsavedDoc: function (b) {
+
+     var doc = app.documents.add();
+     var docCount = app.documents.length;
+
+     b.ellipse(20, 20, 20, 20);
+     b.revert();
+
+     assert(app.documents.length === docCount);
+     assert(b.doc().pageItems.length === 0);
+
   }
 
 });


### PR DESCRIPTION
This adds `b.revert()` as proposed and discussed in #133.

As a reminder: This is useful during the development stage of a script, if you don't want to reset a document manually each time before you run the script (`b.clear(b.doc())` would not work in many cases, as it does not clear new layers and colors etc.)

So while developing your script, it would simply look like this:

```js
// @includepath "~/Documents/;%USERPROFILE%Documents";
// @include "basiljs/basil.js";

function draw() {

  b.revert();
  
  // all code that you are developing here

}

b.go();
```
And this would work both for saved and unsaved documents.

I did some testing and figured out that it is actually much quicker to close the document without saving and re-opening it than use InDesign's actual `doc.revert()` method, so I went with that. Tested this both with empty documents and with larger documents.

This modifies some conditional checks as well, which I explain in #203.

Added tests for it, it passes all other tests as well.

Please review. 🔍 🐛 😎 