### PR TITLE
b-less implementation improvements

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -844,10 +844,6 @@ var init = function() {
 
   app.doScript(runScript, ScriptLanguage.JAVASCRIPT, undefined, UndoModes.ENTIRE_SCRIPT, pub.SCRIPTNAME);
 
-  if($.global.hasOwnProperty("basilTest")) {
-    return;
-  }
-
   if(basilCancelled) {
     exit();
   }

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -27,10 +27,6 @@ var init = function() {
 
   app.doScript(runScript, ScriptLanguage.JAVASCRIPT, undefined, UndoModes.ENTIRE_SCRIPT, pub.SCRIPTNAME);
 
-  if($.global.hasOwnProperty("basilTest")) {
-    return;
-  }
-
   if(basilCancelled) {
     exit();
   }

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -31,7 +31,9 @@ var init = function() {
     return;
   }
 
-  exit(); // quit program execution
+  if(basilCancelled) {
+    exit();
+  }
 };
 
 
@@ -78,6 +80,7 @@ var runScript = function() {
 
   } catch (e) {
     execTime = executionDuration();
+    basilCancelled = true;
 
     if(e.userCancel) {
       println("[Cancelled by user after " + execTime + "]");
@@ -106,8 +109,11 @@ var runScript = function() {
     if (!($.global.loop instanceof Function) || $.global.draw instanceof Function) {
       resetUserSettings();
     }
-  }
 
+    if(!($.global.loop instanceof Function)) {
+      delete $.global.basilRunning;
+    }
+  }
 }
 
 var prepareLoop = function() {
@@ -170,6 +176,7 @@ pub.noLoop = function(printFinished) {
     println("[Finished in " + executionDuration() + "]");
   };
   resetUserSettings();
+  delete $.global.basilRunning;
 };
 
 /**

--- a/src/includes/private-vars.js
+++ b/src/includes/private-vars.js
@@ -39,4 +39,5 @@ var addToStoryCache = null, /* tmp cache, see addToStroy(), via InDesign externa
   matrixStack = null,
   noneSwatchColor = null,
   progressPanel = null,
-  startTime = null;
+  startTime = null,
+  basilCancelled = null;

--- a/src/main.js
+++ b/src/main.js
@@ -44,64 +44,70 @@
 // @target "InDesign";
 
 
-// clearing global space if it is still populated from previous run of a loop script
-// to ensure basil methods work properly
-if($.engineName === "loop" && $.global.basilGlobal) {
-  for (var i = basilGlobal.length - 1; i >= 0; i--) {
-    if($.global.hasOwnProperty(basilGlobal[i])) {
-      try{
-        delete $.global[basilGlobal[i]];
-      } catch(e) {
-        // could not delete
+if(!$.global.hasOwnProperty("basilRunning")) {
+
+  $.global.basilRunning = true;
+
+  // clearing global space if it is still populated from previous run of a loop script
+  // to ensure basil methods work properly
+  if($.global.basilGlobal) {
+    for (var i = basilGlobal.length - 1; i >= 0; i--) {
+      if($.global.hasOwnProperty(basilGlobal[i])) {
+        try{
+          delete $.global[basilGlobal[i]];
+        } catch(e) {
+          // could not delete
+        }
       }
     }
-  }
-  delete $.global.basilGlobal;
-}
-
-if(!$.global.hasOwnProperty("basilTest")) {
-  // load global vars of the user script
-  var sourceScript;
-  try {
-    app.nonExistingProperty;
-  } catch(e) {
-    sourceScript = e.source;
+    delete $.global.basilGlobal;
   }
 
-  var userScript = sourceScript.replace(/[\s\S]*[#@]\s*[i]nclude\s+.+basil\.js["']*[\s;)}]*/, "");
-  app.doScript(userScript);
+  if(!$.global.hasOwnProperty("basilTest")) {
+    // load global vars of the user script
+    var sourceScript;
+    try {
+      app.nonExistingProperty;
+    } catch(e) {
+      sourceScript = e.source;
+    }
+
+    app.doScript(sourceScript);
+  }
+
+
+  (function() {
+
+  var pub = {};
+
+
+  /**
+   * The basil version
+   * @property VERSION {String}
+   * @cat Environment
+   */
+  pub.VERSION = "1.1.0";
+
+  // @include "includes/constants.js";
+  // @include "includes/public-vars.js";
+  // @include "includes/private-vars.js";
+  // @include "includes/global-functions.js";
+
+  // @include "includes/core.js";
+
+  // @include "includes/structure.js";
+  // @include "includes/environment.js";
+  // @include "includes/data.js";
+  // @include "includes/shape.js";
+  // @include "includes/color.js";
+  // @include "includes/typography.js";
+  // @include "includes/image.js";
+  // @include "includes/math.js";
+  // @include "includes/transformation.js";
+  // @include "includes/ui.js";
+
+  init();
+
+  })();
+
 }
-
-
-(function() {
-
-var pub = {};
-
-/**
- * The basil version
- * @property VERSION {String}
- * @cat Environment
- */
-pub.VERSION = "1.1.0";
-
-// @include "includes/constants.js";
-// @include "includes/public-vars.js";
-// @include "includes/private-vars.js";
-// @include "includes/global-functions.js";
-
-// @include "includes/core.js";
-
-// @include "includes/structure.js";
-// @include "includes/environment.js";
-// @include "includes/data.js";
-// @include "includes/shape.js";
-// @include "includes/color.js";
-// @include "includes/typography.js";
-// @include "includes/image.js";
-// @include "includes/math.js";
-// @include "includes/transformation.js";
-// @include "includes/ui.js";
-
-init();
-
-})();


### PR DESCRIPTION
This is a slightly tweaked alternative to the `b-less` implementation that I put up for PR a few weeks ago.

The main difference is that it avoids the regex that parses the source script file, as I think this was a bit to unsafe. It might have failed on special cases like this:

```js
if(something) {
  // @include basiljs/basil.js
  // some comment that makes the regex fail
}
```

The new implementation avoids the regex by setting a global variable `basilRunning` to `true` the first time an execution chain enters `basil.js`. If `basil.js` is entered again (through the execution of the source script to load the global variables outside of `draw()`), it cancels right out again, because basil is already running.

So there is no need anymore to take the `// @include basil/basil.js` lines out with a regex.

Other improvements:

- basil scripts can be chained now from a main script (which is something that was not possible with the old basil).
- main.js does not create a stack overflow anymore when you run it by accident ;)

@fabianmoronzirfas (or anyone from @basiljs) If you agree that this tweak improves the previous implementation, we could pull it into the `b-less` branch. :smile:

This still passes the entire test suite.