### PR TITLE
b.rect() with rounded corners

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -4184,14 +4184,14 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
   }
 
   if(arguments.length > 4) {
+    for(var i = 4; i < arguments.length;i++){
+      if(arguments[i] < 0 ){
+        error("b.rect(), needs positive values as arguments for the rounded corners.");
+        return;
+      }
+    }
     newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;
     if(arguments.length === 8) {
-      for(var i = 4; i < arguments.length;i++){
-        if(arguments[i] < 0 ){
-          error("b.rect(), needs positive values as arguments for the rounded corners.");
-          return;
-        }
-      }
       newRect.topLeftCornerRadius = tl;
       newRect.topRightCornerRadius = tr;
       newRect.bottomRightCornerRadius = br;

--- a/basil.js
+++ b/basil.js
@@ -4186,6 +4186,12 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
   if(arguments.length > 4) {
     newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;
     if(arguments.length === 8) {
+      for(var i = 4; i < arguments.length;i++){
+        if(arguments[i] < 0 ){
+          error("b.rect(), needs positive values as arguments for the rounded corners.");
+          return;
+        }
+      }
       newRect.topLeftCornerRadius = tl;
       newRect.topRightCornerRadius = tr;
       newRect.bottomRightCornerRadius = br;

--- a/basil.js
+++ b/basil.js
@@ -4187,7 +4187,6 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
     for(var i = 4; i < arguments.length;i++){
       if(arguments[i] < 0 ){
         error("b.rect(), needs positive values as arguments for the rounded corners.");
-        // return;
       }
     }
     newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;

--- a/basil.js
+++ b/basil.js
@@ -4128,12 +4128,12 @@ function notCalledBeginShapeError () {
  * @param  {Number} h Height of the rectangle.
  * @return {Rectangle} The rectangle that was created.
  */
-pub.rect = function(x, y, w, h) {
+pub.rect = function(x, y, w, h, tl, tr, br, bl) {
   if (w === 0 || h === 0) {
     // indesign doesn't draw a rectangle if width or height are set to 0
     return false;
   }
-  if (arguments.length !== 4) error("b.rect(), not enough parameters to draw a rect! Use: x, y, w, h");
+  if (arguments.length < 4) error("b.rect(), not enough parameters to draw a rect! Use: x, y, w, h");
 
   var rectBounds = [];
   if (currRectMode === pub.CORNER) {
@@ -4169,6 +4169,18 @@ pub.rect = function(x, y, w, h) {
     newRect.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
                    AnchorPoint.TOP_LEFT_ANCHOR,
                    currMatrix.adobeMatrix());
+  }
+
+  if(arguments.length > 4) {
+    newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;
+    if(arguments.length === 8) {
+      newRect.topLeftCornerRadius = tl;
+      newRect.topRightCornerRadius = tr;
+      newRect.bottomRightCornerRadius = br;
+      newRect.bottomLeftCornerRadius = bl;
+    } else {
+      newRect.topLeftCornerRadius = newRect.topRightCornerRadius = newRect.bottomRightCornerRadius = newRect.bottomLeftCornerRadius = tl;
+    }
   }
   return newRect;
 };

--- a/basil.js
+++ b/basil.js
@@ -4187,7 +4187,7 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
     for(var i = 4; i < arguments.length;i++){
       if(arguments[i] < 0 ){
         error("b.rect(), needs positive values as arguments for the rounded corners.");
-        return;
+        // return;
       }
     }
     newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;

--- a/basil.js
+++ b/basil.js
@@ -4118,6 +4118,8 @@ function notCalledBeginShapeError () {
 
 /**
  * Draws a rectangle on the page.
+ * By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, however, may be changed with the b.rectMode() function.
+ * The fifth, sixth, seventh and eighth parameters, if specified, determine corner radius for the top-right, top-left, lower-right and lower-left corners, respectively. If only a fifth parameter is provided, all corners will be set to this radius.
  *
  * @cat Document
  * @subcat Primitives
@@ -4126,6 +4128,10 @@ function notCalledBeginShapeError () {
  * @param  {Number} y Y-coordinate of the rectangle.
  * @param  {Number} w Width of the rectangle.
  * @param  {Number} h Height of the rectangle.
+ * @param  {Number} [tl] Radius of top left corner or radius of all 4 corners (optional).
+ * @param  {Number} [tr] Radius of top right corner (optional).
+ * @param  {Number} [br] Radius of bottom right corner (optional).
+ * @param  {Number} [bl] Radius of bottom left corner (optional).
  * @return {Rectangle} The rectangle that was created.
  */
 pub.rect = function(x, y, w, h, tl, tr, br, bl) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ basil.js x.x.x DAY MONTH YEAR
 + Added b.isInteger()
   checks if a given variable is an integer
 
+* b.rect() now allows additional parameters to add rounded corners
 * b.paragraphStyle(), b.characterStyle() and b.objectStyle() are expanded:
   They can now get an applied style from a text object/page item and can
   make use of an optional object with property name/value pairs to set

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -420,14 +420,14 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
   }
 
   if(arguments.length > 4) {
+    for(var i = 4; i < arguments.length;i++){
+      if(arguments[i] < 0 ){
+        error("b.rect(), needs positive values as arguments for the rounded corners.");
+        return;
+      }
+    }
     newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;
     if(arguments.length === 8) {
-      for(var i = 4; i < arguments.length;i++){
-        if(arguments[i] < 0 ){
-          error("b.rect(), needs positive values as arguments for the rounded corners.");
-          return;
-        }
-      }
       newRect.topLeftCornerRadius = tl;
       newRect.topRightCornerRadius = tr;
       newRect.bottomRightCornerRadius = br;

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -370,12 +370,12 @@ function notCalledBeginShapeError () {
  * @param  {Number} h Height of the rectangle.
  * @return {Rectangle} The rectangle that was created.
  */
-pub.rect = function(x, y, w, h) {
+pub.rect = function(x, y, w, h, tl, tr, br, bl) {
   if (w === 0 || h === 0) {
     // indesign doesn't draw a rectangle if width or height are set to 0
     return false;
   }
-  if (arguments.length !== 4) error("b.rect(), not enough parameters to draw a rect! Use: x, y, w, h");
+  if (arguments.length < 4) error("b.rect(), not enough parameters to draw a rect! Use: x, y, w, h");
 
   var rectBounds = [];
   if (currRectMode === pub.CORNER) {
@@ -411,6 +411,18 @@ pub.rect = function(x, y, w, h) {
     newRect.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
                    AnchorPoint.TOP_LEFT_ANCHOR,
                    currMatrix.adobeMatrix());
+  }
+
+  if(arguments.length > 4) {
+    newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;
+    if(arguments.length === 8) {
+      newRect.topLeftCornerRadius = tl;
+      newRect.topRightCornerRadius = tr;
+      newRect.bottomRightCornerRadius = br;
+      newRect.bottomLeftCornerRadius = bl;
+    } else {
+      newRect.topLeftCornerRadius = newRect.topRightCornerRadius = newRect.bottomRightCornerRadius = newRect.bottomLeftCornerRadius = tl;
+    }
   }
   return newRect;
 };

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -422,6 +422,12 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
   if(arguments.length > 4) {
     newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;
     if(arguments.length === 8) {
+      for(var i = 4; i < arguments.length;i++){
+        if(arguments[i] < 0 ){
+          error("b.rect(), needs positive values as arguments for the rounded corners.");
+          return;
+        }
+      }
       newRect.topLeftCornerRadius = tl;
       newRect.topRightCornerRadius = tr;
       newRect.bottomRightCornerRadius = br;

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -423,7 +423,6 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
     for(var i = 4; i < arguments.length;i++){
       if(arguments[i] < 0 ){
         error("b.rect(), needs positive values as arguments for the rounded corners.");
-        return;
       }
     }
     newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -360,6 +360,8 @@ function notCalledBeginShapeError () {
 
 /**
  * Draws a rectangle on the page.
+ * By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, however, may be changed with the b.rectMode() function.
+ * The fifth, sixth, seventh and eighth parameters, if specified, determine corner radius for the top-right, top-left, lower-right and lower-left corners, respectively. If only a fifth parameter is provided, all corners will be set to this radius.
  *
  * @cat Document
  * @subcat Primitives
@@ -368,6 +370,10 @@ function notCalledBeginShapeError () {
  * @param  {Number} y Y-coordinate of the rectangle.
  * @param  {Number} w Width of the rectangle.
  * @param  {Number} h Height of the rectangle.
+ * @param  {Number} [tl] Radius of top left corner or radius of all 4 corners (optional).
+ * @param  {Number} [tr] Radius of top right corner (optional).
+ * @param  {Number} [br] Radius of bottom right corner (optional).
+ * @param  {Number} [bl] Radius of bottom left corner (optional).
  * @return {Rectangle} The rectangle that was created.
  */
 pub.rect = function(x, y, w, h, tl, tr, br, bl) {


### PR DESCRIPTION
This adds the option to draw your rects with rounded corners.

This
```js
  b.noFill();

  b.rect(30, 20, 80, 55);

  b.rect(30, 90, 80, 55, 20);

  b.rect(30, 160, 80, 55, 20, 15, 10, 5);
```
turns into this
![bildschirmfoto 2017-11-13 um 18 04 17](https://user-images.githubusercontent.com/9803905/32738709-12a88830-c89e-11e7-842d-1429156322dd.png)

So as Fabian summed up nicely [here](https://github.com/basiljs/basil.js/issues/214), syntax is:
```
Syntax	
b.rect(a, b, c, d)
b.rect(a, b, c, d, r)
b.rect(a, b, c, d, tl, tr, br, bl)
Parameters	
a	float: x-coordinate of the rectangle by default
b	float: y-coordinate of the rectangle by default
c	float: width of the rectangle by default
d	float: height of the rectangle by default
r	float: radii for all four corners
tl	float: radius for top-left corner
tr	float: radius for top-right corner
br	float: radius for bottom-right corner
bl	float: radius for bottom-left corner
```

Please review. 🔍 🐛 

This is another one we discussed in class last week, so if we could get this merged before my class on Wednesday, again, I could show my students the perks of open source development. 😄 
