### PR TITLE
Fixing b.group() and b.ungroup()

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1964,32 +1964,36 @@ pub.layer = function(layer) {
 
 
 /**
- *  Returns the Group instance and sets it if argument Group is given.
+ *  Groups items to a new group. Returns the resulting group instance. If a string is given as the only
+ *  argument, the group by the given name will be returned.
  *
  *  @cat Document
  *  @subCat Page
- *  @method Group
- *  @param {Array} [pItem] The PageItems array (must be at least 2) or name of Group name instance.
- *  @param {String} name The name of the Group, only when creating a Group from Page Item(s).
- *  @return {Group} The current Group instance.
+ *  @method group
+ *  @param {Array} pItems An array of page items (must contain at least two items) or name of group instance.
+ *  @param {String} [name] The name of the group, only when creating a group from page items.
+ *  @return {Group} The group instance.
  */
-pub.group = function (pItem, name) {
-  checkNull(pItem);
-  var group = null;
-  if(pItem instanceof Array) {
-    if(pItem.length < 2) {
-      error("There must be at least two PageItems passed to b.group().");
+pub.group = function (pItems, name) {
+  checkNull(pItems);
+  var group;
+  if(pItems instanceof Array) {
+    if(pItems.length < 2) {
+      error("b.group(), the array passed to b.group() must at least contain two page items.");
     }
     // creates a group from Page Items
-    group = currentDoc().groups.add(pItem);
+    group = currentDoc().groups.add(pItems);
     if(typeof name !== "undefined") {
       group.name = name;
     }
-  } else if(typeof pItem === "string") {
+  } else if(typeof pItems === "string") {
     // get the Group of the given name
-    group = currentDoc().groups.item(pItem);
+    group = currentDoc().groups.item(pItems);
+    if (!group.isValid) {
+      error("b.group(), a group with the provided name doesn't exist.");
+    }
   } else {
-    error("b.group(), not a valid argument.");
+    error("b.group(), not a valid argument. Use an array of page items to group or a name of an existing group.");
   }
 
   return group;
@@ -1997,28 +2001,31 @@ pub.group = function (pItem, name) {
 
 
 /**
- *  Returns an array of the items that were within the Group before b.ungroup() was called
+ *  Ungroups an existing group. Returns an array of the items that were within the group before
+ *  b.ungroup() was called.
  *
  *  @cat Document
  *  @subCat Page
- *  @method Group
- *  @param {Object|String} [pItem] The Group or name of Group name instance.
- *  @param {String} name The name of the Group, only when creating a Group from Page Item(s).
- *  @return {Group} The Page Item(s) that were grouped.
+ *  @method group
+ *  @param {Group|String} group The group instance or name of the group to ungroup.
+ *  @return {Array} An array of the ungrouped page items.
  */
-pub.ungroup = function(pItem) {
-  checkNull(pItem);
+pub.ungroup = function(group) {
+  checkNull(group);
   var ungroupedItems = null;
-  if(pItem instanceof Group) {
-    ungroupedItems = b.items(pItem);
-    pItem.ungroup();
-  } else if(typeof pItem === "string") {
+  if(group instanceof Group) {
+    ungroupedItems = b.items(group);
+    group.ungroup();
+  } else if(typeof group === "string") {
     // get the Group of the given name
-    var group = currentDoc().groups.item(pItem);
+    group = currentDoc().groups.item(group);
+    if (!group.isValid) {
+      error("b.ungroup(), a group with the provided name doesn't exist.");
+    }
     ungroupedItems = b.items(group);
     group.ungroup();
   } else {
-    error("b.ungroup(), not a valid Group. Please select a valid Group.");
+    error("b.ungroup(), not a valid group. Please select a valid group.");
   }
   return ungroupedItems;
 };

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -461,32 +461,36 @@ pub.layer = function(layer) {
 
 
 /**
- *  Returns the Group instance and sets it if argument Group is given.
+ *  Groups items to a new group. Returns the resulting group instance. If a string is given as the only
+ *  argument, the group by the given name will be returned.
  *
  *  @cat Document
  *  @subCat Page
- *  @method Group
- *  @param {Array} [pItem] The PageItems array (must be at least 2) or name of Group name instance.
- *  @param {String} name The name of the Group, only when creating a Group from Page Item(s).
- *  @return {Group} The current Group instance.
+ *  @method group
+ *  @param {Array} pItems An array of page items (must contain at least two items) or name of group instance.
+ *  @param {String} [name] The name of the group, only when creating a group from page items.
+ *  @return {Group} The group instance.
  */
-pub.group = function (pItem, name) {
-  checkNull(pItem);
-  var group = null;
-  if(pItem instanceof Array) {
-    if(pItem.length < 2) {
-      error("There must be at least two PageItems passed to b.group().");
+pub.group = function (pItems, name) {
+  checkNull(pItems);
+  var group;
+  if(pItems instanceof Array) {
+    if(pItems.length < 2) {
+      error("b.group(), the array passed to b.group() must at least contain two page items.");
     }
     // creates a group from Page Items
-    group = currentDoc().groups.add(pItem);
+    group = currentDoc().groups.add(pItems);
     if(typeof name !== "undefined") {
       group.name = name;
     }
-  } else if(typeof pItem === "string") {
+  } else if(typeof pItems === "string") {
     // get the Group of the given name
-    group = currentDoc().groups.item(pItem);
+    group = currentDoc().groups.item(pItems);
+    if (!group.isValid) {
+      error("b.group(), a group with the provided name doesn't exist.");
+    }
   } else {
-    error("b.group(), not a valid argument.");
+    error("b.group(), not a valid argument. Use an array of page items to group or a name of an existing group.");
   }
 
   return group;
@@ -494,28 +498,31 @@ pub.group = function (pItem, name) {
 
 
 /**
- *  Returns an array of the items that were within the Group before b.ungroup() was called
+ *  Ungroups an existing group. Returns an array of the items that were within the group before
+ *  b.ungroup() was called.
  *
  *  @cat Document
  *  @subCat Page
- *  @method Group
- *  @param {Object|String} [pItem] The Group or name of Group name instance.
- *  @param {String} name The name of the Group, only when creating a Group from Page Item(s).
- *  @return {Group} The Page Item(s) that were grouped.
+ *  @method group
+ *  @param {Group|String} group The group instance or name of the group to ungroup.
+ *  @return {Array} An array of the ungrouped page items.
  */
-pub.ungroup = function(pItem) {
-  checkNull(pItem);
+pub.ungroup = function(group) {
+  checkNull(group);
   var ungroupedItems = null;
-  if(pItem instanceof Group) {
-    ungroupedItems = b.items(pItem);
-    pItem.ungroup();
-  } else if(typeof pItem === "string") {
+  if(group instanceof Group) {
+    ungroupedItems = b.items(group);
+    group.ungroup();
+  } else if(typeof group === "string") {
     // get the Group of the given name
-    var group = currentDoc().groups.item(pItem);
+    group = currentDoc().groups.item(group);
+    if (!group.isValid) {
+      error("b.ungroup(), a group with the provided name doesn't exist.");
+    }
     ungroupedItems = b.items(group);
     group.ungroup();
   } else {
-    error("b.ungroup(), not a valid Group. Please select a valid Group.");
+    error("b.ungroup(), not a valid group. Please select a valid group.");
   }
   return ungroupedItems;
 };


### PR DESCRIPTION
I just came across these two functions and the docs were seriously messed up/mixed together (In the auto generation of docs (two `b.group()` methods were created due to a wrong `@method` parameter and lots of other stuff).

So, here are the improvements:

- Fixed and improved the docs
- Made error messages more understandable
- Added additional error checking if strings of non-existing groups are given
- Cleaned up the methods

This does not really change anything in functionality (except the doc generation), so a quick review should do.