### PR TITLE
canvasMode() bugs fixed for 3+ page spreads and single page on facing_pages

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1248,6 +1248,7 @@ var updatePublicPageSizeVars = function () {
   var pageBounds = currentPage().bounds; // [y1, x1, y2, x2]
   var facingPages = currDoc.documentPreferences.facingPages;
   var singlePageMode = false;
+  var spreadCount = currentPage().parent.pages.length;
 
   var widthOffset = 0;
   var heightOffset = 0;
@@ -1293,7 +1294,7 @@ var updatePublicPageSizeVars = function () {
       var w = pageBounds[3] - pageBounds[1] + widthOffset;
       var h = pageBounds[2] - pageBounds[0] + heightOffset;
 
-      pub.width = $.global.width = w * 2;
+      pub.width = $.global.width = w * spreadCount;
 
       if(currentPage().name === "1") {
         pub.width = $.global.width = w;
@@ -1311,14 +1312,14 @@ var updatePublicPageSizeVars = function () {
       pub.resetMatrix();
       pub.translate(-pub.doc().documentPreferences.documentBleedInsideOrLeftOffset, -pub.doc().documentPreferences.documentBleedTopOffset);
 
-      var w = pageBounds[3] - pageBounds[1] + widthOffset / 2;
+      var w = pageBounds[3] - pageBounds[1] + widthOffset / spreadCount;
       var h = pageBounds[2] - pageBounds[0] + heightOffset;
 
-      pub.width = $.global.width = w * 2;
+      pub.width = $.global.width = w * spreadCount;
       pub.height = $.global.height = h;
 
       if(currentPage().side === PageSideOptions.RIGHT_HAND) {
-        pub.translate(-w + widthOffset / 2, 0);
+        pub.translate(-w + widthOffset / spreadCount, 0);
       }
 
       break;
@@ -1329,14 +1330,14 @@ var updatePublicPageSizeVars = function () {
       pub.resetMatrix();
       pub.translate(currentPage().marginPreferences.left, currentPage().marginPreferences.top);
 
-      var w = pageBounds[3] - pageBounds[1] - widthOffset / 2;
+      var w = pageBounds[3] - pageBounds[1] - widthOffset / spreadCount;
       var h = pageBounds[2] - pageBounds[0] - heightOffset;
 
-      pub.width = $.global.width = w * 2;
+      pub.width = $.global.width = w * spreadCount;
       pub.height = $.global.height = h;
 
       if(currentPage().side === PageSideOptions.RIGHT_HAND) {
-        pub.translate(-w - widthOffset / 2, 0);
+        pub.translate(-w - widthOffset / spreadCount, 0);
       }
 
       return; // early exit

--- a/basil.js
+++ b/basil.js
@@ -1272,14 +1272,14 @@ var updatePublicPageSizeVars = function () {
 
     case pub.BLEED:
       widthOffset = pub.doc().documentPreferences.documentBleedInsideOrLeftOffset + pub.doc().documentPreferences.documentBleedOutsideOrRightOffset;
-      if(facingPages) {
+      if(facingPages && spreadCount > 1) {
         widthOffset = pub.doc().documentPreferences.documentBleedInsideOrLeftOffset;
       }
       heightOffset = pub.doc().documentPreferences.documentBleedBottomOffset + pub.doc().documentPreferences.documentBleedTopOffset;
       pub.resetMatrix();
       pub.translate(-pub.doc().documentPreferences.documentBleedInsideOrLeftOffset, -pub.doc().documentPreferences.documentBleedTopOffset);
 
-      if(facingPages && currentPage().side === PageSideOptions.RIGHT_HAND) {
+      if(facingPages && currentPage().side === PageSideOptions.RIGHT_HAND && spreadCount > 1) {
         pub.resetMatrix();
         pub.translate(0, -pub.doc().documentPreferences.documentBleedTopOffset);
       }
@@ -1298,7 +1298,7 @@ var updatePublicPageSizeVars = function () {
 
       if(currentPage().name === "1") {
         pub.width = $.global.width = w;
-      } else if (currentPage().side === PageSideOptions.RIGHT_HAND) {
+      } else if (currentPage().side === PageSideOptions.RIGHT_HAND && spreadCount > 1) {
         pub.translate(-w, 0);
       }
 
@@ -1318,7 +1318,7 @@ var updatePublicPageSizeVars = function () {
       pub.width = $.global.width = w * spreadCount;
       pub.height = $.global.height = h;
 
-      if(currentPage().side === PageSideOptions.RIGHT_HAND) {
+      if(currentPage().side === PageSideOptions.RIGHT_HAND && spreadCount > 1) {
         pub.translate(-w + widthOffset / spreadCount, 0);
       }
 
@@ -1336,7 +1336,7 @@ var updatePublicPageSizeVars = function () {
       pub.width = $.global.width = w * spreadCount;
       pub.height = $.global.height = h;
 
-      if(currentPage().side === PageSideOptions.RIGHT_HAND) {
+      if(currentPage().side === PageSideOptions.RIGHT_HAND && spreadCount > 1) {
         pub.translate(-w - widthOffset / spreadCount, 0);
       }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -60,6 +60,7 @@ basil.js x.x.x DAY MONTH YEAR
 * Changed the location of the basil.js library from `~/Documents/basiljs/bundle/basil.js` to `~/Documents/basiljs/basil.js` in all the example files.
 The user is allowed to have his files wherever he wants.
 * FACING_PAGES, FACING_BLEEDS, FACING_MARGINS, fixed for 3+ page spreads
+* BLEED, FACING_BLEEDS, FACING_MARGINS, fixed for single page in facing_pages mode
 
 - b.go() and b.loop() are removed (use function draw() or function loop() instead)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -59,6 +59,7 @@ basil.js x.x.x DAY MONTH YEAR
 * Linted all the test files
 * Changed the location of the basil.js library from `~/Documents/basiljs/bundle/basil.js` to `~/Documents/basiljs/basil.js` in all the example files.
 The user is allowed to have his files wherever he wants.
+* FACING_PAGES, FACING_BLEEDS, FACING_MARGINS, fixed for 3+ page spreads
 
 - b.go() and b.loop() are removed (use function draw() or function loop() instead)
 

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -436,6 +436,7 @@ var updatePublicPageSizeVars = function () {
   var pageBounds = currentPage().bounds; // [y1, x1, y2, x2]
   var facingPages = currDoc.documentPreferences.facingPages;
   var singlePageMode = false;
+  var spreadCount = currentPage().parent.pages.length;
 
   var widthOffset = 0;
   var heightOffset = 0;
@@ -481,7 +482,7 @@ var updatePublicPageSizeVars = function () {
       var w = pageBounds[3] - pageBounds[1] + widthOffset;
       var h = pageBounds[2] - pageBounds[0] + heightOffset;
 
-      pub.width = $.global.width = w * 2;
+      pub.width = $.global.width = w * spreadCount;
 
       if(currentPage().name === "1") {
         pub.width = $.global.width = w;
@@ -499,14 +500,14 @@ var updatePublicPageSizeVars = function () {
       pub.resetMatrix();
       pub.translate(-pub.doc().documentPreferences.documentBleedInsideOrLeftOffset, -pub.doc().documentPreferences.documentBleedTopOffset);
 
-      var w = pageBounds[3] - pageBounds[1] + widthOffset / 2;
+      var w = pageBounds[3] - pageBounds[1] + widthOffset / spreadCount;
       var h = pageBounds[2] - pageBounds[0] + heightOffset;
 
-      pub.width = $.global.width = w * 2;
+      pub.width = $.global.width = w * spreadCount;
       pub.height = $.global.height = h;
 
       if(currentPage().side === PageSideOptions.RIGHT_HAND) {
-        pub.translate(-w + widthOffset / 2, 0);
+        pub.translate(-w + widthOffset / spreadCount, 0);
       }
 
       break;
@@ -517,14 +518,14 @@ var updatePublicPageSizeVars = function () {
       pub.resetMatrix();
       pub.translate(currentPage().marginPreferences.left, currentPage().marginPreferences.top);
 
-      var w = pageBounds[3] - pageBounds[1] - widthOffset / 2;
+      var w = pageBounds[3] - pageBounds[1] - widthOffset / spreadCount;
       var h = pageBounds[2] - pageBounds[0] - heightOffset;
 
-      pub.width = $.global.width = w * 2;
+      pub.width = $.global.width = w * spreadCount;
       pub.height = $.global.height = h;
 
       if(currentPage().side === PageSideOptions.RIGHT_HAND) {
-        pub.translate(-w - widthOffset / 2, 0);
+        pub.translate(-w - widthOffset / spreadCount, 0);
       }
 
       return; // early exit

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -460,14 +460,14 @@ var updatePublicPageSizeVars = function () {
 
     case pub.BLEED:
       widthOffset = pub.doc().documentPreferences.documentBleedInsideOrLeftOffset + pub.doc().documentPreferences.documentBleedOutsideOrRightOffset;
-      if(facingPages) {
+      if(facingPages && spreadCount > 1) {
         widthOffset = pub.doc().documentPreferences.documentBleedInsideOrLeftOffset;
       }
       heightOffset = pub.doc().documentPreferences.documentBleedBottomOffset + pub.doc().documentPreferences.documentBleedTopOffset;
       pub.resetMatrix();
       pub.translate(-pub.doc().documentPreferences.documentBleedInsideOrLeftOffset, -pub.doc().documentPreferences.documentBleedTopOffset);
 
-      if(facingPages && currentPage().side === PageSideOptions.RIGHT_HAND) {
+      if(facingPages && currentPage().side === PageSideOptions.RIGHT_HAND && spreadCount > 1) {
         pub.resetMatrix();
         pub.translate(0, -pub.doc().documentPreferences.documentBleedTopOffset);
       }
@@ -486,7 +486,7 @@ var updatePublicPageSizeVars = function () {
 
       if(currentPage().name === "1") {
         pub.width = $.global.width = w;
-      } else if (currentPage().side === PageSideOptions.RIGHT_HAND) {
+      } else if (currentPage().side === PageSideOptions.RIGHT_HAND && spreadCount > 1) {
         pub.translate(-w, 0);
       }
 
@@ -506,7 +506,7 @@ var updatePublicPageSizeVars = function () {
       pub.width = $.global.width = w * spreadCount;
       pub.height = $.global.height = h;
 
-      if(currentPage().side === PageSideOptions.RIGHT_HAND) {
+      if(currentPage().side === PageSideOptions.RIGHT_HAND && spreadCount > 1) {
         pub.translate(-w + widthOffset / spreadCount, 0);
       }
 
@@ -524,7 +524,7 @@ var updatePublicPageSizeVars = function () {
       pub.width = $.global.width = w * spreadCount;
       pub.height = $.global.height = h;
 
-      if(currentPage().side === PageSideOptions.RIGHT_HAND) {
+      if(currentPage().side === PageSideOptions.RIGHT_HAND && spreadCount > 1) {
         pub.translate(-w - widthOffset / spreadCount, 0);
       }
 


### PR DESCRIPTION
- FACING_PAGES, FACING_MARGINS, FACING_BLEEDS was hard coded for a 2 page spread, but now works with 3+ spreads.

- fixes bug that BLEED, FACING_BLEEDS, FACING_MARGINS all had issues if used on single page within a document with facing_pages - could easily happen if starting a new document with only one page in that mode