### PR TITLE
Fixing wrong method name

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -2106,7 +2106,7 @@ pub.group = function (pItems, name) {
  *
  *  @cat Document
  *  @subCat Page
- *  @method group
+ *  @method ungroup
  *  @param {Group|String} group The group instance or name of the group to ungroup.
  *  @return {Array} An array of the ungrouped page items.
  */

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -571,7 +571,7 @@ pub.group = function (pItems, name) {
  *
  *  @cat Document
  *  @subCat Page
- *  @method group
+ *  @method ungroup
  *  @param {Group|String} group The group instance or name of the group to ungroup.
  *  @return {Array} An array of the ungrouped page items.
  */


### PR DESCRIPTION
Fixing ungroup method name in docs.