### PR TITLE
Shape Mode fixes

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -4076,6 +4076,11 @@ pub.rect = function(x, y, w, h) {
     rectBounds[1] = x - (w / 2);
     rectBounds[2] = (y + h) - (h / 2);
     rectBounds[3] = (x + w) - (w / 2);
+  } else if (currRectMode === pub.RADIUS) {
+    rectBounds[0] = y - h;
+    rectBounds[1] = x - w;
+    rectBounds[2] = y + h;
+    rectBounds[3] = x + w;
   }
 
   var newRect = currentPage().rectangles.add(currentLayer());
@@ -4086,7 +4091,7 @@ pub.rect = function(x, y, w, h) {
   newRect.fillTint = currFillTint;
   newRect.strokeColor = currStrokeColor;
 
-  if (currRectMode === pub.CENTER) {
+  if (currRectMode === pub.CENTER || currRectMode === pub.RADIUS) {
     newRect.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
                        AnchorPoint.CENTER_ANCHOR,
                        currMatrix.adobeMatrix());
@@ -4123,11 +4128,11 @@ pub.rect = function(x, y, w, h) {
  */
 pub.rectMode = function (mode) {
   if (arguments.length === 0) return currRectMode;
-  if (mode === pub.CORNER || mode === pub.CORNERS || mode === pub.CENTER) {
+  if (mode === pub.CORNER || mode === pub.CORNERS || mode === pub.CENTER || mode === pub.RADIUS) {
     currRectMode = mode;
     return currRectMode;
   } else {
-    error("b.rectMode(), unsupported rectMode. Use: CORNER, CORNERS, CENTER.");
+    error("b.rectMode(), unsupported rectMode. Use: CORNER, CORNERS, CENTER, RADIUS.");
   }
 };
 

--- a/basil.js
+++ b/basil.js
@@ -4107,18 +4107,17 @@ pub.rect = function(x, y, w, h) {
 // -- Attributes --
 
 /**
- * Modifies the location from which rectangles draw. The default mode is
- * rectMode(CORNER), which specifies the location to be the upper left
- * corner of the shape and uses the third and fourth parameters of rect()
- * to specify the width and height. The syntax rectMode(CORNERS) uses the
- * first and second parameters of rect() to set the location of one corner
- * and uses the third and fourth parameters to set the opposite corner.
- * The syntax rectMode(CENTER) draws the image from its center point and
- * uses the third and forth parameters of rect() to specify the image's
- * width and height. The syntax rectMode(RADIUS) draws the image from its
- * center point and uses the third and forth parameters of rect() to specify
- * half of the image's width and height. The parameter must be written in
- * "ALL CAPS".
+ * Modifies the location from which rectangles or text frames draw. The default
+ * mode is b.rectMode(b.CORNER), which specifies the location to be the upper left
+ * corner of the shape and uses the <code>w</code> and <code>h</code> parameters to specify the
+ * width and height. The syntax b.rectMode(b.CORNERS) uses the <code>x</code> and <code>y</code>
+ * parameters of b.rect() or b.text() to set the location of one corner
+ * and uses the <code>w</code> and <code>h</code> parameters to set the opposite corner.
+ * The syntax b.rectMode(b.CENTER) draws the shape from its center point and
+ * uses the <code>w</code> and <code>h</code> parameters to specify the shape's
+ * width and height. The syntax b.rectMode(b.RADIUS) draws the shape from its
+ * center point and uses the <code>w</code> and <code>h</code> parameters to specify
+ * half of the shape's width and height.
  *
  * @cat Document
  * @subcat Attributes
@@ -4132,19 +4131,19 @@ pub.rectMode = function (mode) {
     currRectMode = mode;
     return currRectMode;
   } else {
-    error("b.rectMode(), unsupported rectMode. Use: CORNER, CORNERS, CENTER, RADIUS.");
+    error("b.rectMode(), unsupported rectMode. Use: b.CORNER, b.CORNERS, b.CENTER, b.RADIUS.");
   }
 };
 
 /**
- * The origin of new ellipses is modified by the ellipseMode() function.
- * The default configuration is ellipseMode(CENTER), which specifies the
- * location of the ellipse as the center of the shape. The RADIUS mode is
- * the same, but the width and height parameters to ellipse() specify the
- * radius of the ellipse, rather than the diameter. The CORNER mode draws
- * the shape from the upper-left corner of its bounding box. The CORNERS
- * mode uses the four parameters to ellipse() to set two opposing corners
- * of the ellipse's bounding box. The parameter must be written in "ALL CAPS".
+ * The origin of new ellipses is modified by the b.ellipseMode() function.
+ * The default configuration is b.ellipseMode(b.CENTER), which specifies the
+ * location of the ellipse as the center of the shape. The b.RADIUS mode is
+ * the same, but the <code>w</code> and <code>h</code> parameters to b.ellipse() specify the
+ * radius of the ellipse, rather than the diameter. The b.CORNER mode draws
+ * the shape from the upper-left corner of its bounding box. The b.CORNERS
+ * mode uses the four parameters to b.ellipse() to set two opposing corners
+ * of the ellipse's bounding box.
  *
  * @cat Document
  * @subcat Attributes
@@ -4157,7 +4156,7 @@ pub.ellipseMode = function (mode) {
     currEllipseMode = mode;
     return currEllipseMode;
   } else {
-    error("b.ellipseMode(), Unsupported ellipseMode. Use: CENTER, RADIUS, CORNER, CORNERS.");
+    error("b.ellipseMode(), unsupported ellipseMode. Use: b.CENTER, b.RADIUS, b.CORNER, b.CORNERS.");
   }
 };
 

--- a/basil.js
+++ b/basil.js
@@ -3703,8 +3703,8 @@ pub.ellipse = function(x, y, w, h) {
   if (currEllipseMode === pub.CORNER) {
     ellipseBounds[0] = y;
     ellipseBounds[1] = x;
-    ellipseBounds[2] = (y + h);
-    ellipseBounds[3] = (x + w);
+    ellipseBounds[2] = y + h;
+    ellipseBounds[3] = x + w;
   } else if (currEllipseMode === pub.CORNERS) {
     ellipseBounds[0] = y;
     ellipseBounds[1] = x;
@@ -3713,13 +3713,13 @@ pub.ellipse = function(x, y, w, h) {
   } else if (currEllipseMode === pub.CENTER) {
     ellipseBounds[0] = y - (h / 2);
     ellipseBounds[1] = x - (w / 2);
-    ellipseBounds[2] = (y + h) - (h / 2);
-    ellipseBounds[3] = (x + w) - (w / 2);
+    ellipseBounds[2] = y + (h / 2);
+    ellipseBounds[3] = x + (w / 2);
   } else if (currEllipseMode === pub.RADIUS) {
-    ellipseBounds[0] = y - (h);
-    ellipseBounds[1] = x - (w);
-    ellipseBounds[2] = y + (h);
-    ellipseBounds[3] = x + (w);
+    ellipseBounds[0] = y - h;
+    ellipseBounds[1] = x - w;
+    ellipseBounds[2] = y + h;
+    ellipseBounds[3] = x + w;
   }
 
   if(w === 0 || h === 0)
@@ -4064,8 +4064,8 @@ pub.rect = function(x, y, w, h) {
   if (currRectMode === pub.CORNER) {
     rectBounds[0] = y;
     rectBounds[1] = x;
-    rectBounds[2] = (y + h);
-    rectBounds[3] = (x + w);
+    rectBounds[2] = y + h;
+    rectBounds[3] = x + w;
   } else if (currRectMode === pub.CORNERS) {
     rectBounds[0] = y;
     rectBounds[1] = x;
@@ -4074,8 +4074,8 @@ pub.rect = function(x, y, w, h) {
   } else if (currRectMode === pub.CENTER) {
     rectBounds[0] = y - (h / 2);
     rectBounds[1] = x - (w / 2);
-    rectBounds[2] = (y + h) - (h / 2);
-    rectBounds[3] = (x + w) - (w / 2);
+    rectBounds[2] = y + (h / 2);
+    rectBounds[3] = x + (w / 2);
   } else if (currRectMode === pub.RADIUS) {
     rectBounds[0] = y - h;
     rectBounds[1] = x - w;

--- a/basil.js
+++ b/basil.js
@@ -4870,9 +4870,33 @@ pub.text = function(txt, x, y, w, h) {
   if (!(isString(txt) || isNumber(txt))) {
     warning("b.text(), the first parameter has to be a string! But is something else: " + typeof txt + ". Use: b.text(txt, x, y, w, h)");
   }
+
+  var textBounds = [];
+  if (currRectMode === pub.CORNER) {
+    textBounds[0] = y;
+    textBounds[1] = x;
+    textBounds[2] = y + h;
+    textBounds[3] = x + w;
+  } else if (currRectMode === pub.CORNERS) {
+    textBounds[0] = y;
+    textBounds[1] = x;
+    textBounds[2] = h;
+    textBounds[3] = w;
+  } else if (currRectMode === pub.CENTER) {
+    textBounds[0] = y - (h / 2);
+    textBounds[1] = x - (w / 2);
+    textBounds[2] = y + (h / 2);
+    textBounds[3] = x + (w / 2);
+  } else if (currRectMode === pub.RADIUS) {
+    textBounds[0] = y - h;
+    textBounds[1] = x - w;
+    textBounds[2] = y + h;
+    textBounds[3] = x + w;
+  }
+
   var textFrame = currentPage().textFrames.add(currentLayer());
   textFrame.contents = txt.toString();
-  textFrame.geometricBounds = [y, x, (y + h), (x + w)];
+  textFrame.geometricBounds = textBounds;
   textFrame.textFramePreferences.verticalJustification = currYAlign;
 
   pub.typo(textFrame, {
@@ -4886,7 +4910,7 @@ pub.text = function(txt, x, y, w, h) {
   });
 
 
-  if (currAlign === Justification.CENTER_ALIGN || currAlign === Justification.CENTER_JUSTIFIED) {
+  if (currRectMode === pub.CENTER || currRectMode === pub.RADIUS) {
     textFrame.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
                        AnchorPoint.CENTER_ANCHOR,
                        currMatrix.adobeMatrix());

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,8 @@ basil.js x.x.x DAY MONTH YEAR
   Options to show or hide properties, values and/or methods.
   Option to show only certain properties.
   Lots of minor fixes.
+* b.text() now respects the currently set rectangle mode
+* b.rectMode() now works with b.RADIUS
 * Improved the speed of b.clear() considerably
 * b.textFont() does no longer stop the script if a font is missing, but gives a console warning instead
 * b.isText() now correctly identifies collections of multiple text objects as text

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -393,6 +393,11 @@ pub.rect = function(x, y, w, h) {
     rectBounds[1] = x - (w / 2);
     rectBounds[2] = (y + h) - (h / 2);
     rectBounds[3] = (x + w) - (w / 2);
+  } else if (currRectMode === pub.RADIUS) {
+    rectBounds[0] = y - h;
+    rectBounds[1] = x - w;
+    rectBounds[2] = y + h;
+    rectBounds[3] = x + w;
   }
 
   var newRect = currentPage().rectangles.add(currentLayer());
@@ -403,7 +408,7 @@ pub.rect = function(x, y, w, h) {
   newRect.fillTint = currFillTint;
   newRect.strokeColor = currStrokeColor;
 
-  if (currRectMode === pub.CENTER) {
+  if (currRectMode === pub.CENTER || currRectMode === pub.RADIUS) {
     newRect.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
                        AnchorPoint.CENTER_ANCHOR,
                        currMatrix.adobeMatrix());
@@ -440,11 +445,11 @@ pub.rect = function(x, y, w, h) {
  */
 pub.rectMode = function (mode) {
   if (arguments.length === 0) return currRectMode;
-  if (mode === pub.CORNER || mode === pub.CORNERS || mode === pub.CENTER) {
+  if (mode === pub.CORNER || mode === pub.CORNERS || mode === pub.CENTER || mode === pub.RADIUS) {
     currRectMode = mode;
     return currRectMode;
   } else {
-    error("b.rectMode(), unsupported rectMode. Use: CORNER, CORNERS, CENTER.");
+    error("b.rectMode(), unsupported rectMode. Use: CORNER, CORNERS, CENTER, RADIUS.");
   }
 };
 

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -20,8 +20,8 @@ pub.ellipse = function(x, y, w, h) {
   if (currEllipseMode === pub.CORNER) {
     ellipseBounds[0] = y;
     ellipseBounds[1] = x;
-    ellipseBounds[2] = (y + h);
-    ellipseBounds[3] = (x + w);
+    ellipseBounds[2] = y + h;
+    ellipseBounds[3] = x + w;
   } else if (currEllipseMode === pub.CORNERS) {
     ellipseBounds[0] = y;
     ellipseBounds[1] = x;
@@ -30,13 +30,13 @@ pub.ellipse = function(x, y, w, h) {
   } else if (currEllipseMode === pub.CENTER) {
     ellipseBounds[0] = y - (h / 2);
     ellipseBounds[1] = x - (w / 2);
-    ellipseBounds[2] = (y + h) - (h / 2);
-    ellipseBounds[3] = (x + w) - (w / 2);
+    ellipseBounds[2] = y + (h / 2);
+    ellipseBounds[3] = x + (w / 2);
   } else if (currEllipseMode === pub.RADIUS) {
-    ellipseBounds[0] = y - (h);
-    ellipseBounds[1] = x - (w);
-    ellipseBounds[2] = y + (h);
-    ellipseBounds[3] = x + (w);
+    ellipseBounds[0] = y - h;
+    ellipseBounds[1] = x - w;
+    ellipseBounds[2] = y + h;
+    ellipseBounds[3] = x + w;
   }
 
   if(w === 0 || h === 0)
@@ -381,8 +381,8 @@ pub.rect = function(x, y, w, h) {
   if (currRectMode === pub.CORNER) {
     rectBounds[0] = y;
     rectBounds[1] = x;
-    rectBounds[2] = (y + h);
-    rectBounds[3] = (x + w);
+    rectBounds[2] = y + h;
+    rectBounds[3] = x + w;
   } else if (currRectMode === pub.CORNERS) {
     rectBounds[0] = y;
     rectBounds[1] = x;
@@ -391,8 +391,8 @@ pub.rect = function(x, y, w, h) {
   } else if (currRectMode === pub.CENTER) {
     rectBounds[0] = y - (h / 2);
     rectBounds[1] = x - (w / 2);
-    rectBounds[2] = (y + h) - (h / 2);
-    rectBounds[3] = (x + w) - (w / 2);
+    rectBounds[2] = y + (h / 2);
+    rectBounds[3] = x + (w / 2);
   } else if (currRectMode === pub.RADIUS) {
     rectBounds[0] = y - h;
     rectBounds[1] = x - w;

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -424,18 +424,17 @@ pub.rect = function(x, y, w, h) {
 // -- Attributes --
 
 /**
- * Modifies the location from which rectangles draw. The default mode is
- * rectMode(CORNER), which specifies the location to be the upper left
- * corner of the shape and uses the third and fourth parameters of rect()
- * to specify the width and height. The syntax rectMode(CORNERS) uses the
- * first and second parameters of rect() to set the location of one corner
- * and uses the third and fourth parameters to set the opposite corner.
- * The syntax rectMode(CENTER) draws the image from its center point and
- * uses the third and forth parameters of rect() to specify the image's
- * width and height. The syntax rectMode(RADIUS) draws the image from its
- * center point and uses the third and forth parameters of rect() to specify
- * half of the image's width and height. The parameter must be written in
- * "ALL CAPS".
+ * Modifies the location from which rectangles or text frames draw. The default
+ * mode is b.rectMode(b.CORNER), which specifies the location to be the upper left
+ * corner of the shape and uses the <code>w</code> and <code>h</code> parameters to specify the
+ * width and height. The syntax b.rectMode(b.CORNERS) uses the <code>x</code> and <code>y</code>
+ * parameters of b.rect() or b.text() to set the location of one corner
+ * and uses the <code>w</code> and <code>h</code> parameters to set the opposite corner.
+ * The syntax b.rectMode(b.CENTER) draws the shape from its center point and
+ * uses the <code>w</code> and <code>h</code> parameters to specify the shape's
+ * width and height. The syntax b.rectMode(b.RADIUS) draws the shape from its
+ * center point and uses the <code>w</code> and <code>h</code> parameters to specify
+ * half of the shape's width and height.
  *
  * @cat Document
  * @subcat Attributes
@@ -449,19 +448,19 @@ pub.rectMode = function (mode) {
     currRectMode = mode;
     return currRectMode;
   } else {
-    error("b.rectMode(), unsupported rectMode. Use: CORNER, CORNERS, CENTER, RADIUS.");
+    error("b.rectMode(), unsupported rectMode. Use: b.CORNER, b.CORNERS, b.CENTER, b.RADIUS.");
   }
 };
 
 /**
- * The origin of new ellipses is modified by the ellipseMode() function.
- * The default configuration is ellipseMode(CENTER), which specifies the
- * location of the ellipse as the center of the shape. The RADIUS mode is
- * the same, but the width and height parameters to ellipse() specify the
- * radius of the ellipse, rather than the diameter. The CORNER mode draws
- * the shape from the upper-left corner of its bounding box. The CORNERS
- * mode uses the four parameters to ellipse() to set two opposing corners
- * of the ellipse's bounding box. The parameter must be written in "ALL CAPS".
+ * The origin of new ellipses is modified by the b.ellipseMode() function.
+ * The default configuration is b.ellipseMode(b.CENTER), which specifies the
+ * location of the ellipse as the center of the shape. The b.RADIUS mode is
+ * the same, but the <code>w</code> and <code>h</code> parameters to b.ellipse() specify the
+ * radius of the ellipse, rather than the diameter. The b.CORNER mode draws
+ * the shape from the upper-left corner of its bounding box. The b.CORNERS
+ * mode uses the four parameters to b.ellipse() to set two opposing corners
+ * of the ellipse's bounding box.
  *
  * @cat Document
  * @subcat Attributes
@@ -474,7 +473,7 @@ pub.ellipseMode = function (mode) {
     currEllipseMode = mode;
     return currEllipseMode;
   } else {
-    error("b.ellipseMode(), Unsupported ellipseMode. Use: CENTER, RADIUS, CORNER, CORNERS.");
+    error("b.ellipseMode(), unsupported ellipseMode. Use: b.CENTER, b.RADIUS, b.CORNER, b.CORNERS.");
   }
 };
 

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -26,9 +26,33 @@ pub.text = function(txt, x, y, w, h) {
   if (!(isString(txt) || isNumber(txt))) {
     warning("b.text(), the first parameter has to be a string! But is something else: " + typeof txt + ". Use: b.text(txt, x, y, w, h)");
   }
+
+  var textBounds = [];
+  if (currRectMode === pub.CORNER) {
+    textBounds[0] = y;
+    textBounds[1] = x;
+    textBounds[2] = y + h;
+    textBounds[3] = x + w;
+  } else if (currRectMode === pub.CORNERS) {
+    textBounds[0] = y;
+    textBounds[1] = x;
+    textBounds[2] = h;
+    textBounds[3] = w;
+  } else if (currRectMode === pub.CENTER) {
+    textBounds[0] = y - (h / 2);
+    textBounds[1] = x - (w / 2);
+    textBounds[2] = y + (h / 2);
+    textBounds[3] = x + (w / 2);
+  } else if (currRectMode === pub.RADIUS) {
+    textBounds[0] = y - h;
+    textBounds[1] = x - w;
+    textBounds[2] = y + h;
+    textBounds[3] = x + w;
+  }
+
   var textFrame = currentPage().textFrames.add(currentLayer());
   textFrame.contents = txt.toString();
-  textFrame.geometricBounds = [y, x, (y + h), (x + w)];
+  textFrame.geometricBounds = textBounds;
   textFrame.textFramePreferences.verticalJustification = currYAlign;
 
   pub.typo(textFrame, {
@@ -42,7 +66,7 @@ pub.text = function(txt, x, y, w, h) {
   });
 
 
-  if (currAlign === Justification.CENTER_ALIGN || currAlign === Justification.CENTER_JUSTIFIED) {
+  if (currRectMode === pub.CENTER || currRectMode === pub.RADIUS) {
     textFrame.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
                        AnchorPoint.CENTER_ANCHOR,
                        currMatrix.adobeMatrix());


### PR DESCRIPTION
This PR fixes the following:

- Adds the `b.RADIUS` option for `b.rectMode()` (for some reason this was missing, although it was mentioned in the docs?).
- Makes `b.rectMode()` work for text frames as well (as we agreed on [here](https://github.com/basiljs/basil.js/issues/145)). This makes working with both text frames and rectangles much more intuitive, as they are drawn in the same way.
- Updates, improves and fixes docs for `b.rectMode()`, `b.ellipseMode()`, `b.text()`.

Please review! 🔍 🐛 