### PR TITLE
Improving trim word to trim all sorts of punctuation

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -3089,12 +3089,11 @@ pub.unhex = function(hex) {
  * @param {String} s The String to trim
  * @return {String} The trimmed string
  */
- // from: http://www.qodo.co.uk/blog/javascript-trim-leading-and-trailing-spaces/
+ // from: https://stackoverflow.com/a/25575009/3399765
 pub.trimWord = function(s) {
-  s = s.replace(/(^[,.!?-]*)|([-,.!?]*$)/gi, "");
-  s = s.replace(/\s*/gi, "");
-//    s = s.replace(/[ ]{2,}/gi," ");
-  s = s.replace(/\n*/, "");
+  s = s.replace(/\s*/g, "")
+       .replace(/\n*/g, "")
+       .replace(/(^[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]*)|([\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]*$)/gi, "");
   return s;
 };
 

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -348,12 +348,11 @@ pub.unhex = function(hex) {
  * @param {String} s The String to trim
  * @return {String} The trimmed string
  */
- // from: http://www.qodo.co.uk/blog/javascript-trim-leading-and-trailing-spaces/
+ // from: https://stackoverflow.com/a/25575009/3399765
 pub.trimWord = function(s) {
-  s = s.replace(/(^[,.!?-]*)|([-,.!?]*$)/gi, "");
-  s = s.replace(/\s*/gi, "");
-//    s = s.replace(/[ ]{2,}/gi," ");
-  s = s.replace(/\n*/, "");
+  s = s.replace(/\s*/g, "")
+       .replace(/\n*/g, "")
+       .replace(/(^[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]*)|([\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]*$)/gi, "");
   return s;
 };
 


### PR DESCRIPTION
This fixes `b.trimWord()` to actually trim all punctuation from the word's beginning and end (see #230).

RegEx might look a bit scary, but it works. Also updated the source, as not to give the impression that I know anything about RegEx. 😉

Will merge right away.