### PR TITLE
Improved error handling for b.startsWith() and b.endsWith()

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -3285,6 +3285,9 @@ var isURL = pub.isURL = function(url) {
  * @return {Boolean} Returns either true or false
  */
 var endsWith = pub.endsWith = function(str, suffix) {
+  if(!isString(str) || !isString(suffix)) {
+    error("b.endsWith() requires two strings, the string to be checked and the suffix to look for.");
+  }
   return str.indexOf(suffix, str.length - suffix.length) !== -1;
 };
 
@@ -3299,6 +3302,9 @@ var endsWith = pub.endsWith = function(str, suffix) {
  * @return {Boolean} Returns either true or false
  */
 var startsWith = pub.startsWith = function(str, prefix) {
+  if(!isString(str) || !isString(prefix)) {
+    error("b.startsWith() requires two strings, the string to be checked and the prefix to look for.");
+  }
   return str.indexOf(prefix) === 0;
 };
 

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -633,6 +633,9 @@ var isURL = pub.isURL = function(url) {
  * @return {Boolean} Returns either true or false
  */
 var endsWith = pub.endsWith = function(str, suffix) {
+  if(!isString(str) || !isString(suffix)) {
+    error("b.endsWith() requires two strings, the string to be checked and the suffix to look for.");
+  }
   return str.indexOf(suffix, str.length - suffix.length) !== -1;
 };
 
@@ -647,6 +650,9 @@ var endsWith = pub.endsWith = function(str, suffix) {
  * @return {Boolean} Returns either true or false
  */
 var startsWith = pub.startsWith = function(str, prefix) {
+  if(!isString(str) || !isString(prefix)) {
+    error("b.startsWith() requires two strings, the string to be checked and the prefix to look for.");
+  }
   return str.indexOf(prefix) === 0;
 };
 


### PR DESCRIPTION
A quick fix to add some parameter checks for `b.startsWith()` and `b.endsWith()` as described in #213. Quick review anyone.? :)