### PR TITLE
Revert "Simplified isString"

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -3453,7 +3453,7 @@ var isInteger = pub.isInteger = function(num) {
  * @return {Boolean} returns true if this is the case
  */
 var isString = pub.isString = function(str) {
-  return str.constructor.name === "String";
+  return Object.prototype.toString.call(str) === "[object String]";
 };
 
 /**

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -712,7 +712,7 @@ var isInteger = pub.isInteger = function(num) {
  * @return {Boolean} returns true if this is the case
  */
 var isString = pub.isString = function(str) {
-  return str.constructor.name === "String";
+  return Object.prototype.toString.call(str) === "[object String]";
 };
 
 /**


### PR DESCRIPTION
Reverts basiljs/basil.js#228

Reverting this change, because I did not fully think this through. 😉

(new version did not work with `null` or `undefined` as input)