### PR TITLE
Consistent formatting of jsdocs comments

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -523,16 +523,18 @@ var ERROR_PREFIX = "\nBasil.js Error -> ",
 // ----------------------------------------
 
 /**
- * System variable which stores the width of the current page.
- * @property {Number} width Width of the current page.
+ * @description System variable which stores the width of the current page.
+ *
  * @cat Environment
+ * @property {Number} width Width of the current page.
  */
 pub.width = null;
 
 /**
- * System variable which stores the height of the current page.
- * @property {Number} height Height of the current page.
+ * @description System variable which stores the height of the current page.
+ *
  * @cat Environment
+ * @property {Number} height Height of the current page.
  */
 pub.height = null;
 
@@ -588,7 +590,8 @@ var addToStoryCache = null, /* tmp cache, see addToStroy(), via InDesign externa
 
 /**
  * @description The <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/filter">filter()</a> method creates a new array with all elements that pass the test implemented by the provided function.
- * @cat Data
+ *
+ * @cat    Data
  * @subcat Array
  * @method Array.filter
  * @param  {Function} callback The Function is a predicate, to test each element of the array. Return true to keep the element, false otherwise.
@@ -614,7 +617,8 @@ if (!Array.prototype.filter) {
 
 /**
  * @description The <a href="https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array/map">map()</a> method creates a new array with the results of calling a provided function on every element in this array.
- * @cat Data
+ *
+ * @cat    Data
  * @subcat Array
  * @method Array.map
  * @param  {Function} callback Function that produces an element of the new Array.
@@ -650,13 +654,13 @@ if (!Array.prototype.map) {
 }
 
 /**
-* Used to run a function on all elements of an array. Please note the existance of the convenience methods <code>stories()</code>, <code>paragraphs()</code>, <code>lines()</code>, <code>words()</code> and <code>characters()</code> that are used to iterate through all instances of the given type in the given document.
+* @description Used to run a function on all elements of an array. Please note the existance of the convenience methods <code>stories()</code>, <code>paragraphs()</code>, <code>lines()</code>, <code>words()</code> and <code>characters()</code> that are used to iterate through all instances of the given type in the given document.
 *
-* @cat Data
+* @cat    Data
 * @subcat Array
 * @method Array.forEach
-* @param {Array} collection The array to be processed.
-* @param {Function} cb The function that will be called on each element. The call will be like function(item,i) where i is the current index of the item within the array.
+* @param  {Array} collection The array to be processed.
+* @param  {Function} cb The function that will be called on each element. The call will be like function(item,i) where i is the current index of the item within the array.
 */
 forEach = function(collection, cb) {
   for (var i = 0, len = collection.length; i < len; i++) {
@@ -674,12 +678,12 @@ forEach = function(collection, cb) {
 };
 
 /**
- * HashList is a data container that allows you to store information as key - value pairs. As usual in JavaScript mixed types of keys and values are accepted in one HashList instance.
+ * @description HashList is a data container that allows you to store information as key - value pairs. As usual in JavaScript mixed types of keys and values are accepted in one HashList instance.
  *
- * @constructor
- * @cat Data
+ * @cat    Data
  * @subcat HashList
  * @method HashList
+ * @constructor
  */
 // taken from http://pbrajkumar.wordpress.com/2011/01/17/hashmap-in-javascript/
 HashList = function () {
@@ -700,12 +704,12 @@ HashList = function () {
 
   /**
    *
-   * This removes a key - value pair by its key.
+   * @description This removes a key - value pair by its key.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.remove
-   * @param {String} key The key to delete.
+   * @param  {String} key The key to delete.
    * @return {Object} The value before deletion.
    */
   that.remove = function(key) {
@@ -719,12 +723,12 @@ HashList = function () {
   };
 
   /**
-   * This gets a value by its key.
+   * @description This gets a value by its key.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.get
-   * @param {String} key The key to look for.
+   * @param  {String} key The key to look for.
    * @return {Object} The value.
    */
   that.get = function(key) {
@@ -732,13 +736,13 @@ HashList = function () {
   };
 
   /**
-   * This sets a key - value pair. If a key is already existing, the value will be updated. Please note that Functions are currently not supported as values.
+   * @description This sets a key - value pair. If a key is already existing, the value will be updated. Please note that Functions are currently not supported as values.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.set
-   * @param {String} key The key to use.
-   * @param {Object|String|Number|Boolean} value The value to set.
+   * @param  {String} key The key to use.
+   * @param  {Object|String|Number|Boolean} value The value to set.
    * @return {Object} The value after setting.
    */
   that.set = function(key, value) {
@@ -755,12 +759,12 @@ HashList = function () {
   };
 
   /**
-   * Checks for the existence of a given key.
+   * @description Checks for the existence of a given key.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.hasKey
-   * @param {String} key The key to check.
+   * @param  {String} key The key to check.
    * @return {Boolean} Returns true or false.
    */
   that.hasKey = function(key) {
@@ -769,12 +773,12 @@ HashList = function () {
   };
 
   /**
-   * Checks if a certain value exists at least once in all of the key - value pairs.
+   * @description Checks if a certain value exists at least once in all of the key - value pairs.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.hasValue
-   * @param {Object|String|Number|Boolean} value The value to check.
+   * @param  {Object|String|Number|Boolean} value The value to check.
    * @return {Boolean} Returns true or false.
    */
   that.hasValue = function(value) {
@@ -790,9 +794,9 @@ HashList = function () {
   };
 
   /**
-   * Returns an array of all keys that are sorted by their values from highest to lowest. Please note that this only works if you have conistently used Numbers for values.
+   * @description Returns an array of all keys that are sorted by their values from highest to lowest. Please note that this only works if you have conistently used Numbers for values.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.getKeysByValues
    * @return {Array} An array with all the keys.
@@ -809,9 +813,9 @@ HashList = function () {
   };
 
   /**
-   * Returns an array with all keys in a sorted order from higher to lower magnitude.
+   * @description Returns an array with all keys in a sorted order from higher to lower magnitude.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.getSortedKeys
    * @return {Array} An array with all the keys sorted.
@@ -821,9 +825,9 @@ HashList = function () {
   };
 
   /**
-   * Returns an array with all keys.
+   * @description Returns an array with all keys.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.getKeys
    * @return {Array} An array with all the keys.
@@ -842,9 +846,9 @@ HashList = function () {
   };
 
   /**
-   * Returns an array with all values.
+   * @description Returns an array with all values.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.getValues
    * @return {Array} An array with all the values.
@@ -862,9 +866,9 @@ HashList = function () {
   };
 
   /**
-   * Deletes all the key - value pairs in this HashList.
+   * @description Deletes all the key - value pairs in this HashList.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.clear
    */
@@ -1022,11 +1026,11 @@ var prepareLoop = function() {
 }
 
 /**
- * Sets the framerate per second to determine how often loop() is called per second. If the processor is not fast enough to maintain the specified rate, the frame rate will not be achieved. Setting the frame rate within setup() is recommended. The default rate is 25 frames per second. Calling frameRate() with no arguments returns the currently set framerate.
+ * @description Sets the framerate per second to determine how often loop() is called per second. If the processor is not fast enough to maintain the specified rate, the frame rate will not be achieved. Setting the frame rate within setup() is recommended. The default rate is 25 frames per second. Calling frameRate() with no arguments returns the currently set framerate.
  *
- * @cat Environment
+ * @cat    Environment
  * @method frameRate
- * @param {Number} [fps] Frames per second.
+ * @param  {Number} [fps] Frames per second.
  * @return {Number} Currently set frame rate.
  */
 pub.frameRate = function(fps) {
@@ -1044,9 +1048,9 @@ pub.frameRate = function(fps) {
 };
 
 /**
- * Stops basil from continuously executing the code within loop() and quits the script.
+ * @description Stops basil from continuously executing the code within loop() and quits the script.
  *
- * @cat Environment
+ * @cat    Environment
  * @method noLoop
  */
 pub.noLoop = function(printFinished) {
@@ -1062,12 +1066,12 @@ pub.noLoop = function(printFinished) {
 };
 
 /**
- * Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, <code>mode()</code> should be placed in the beginning of the script. In basil there are three different performance modes:
- * <code>VISIBLE</code> is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.
- * <code>HIDDEN</code> allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use <code>println("yourMessage")</code> in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.
+ * @description Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, <code>mode()</code> should be placed in the beginning of the script. In basil there are three different performance modes:<br>
+ * <code>VISIBLE</code> is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.<br>
+ * <code>HIDDEN</code> allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use <code>println("yourMessage")</code> in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.<br>
  * <code>SILENT</code> processes the document without redrawing the screen. The document will stay visible and only update once the script is finished or once the mode is changed back to <code>VISIBLE</code>.
  *
- * @cat Environment
+ * @cat    Environment
  * @method mode
  * @param  {String} mode The performance mode to switch to.
  */
@@ -1588,10 +1592,10 @@ var textCollection = function(collection, legalContainers, container, cb) {
 
 };
 /**
- * @description Suspends the calling thread for a number of milliseconds.
+ * @description Suspends the calling thread for a number of milliseconds.<br>
  * During a sleep period, checks at 100 millisecond intervals to see whether the sleep should be terminated.
  *
- * @cat Environment
+ * @cat    Environment
  * @method delay
  * @param  {Number} milliseconds  The delay time in milliseconds.
  */
@@ -1602,17 +1606,18 @@ pub.delay = function (milliseconds) {
 /**
  * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function with each story of the given document.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method stories
  * @param  {Document} doc The document instance to iterate the stories in
  * @param  {Function} [cb] The callback function to call with each story. When this function returns false the loop stops. Passed arguments: story, loopCount.
+ * @return {Stories} A collection of Story objects.
+ *
  * @example
  * stories(doc(), function(story, loopCount){
  *   println("Number of words in each Story:");
  *   println(story.words.length);
  * });
- * @return {Stories} A collection of Story objects.
  */
 pub.stories = function(doc, cb) {
 
@@ -1630,7 +1635,7 @@ pub.stories = function(doc, cb) {
 /**
  * @description If no callback function is given it returns a Collection of paragraphs in the container otherwise calls the given callback function with each paragraph of the given document, page, story or textFrame.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method paragraphs
  * @param  {Document|Page|Story|TextFrame} container The document, story, page or textFrame instance to iterate the paragraphs in.
@@ -1647,7 +1652,7 @@ pub.paragraphs = function(container, cb) {
 /**
  * @description If no callback function is given it returns a Collection of lines in the container otherwise calls the given callback function with each line of the given document, page, story, textFrame or paragraph.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method lines
  * @param  {Document|Page|Story|TextFrame|Paragraph} container The document, page, story, textFrame or paragraph instance to iterate the lines in.
@@ -1664,7 +1669,7 @@ pub.lines = function(container, cb) {
 /**
  * @description If no callback function is given it returns a Collection of words in the container otherwise calls the given callback function with each word of the given document, page, story, textFrame, paragraph or line.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method words
  * @param  {Document|Page|Story|TextFrame|Paragraph|Line} container The document, page, story, textFrame, paragraph or line instance to iterate the words in.
@@ -1681,7 +1686,7 @@ pub.words = function(container, cb) {
 /**
  * @description If no callback function is given it returns a Collection of characters in the container otherwise calls the given callback function with each character of the given document, page, story, textFrame, paragraph, line or word.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method characters
  * @param  {Document|Page|Story|TextFrame|Paragraph|Line|Word} container The document, page, story, textFrame, paragraph, line or word instance to  iterate the characters in.
@@ -1699,7 +1704,7 @@ pub.characters = function(container, cb) {
 /**
  * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function for each of the PageItems in the given Document, Page, Layer or Group.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method items
  * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in
@@ -1727,7 +1732,7 @@ pub.items = function(container, cb) {
 /**
  * @description Removes all PageItems (including locked ones) in the given Document, Page, Layer or Group. If the selected container is a Group, the Group itself will be removed as well.
  *
- * @cat Document
+ * @cat    Document
  * @method clear
  * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in.
  */
@@ -1753,7 +1758,7 @@ pub.clear = function(container) {
 /**
  * @description Removes the provided Page, Layer, PageItem, Swatch, etc.
  *
- * @cat Document
+ * @cat    Document
  * @method remove
  * @param  {PageItem} obj The object to be removed.
  */
@@ -1771,11 +1776,11 @@ pub.remove = function(obj) {
 // ----------------------------------------
 
 /**
- * Sets or possibly creates the current document and returns it.
+ * @description Sets or possibly creates the current document and returns it.
  * If the param doc is not given the current document gets set to the active document
  * in the application. If no document at all is open, a new document gets created.
  *
- * @cat Document
+ * @cat    Document
  * @method doc
  * @param  {Document} [doc] The document to set the current document to.
  * @return {Document} The current document instance.
@@ -1790,13 +1795,13 @@ pub.doc = function(doc) {
 };
 
 /**
- * Sets the size of the current document, if arguments are given.
+ * @description Sets the size of the current document, if arguments are given.
  * If only one argument is given, both the width and the height are set to this value.
  * Alternatively, a string can be given as the first argument to apply an existing page size preset ("A4", "Letter" etc.).
  * In this case, either PORTRAIT or LANDSCAPE can be used as a second argument to determine the orientation of the page.
  * If no argument is given, an object containing the current document's width and height is returned.
  *
- * @cat Document
+ * @cat    Document
  * @method size
  * @param  {Number|String} [widthOrPageSize] The desired width of the current document or the name of a page size preset.
  * @param  {Number|String} [heightOrOrientation] The desired height of the current document. If not provided the width will be used as the height. If the first argument is a page size preset, the second argument can be used to set the orientation.
@@ -1860,9 +1865,9 @@ pub.size = function(widthOrPageSize, heightOrOrientation) {
 };
 
 /**
- * Closes the current document. If no saveOptions argument is used, the user will be asked if they want to save or not.
+ * @description Closes the current document. If no saveOptions argument is used, the user will be asked if they want to save or not.
  *
- * @cat Document
+ * @cat    Document
  * @method close
  * @param  {Object|Boolean} [saveOptions] The InDesign SaveOptions constant or either true for triggering saving before closing or false for closing without saving.
  * @param  {File} [file] The InDesign file instance to save the document to.
@@ -1896,7 +1901,7 @@ pub.close = function(saveOptions, file) {
 /**
  * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
  *
- * @cat Document
+ * @cat    Document
  * @method revert
  * @return {Document} The reverted document.
  */
@@ -1919,9 +1924,10 @@ pub.revert = function() {
 };
 
 /**
- * Use this to set the dimensions of the canvas. Choose between PAGE (default), MARGIN, BLEED resp. FACING_PAGES, FACING_MARGINS and FACING_BLEEDS for book setups with facing page. Please note: Setups with more than two facing pages are not yet supported.
+ * @description Use this to set the dimensions of the canvas. Choose between PAGE (default), MARGIN, BLEED resp. FACING_PAGES, FACING_MARGINS and FACING_BLEEDS for book setups with facing page. Please note: Setups with more than two facing pages are not yet supported.<br>
  * Please note that you will loose your current MatrixTransformation. You should set the canvasMode before you attempt to use translate(), rotate() and scale();
- * @cat Document
+ *
+ * @cat    Document
  * @subcat Page
  * @method canvasMode
  * @param  {String} mode The canvas mode to set.
@@ -1946,9 +1952,9 @@ pub.canvasMode = function (m) {
 
 
 /**
- * Returns the current horizontal and vertical pasteboard margins and sets them if both arguements are given.
+ * @description Returns the current horizontal and vertical pasteboard margins and sets them if both arguements are given.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method pasteboard
  * @param  {Number} h The desired horizontal pasteboard margin.
@@ -1969,9 +1975,9 @@ pub.pasteboard = function (h, v) {
 };
 
 /**
- * Returns the current page and sets it if argument page is given. Numbering starts with 1.
+ * @description Returns the current page and sets it if argument page is given. Numbering starts with 1.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method page
  * @param  {Page|Number|PageItem} [page] The page object or page number to set the current page to. If you pass a PageItem the current page will be set to it's containing page.
@@ -2006,9 +2012,9 @@ pub.page = function(page) {
 };
 
 /**
- * Adds a new page to the document. Set the optional location parameter to either AT_END (default), AT_BEGINNING, AFTER or BEFORE. AFTER and BEFORE will use the current page as insertion point.
+ * @description Adds a new page to the document. Set the optional location parameter to either AT_END (default), AT_BEGINNING, AFTER or BEFORE. AFTER and BEFORE will use the current page as insertion point.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method addPage
  * @param  {String} [location] The location placement mode.
@@ -2058,9 +2064,9 @@ pub.addPage = function(location) {
 
 
 /**
- * Removes a page from the current document. This will either be the current Page if the parameter page is left empty, or the given Page object or page number.
+ * @description Removes a page from the current document. This will either be the current Page if the parameter page is left empty, or the given Page object or page number.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method removePage
  * @param  {Page|Number} [page] The page to be removed as Page object or page number.
@@ -2078,9 +2084,9 @@ pub.removePage = function (page) {
 };
 
 /**
- * Returns the current page number of either the current page or the given Page object.
+ * @description Returns the current page number of either the current page or the given Page object.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method pageNumber
  * @param  {Page} [pageObj] The page you want to know the number of.
@@ -2098,9 +2104,9 @@ pub.pageNumber = function (pageObj) {
 };
 
 /**
- * Set the next page of the document to be the active one. Returns new active page.
+ * @description Set the next page of the document to be the active one. Returns new active page.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method nextPage
  * @return {Page} The active page.
@@ -2112,9 +2118,9 @@ pub.nextPage = function () {
 
 
 /**
- * Set the previous page of the document to be the active one. Returns new active page.
+ * @description Set the previous page of the document to be the active one. Returns new active page.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method previousPage
  * @return {Page} The active page.
@@ -2126,12 +2132,12 @@ pub.previousPage = function () {
 
 
 /**
- * Returns the number of all pages in the current document. If a number is given as an argument,
+ * @description Returns the number of all pages in the current document. If a number is given as an argument,
  * it will set the document's page count to the given number by either adding pages or removing
  * pages until the number is reached. If pages are added, the master page of the document's last
  * page will be applied to the new pages.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method pageCount
  * @param  {Number} [pageCount] New page count of the document (integer between 1 and 9999).
@@ -2150,9 +2156,9 @@ pub.pageCount = function(pageCount) {
 
 
 /**
- * The number of all stories in the current document.
+ * @description The number of all stories in the current document.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Story
  * @method storyCount
  * @return {Number} count The amount of stories.
@@ -2162,14 +2168,14 @@ pub.storyCount = function() {
 };
 
 /**
- * Adds a page item or a string to an existing story. You can control the position of the insert via the last parameter. It accepts either an InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
+ * @description Adds a page item or a string to an existing story. You can control the position of the insert via the last parameter. It accepts either an InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Story
  * @method addToStory
- * @param {Story} story The story.
- * @param {PageItem|String} itemOrString The itemOrString either a PageItem, a String or one the following constants: AT_BEGINNING and AT_END.
- * @param {InsertionPoint|String} insertionPointOrMode InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
+ * @param  {Story} story The story.
+ * @param  {PageItem|String} itemOrString The itemOrString either a PageItem, a String or one the following constants: AT_BEGINNING and AT_END.
+ * @param  {InsertionPoint|String} insertionPointOrMode InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
  */
 pub.addToStory = function(story, itemOrString, insertionPointorMode) {
 
@@ -2224,9 +2230,9 @@ pub.addToStory = function(story, itemOrString, insertionPointorMode) {
 
 
 /**
- * Returns the current layer if no argument is given. Sets active layer if layer object or name of existing layer is given. Newly creates layer and sets it to active if new name is given.
+ * @description Returns the current layer if no argument is given. Sets active layer if layer object or name of existing layer is given. Newly creates layer and sets it to active if new name is given.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method layer
  * @param  {Layer|String} [layer] The layer or layer name to set the current layer to.
@@ -2255,12 +2261,12 @@ pub.layer = function(layer) {
 /**
  * @description Arranges a page item or a layer before or behind other page items or layers. If using the constants <code>FORWARD</code> or <code>BACKWARD</code> the object is sent forward or back one step. The constants <code>FRONT</code> or <code>BACK</code> send the object to the very front or very back. Using <code>FRONT</code> or <code>BACK</code> together with the optional reference object, sends the object in front or behind this reference object.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method arrange
- * @param {PageItem|Layer} pItemOrLayer The page item or layer to be moved to a new position.
- * @param {String} positionOrDirection The position or direction to move the page item or layer. Can be <code>FRONT</code>, <code>BACK</code>, <code>FORWARD</code> or <code>BACKWARD</code>.
- * @param {PageItem|Layer} [reference] A reference object to move the page item or layer behind or in front of.
+ * @param  {PageItem|Layer} pItemOrLayer The page item or layer to be moved to a new position.
+ * @param  {String} positionOrDirection The position or direction to move the page item or layer. Can be <code>FRONT</code>, <code>BACK</code>, <code>FORWARD</code> or <code>BACKWARD</code>.
+ * @param  {PageItem|Layer} [reference] A reference object to move the page item or layer behind or in front of.
  * @return {PageItem|Layer} The newly arranged page item or layer.
  */
 pub.arrange = function(pItemOrLayer, positionOrDirection, reference) {
@@ -2309,15 +2315,15 @@ pub.arrange = function(pItemOrLayer, positionOrDirection, reference) {
 
 
 /**
- *  Returns the Group instance and sets it if argument Group is given.
+ *  @description Returns the Group instance and sets it if argument Group is given.
  *  Groups items to a new group. Returns the resulting group instance. If a string is given as the only
  *  argument, the group by the given name will be returned.
  *
- *  @cat Document
+ *  @cat    Document
  *  @subCat Page
  *  @method group
- *  @param {Array} pItems An array of page items (must contain at least two items) or name of group instance.
- *  @param {String} [name] The name of the group, only when creating a group from page items.
+ *  @param  {Array} pItems An array of page items (must contain at least two items) or name of group instance.
+ *  @param  {String} [name] The name of the group, only when creating a group from page items.
  *  @return {Group} The group instance.
  */
 pub.group = function (pItems, name) {
@@ -2347,12 +2353,12 @@ pub.group = function (pItems, name) {
 
 
 /**
- *  Ungroups an existing group. Returns an array of the items that were within the group before ungroup() was called.
+ *  @description Ungroups an existing group. Returns an array of the items that were within the group before ungroup() was called.
  *
- *  @cat Document
+ *  @cat    Document
  *  @subCat Page
  *  @method ungroup
- *  @param {Group|String} group The group instance or name of the group to ungroup.
+ *  @param  {Group|String} group The group instance or name of the group to ungroup.
  *  @return {Array} An array of the ungrouped page items.
  */
 pub.ungroup = function(group) {
@@ -2377,9 +2383,9 @@ pub.ungroup = function(group) {
 
 
 /**
- * Returns items tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label).
+ * @description Returns items tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label).
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method labels
  * @param  {String} label The label identifier.
@@ -2408,9 +2414,9 @@ pub.labels = function(label, cb) {
 
 
 /**
- * Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of <code>labels()</code>, when you know you just have one thing with that label and don't want to deal with a single-element array.
+ * @description Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of <code>labels()</code>, when you know you just have one thing with that label and don't want to deal with a single-element array.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method label
  * @param  {String} label The label identifier.
@@ -2430,9 +2436,9 @@ pub.label = function(label) {
 
 
 /**
- * Returns the first currently selected object. Use this if you know you only have one selected item and don't want to deal with an array.
+ * @description Returns the first currently selected object. Use this if you know you only have one selected item and don't want to deal with an array.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method selection
  * @return {Object} The first selected object.
@@ -2445,9 +2451,9 @@ pub.selection = function() {
 };
 
 /**
- * Returns the currently selected object(s)
+ * @description Returns the currently selected object(s)
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method selections
  * @param  {Function} [cb] The callback function to call with each item in the selection. When this function returns false the loop stops. Passed arguments: item, loopCount.
@@ -2464,9 +2470,9 @@ pub.selections = function(cb) {
 };
 
 /**
- * Returns the first item on the active page that is named by the given name in the Layers pane (Window -> Layer).
+ * @description Returns the first item on the active page that is named by the given name in the Layers pane (Window -> Layer).
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method nameOnPage
  * @return {Object} The first object on the active page with the given name.
@@ -2490,9 +2496,9 @@ pub.nameOnPage = function(name) {
 
 
 /**
- * Sets the units of the document (like right clicking the rulers). By default basil uses the units of the user's document or the user's default units.
+ * @description Sets the units of the document (like right clicking the rulers). By default basil uses the units of the user's document or the user's default units.
  *
- * @cat Document
+ * @cat    Document
  * @method units
  * @param  {String} [units] Supported units: PT, PX, CM, MM or IN.
  * @return {String} Current unit setting.
@@ -2542,9 +2548,9 @@ pub.units = function (units) {
 };
 
 /**
- * Creates a vertical guide line at the current spread and current layer.
+ * @description Creates a vertical guide line at the current spread and current layer.
  *
- * @cat Document
+ * @cat    Document
  * @method guideX
  * @param  {Number} x Position of the new guide line.
  * @return {Guide} New guide line.
@@ -2561,9 +2567,9 @@ pub.guideX = function (x) {
 
 
 /**
- * Creates a horizontal guide line at the current spread and current layer.
+ * @description Creates a horizontal guide line at the current spread and current layer.
  *
- * @cat Document
+ * @cat    Document
  * @method guideY
  * @param  {Number} y Position of the new guide line.
  * @return {Guide} New guide line.
@@ -2580,16 +2586,16 @@ pub.guideY = function (y) {
 
 
 /**
- * Sets the margins of a given page. If 1 value is given, all 4 sides are set equally. If 4 values are given, the current page will be adjusted. Adding a 5th value will set the margin of a given page. Calling the function without any values, will return the margins for the current page.
+ * @description Sets the margins of a given page. If 1 value is given, all 4 sides are set equally. If 4 values are given, the current page will be adjusted. Adding a 5th value will set the margin of a given page. Calling the function without any values, will return the margins for the current page.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method margins
- * @param {Number} [top] Top margin or all if only one.
- * @param {Number} [right] Right margin.
- * @param {Number} [bottom] Bottom margin.
- * @param {Number} [left] Left margin.
- * @param {Number} [pageNumber] Sets margins to selected page, currentPage() if left blank.
+ * @param  {Number} [top] Top margin or all if only one.
+ * @param  {Number} [right] Right margin.
+ * @param  {Number} [bottom] Bottom margin.
+ * @param  {Number} [left] Left margin.
+ * @param  {Number} [pageNumber] Sets margins to selected page, currentPage() if left blank.
  * @return {Object} Current page margins with the properties: top, right, bottom, left.
  */
 pub.margins = function(top, right, bottom, left, pageNumber) {
@@ -2617,15 +2623,15 @@ pub.margins = function(top, right, bottom, left, pageNumber) {
 
 
 /**
- * Sets the document bleeds. If one value is given, all 4 are set equally. If 4 values are given, the top/right/bottom/left document bleeds will be adjusted. Calling the function without any values, will return the document bleed settings.
+ * @description Sets the document bleeds. If one value is given, all 4 are set equally. If 4 values are given, the top/right/bottom/left document bleeds will be adjusted. Calling the function without any values, will return the document bleed settings.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method bleeds
- * @param {Number} [top] Top bleed or all if only one.
- * @param {Number} [right] Right bleed.
- * @param {Number} [bottom] Bottom bleed.
- * @param {Number} [left] Left bleed.
+ * @param  {Number} [top] Top bleed or all if only one.
+ * @param  {Number} [right] Right bleed.
+ * @param  {Number} [bottom] Bottom bleed.
+ * @param  {Number} [left] Left bleed.
  * @return {Object} Current document bleeds settings.
  */
 pub.bleeds = function(top, right, bottom, left) {
@@ -2648,15 +2654,15 @@ pub.bleeds = function(top, right, bottom, left) {
 
 
 /**
- * @description Inspects a given object or any other data item and prints the result to the console. This is useful for inspecting or debugging any kind of variable or data item. The optional settings object allows to control the function's output. The following parameters can be set in the settings object:
- * <code>showProps</code>: Show or hide properties. Default: <code>true</code>
- * <code>showValues</code>: Show or hide values. Default: <code>true</code>
- * <code>showMethods</code>: Show or hide methods. Default: <code>false</code>
- * <code>maxLevel</code>: Chooses how many levels of properties should be inspected recursively. Default: <code>1</code>
- * <code>propList</code>: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: <code>[]</code> (no propList)
+ * @description Inspects a given object or any other data item and prints the result to the console. This is useful for inspecting or debugging any kind of variable or data item. The optional settings object allows to control the function's output. The following parameters can be set in the settings object:<br>
+ * <code>showProps</code>: Show or hide properties. Default: <code>true</code><br>
+ * <code>showValues</code>: Show or hide values. Default: <code>true</code><br>
+ * <code>showMethods</code>: Show or hide methods. Default: <code>false</code><br>
+ * <code>maxLevel</code>: Chooses how many levels of properties should be inspected recursively. Default: <code>1</code><br>
+ * <code>propList</code>: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: <code>[]</code> (no propList)<br>
  * If no settings object is set, the default values will be used.
  *
- * @cat Output
+ * @cat    Output
  * @method inspect
  * @param  {Object} obj An object or any other data item to be inspected.
  * @param  {Object} [settings] A settings object to control the function's behavior.
@@ -2840,12 +2846,12 @@ pub.inspect = function (obj, settings, level, branchArray, branchEnd) {
 // Files & Folders
 
 /**
- * Returns a file object.
+ * @description Returns a file object.<br>
  * Note that the resulting file object can either refer to an already existing file or if the file does not exist, it can create a preliminary "virtual" file that refers to a file that could be created later (i.e. by an export command).
  *
- * @cat Files
+ * @cat    Files
  * @method file
- * @param {String} filePath The file path.
+ * @param  {String} filePath The file path.
  * @return {File} File at the given path.
  *
  * @example <caption>Get an image file from the desktop and place it in the document</caption>
@@ -2878,12 +2884,12 @@ pub.file = function(filePath) {
 };
 
 /**
- * Returns a folder object.
+ * @description Returns a folder object.<br>
  * Note that the resulting folder object can either refer to an already existing folder or if the folder does not exist, it can create a preliminary "virtual" folder that refers to a folder that could be created later.
  *
- * @cat Files
+ * @cat    Files
  * @method folder
- * @param {String} [folderPath] The path of the folder.
+ * @param  {String} [folderPath] The path of the folder.
  * @return {Folder} Folder at the given path. If no path is given, but the document is already saved, the document's data folder will be returned.
  *
  * @example <caption>Get a folder from the desktop and load its files</caption>
@@ -2922,16 +2928,16 @@ pub.folder = function(folderPath) {
 };
 
 /**
- * Gets all files of a folder and returns them in an array of file objects.
+ * @description Gets all files of a folder and returns them in an array of file objects.
  * The settings object can be used to restrict the search to certain file types only, to include hidden files and to include files in subfolders.
  *
- * @cat Files
+ * @cat    Files
  * @method files
- * @param {Folder|String} [folder] The folder that holds the files or a string describing the path to that folder.
- * @param {Object} [settings] A settings object to control the function's behavior.
- * @param {String|Array} [settings.filter] Suffix(es) of file types to include. Default: <code>"*"</code> (include all file types)
- * @param {Boolean} [settings.hidden] Hidden files will be included. Default: <code>false</code>
- * @param {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: <code>false</code>
+ * @param  {Folder|String} [folder] The folder that holds the files or a string describing the path to that folder.
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String|Array} [settings.filter] Suffix(es) of file types to include. Default: <code>"*"</code> (include all file types)
+ * @param  {Boolean} [settings.hidden] Hidden files will be included. Default: <code>false</code>
+ * @param  {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: <code>false</code>
  * @return {Array} Array of the resulting file(s). If no files are found, an empty array will be returned.
  *
  * @example <caption>Get a folder from the desktop and load all its JPEG files</caption>
@@ -3002,14 +3008,14 @@ pub.files = function(folder, settings, collectedFiles) {
 };
 
 /**
- * Opens a selection dialog that allows to select one file. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select one file. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
  *
- * @cat Files
+ * @cat    Files
  * @method selectFile
- * @param {Object} [settings] A settings object to control the function's behavior.
- * @param {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
- * @param {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
- * @param {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
+ * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
+ * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
  * @return {File|Null} The selected file. If the user cancels, <code>null</code> will be returned.
  *
  * @example <caption>Open file selection dialog with a prompt text</caption>
@@ -3023,14 +3029,14 @@ pub.selectFile = function(settings) {
 };
 
 /**
- * Opens a selection dialog that allows to select one or multiple files. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select one or multiple files. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
  *
- * @cat Files
+ * @cat    Files
  * @method selectFiles
- * @param {Object} [settings] A settings object to control the function's behavior.
- * @param {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
- * @param {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
- * @param {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
+ * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
+ * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
  * @return {Array} Array of the selected file(s). If the user cancels, an empty array will be returned.
  *
  * @example <caption>Open file selection dialog with a prompt text</caption>
@@ -3049,13 +3055,13 @@ pub.selectFiles = function(settings) {
 };
 
 /**
- * Opens a selection dialog that allows to select a folder. The settings object can be used to add a prompt text at the top of the dialog and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select a folder. The settings object can be used to add a prompt text at the top of the dialog and to set the dialog's starting folder.
  *
- * @cat Files
+ * @cat    Files
  * @method selectFolder
- * @param {Object} [settings] A settings object to control the function's behavior.
- * @param {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: <code>""</code> (no prompt)
- * @param {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: <code>""</code> (no prompt)
+ * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
  * @return {Folder|Null} The selected folder. If the user cancels, <code>null</code> will be returned.
  *
  * @example <caption>Open folder selection dialog with a prompt text</caption>
@@ -3078,9 +3084,9 @@ pub.selectFolder = function(settings) {
 // Date
 
 /**
- * The year() function returns the current year as an integer (2012, 2013 etc).
+ * @description The year() function returns the current year as an integer (2012, 2013 etc).
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method year
  * @return {Number} The current year.
@@ -3091,9 +3097,9 @@ pub.year = function() {
 
 
 /**
- * The month() function returns the current month as a value from 1 - 12.
+ * @description The month() function returns the current month as a value from 1 - 12.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method month
  * @return {Number} The current month number.
@@ -3104,9 +3110,9 @@ pub.month = function() {
 
 
 /**
- * The day() function returns the current day as a value from 1 - 31.
+ * @description The day() function returns the current day as a value from 1 - 31.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method day
  * @return {Number} The current day number.
@@ -3117,9 +3123,9 @@ pub.day = function() {
 
 
 /**
- * The weekday() function returns the current weekday as a string from Sunday, Monday, Tuesday...
+ * @description The weekday() function returns the current weekday as a string from Sunday, Monday, Tuesday...
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method weekday
  * @return {String} The current weekday name.
@@ -3131,9 +3137,9 @@ pub.weekday = function() {
 
 
 /**
- * The hour() function returns the current hour as a value from 0 - 23.
+ * @description The hour() function returns the current hour as a value from 0 - 23.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method hour
  * @return {Number} The current hour.
@@ -3144,9 +3150,9 @@ pub.hour = function() {
 
 
 /**
- * The minute() function returns the current minute as a value from 0 - 59.
+ * @description The minute() function returns the current minute as a value from 0 - 59.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method minute
  * @return {Number} The current minute.
@@ -3157,9 +3163,9 @@ pub.minute = function() {
 
 
 /**
- * The second() function returns the current second as a value from 0 - 59.
+ * @description The second() function returns the current second as a value from 0 - 59.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method second
  * @return {Number} The current second.
@@ -3170,9 +3176,9 @@ pub.second = function() {
 
 
 /**
- * Returns the number of milliseconds (thousandths of a second) since starting an applet.
+ * @description Returns the number of milliseconds (thousandths of a second) since starting an applet.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method millis
  * @return {Number} The current milli.
@@ -3183,9 +3189,9 @@ pub.millis = function() {
 
 
 /**
- * The millisecond() function differs from millis(), in that it returns the exact millisecond (thousandths of a second) of the current time.
+ * @description The millisecond() function differs from millis(), in that it returns the exact millisecond (thousandths of a second) of the current time.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method millisecond
  * @return {Number} The current millisecond.
@@ -3196,9 +3202,9 @@ pub.millisecond = function() {
 
 
 /**
- * The timestamp() function returns the current date formatted as YYYYMMDD_HHMMSS for useful unique filenaming.
+ * @description The timestamp() function returns the current date formatted as YYYYMMDD_HHMMSS for useful unique filenaming.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method timestamp
  * @return {String} The current time in YYYYMMDD_HHMMSS.
@@ -3221,11 +3227,11 @@ pub.timestamp = function() {
 
 pub.JSON = {
   /**
-   * Function parses and validates a string as JSON-object. Usage:
+   * @description Function parses and validates a string as JSON-object. Usage:<br>
    * var obj = JSON.decode(str);
    * var str = JSON.encode(obj);
    *
-   * @cat Data
+   * @cat    Data
    * @subcat JSON
    * @method JSON.decode
    * @param  {String} String to be parsed as JSON-object.
@@ -3251,11 +3257,11 @@ pub.JSON = {
     error("JSON.decode(), invalid JSON: " + data);
   },
   /**
-   * Function convert an javascript object to a JSON-string. Usage:
+   * Function convert an javascript object to a JSON-string. Usage:<br>
    * var str = JSON.encode(obj);
    * var obj = JSON.decode(str);
    *
-   * @cat Data
+   * @cat    Data
    * @subcat JSON
    * @method JSON.encode
    * @param  {Object} Object to be converted to a JSON-string
@@ -3303,9 +3309,9 @@ function CSV() {
   }
 
   /**
-   * Sets the delimiter of the CSV decode and encode function.
+   * @description Sets the delimiter of the CSV decode and encode function.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat CSV
    * @method CSV.delimiter
    * @param  {String} [delimiter] Optional Sets the delimiter for CSV parsing
@@ -3321,11 +3327,11 @@ function CSV() {
   };
 
   /**
-   * Function parses a string as CSV-object Array. Usage:
+   * @description Function parses a string as CSV-object Array. Usage:<br>
    * var arr = CSV.decode(str);
    * var str = CSV.encode(arr);
    *
-   * @cat Data
+   * @cat    Data
    * @subcat CSV
    * @method CSV.decode
    * @param  {String} String to be parsed as CSV-object.
@@ -3346,11 +3352,11 @@ function CSV() {
   };
 
   /**
-   * Function convert an javascript array of objects to a CSV-string. Usage:
+   * @description Function convert an javascript array of objects to a CSV-string. Usage:<br>
    * var str = CSV.encode(arr);
    * var arr = CSV.decode(str);
    *
-   * @cat Data
+   * @cat    Data
    * @subcat CSV
    * @method CSV.encode
    * @param  {Array} Array to be converted to a CSV-string
@@ -3449,17 +3455,17 @@ function CSV() {
 
 
 /**
- * Converts a byte, char, int, or color to a String containing the
+ * @description Converts a byte, char, int, or color to a String containing the
  * equivalent binary notation. For example color(0, 102, 153, 255)
  * will convert to the String "11111111000000000110011010011001". This
  * function can help make your geeky debugging sessions much happier.
  *
 
- * @cat Data
+ * @cat    Data
  * @subcat Conversion
  * @method binary
- * @param {Number} num value to convert
- * @param {Number} [numBits] number of digits to return
+ * @param  {Number} num value to convert
+ * @param  {Number} [numBits] number of digits to return
  * @return {String} A formatted string
  */
  // From: http://processingjs.org/reference/binary_/
@@ -3479,14 +3485,14 @@ pub.binary = function(num, numBits) {
 };
 
 /**
- * Converts a String representation of a binary number to its
+ * @description Converts a String representation of a binary number to its
  * equivalent integer value. For example, unbinary("00001000") will
  * return 8.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Conversion
  * @method unbinary
- * @param {String} binaryString value to convert
+ * @param  {String} binaryString value to convert
  * @return {Number} The integer representation
  */
  // From: http://processingjs.org/reference/unbinary_/
@@ -3514,13 +3520,13 @@ var decimalToHex = function(d, padding) {
 };
 
 /**
- * Convert a number to a hex representation.
+ * @description Convert a number to a hex representation.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Conversion
  * @method hex
- * @param {Number} value The number to convert
- * @param {Number} [len] The length of the hex number to be created, default: 8
+ * @param  {Number} value The number to convert
+ * @param  {Number} [len] The length of the hex number to be created, default: 8
  * @return {String} The hex representation as a string
  */
 pub.hex = function(value, len) {
@@ -3535,12 +3541,12 @@ var unhexScalar = function(hex) {
 };
 
 /**
- * Convert a hex representation to a number.
+ * @description Convert a hex representation to a number.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Conversion
  * @method unhex
- * @param {String} hex The hex representation
+ * @param  {String} hex The hex representation
  * @return {Number} The number
  */
 pub.unhex = function(hex) {
@@ -3558,12 +3564,12 @@ pub.unhex = function(hex) {
 
 
 /**
- * Removes multiple, leading or trailing spaces and punctuation from "words". E.g. converts "word!" to "word". Especially useful together with words();
+ * @description Removes multiple, leading or trailing spaces and punctuation from "words". E.g. converts "word!" to "word". Especially useful together with words();
  *
- * @method trimWord
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
- * @param {String} s The String to trim
+ * @method trimWord
+ * @param  {String} s The String to trim
  * @return {String} The trimmed string
  */
  // from: https://stackoverflow.com/a/25575009/3399765
@@ -3575,16 +3581,16 @@ pub.trimWord = function(s) {
 };
 
 /**
- * Combines an array of Strings into one String, each separated by
+ * @description Combines an array of Strings into one String, each separated by
  * the character(s) used for the separator parameter. To join arrays
  * of ints or floats, it's necessary to first convert them to strings
  * using nf() or nfs().
  *
- * @method join
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
- * @param {Array} array A string array
- * @param {String} separator The separator to be inserted
+ * @method join
+ * @param  {Array} array A string array
+ * @param  {String} separator The separator to be inserted
  * @return {String} The joined string
  */
  // http://processingjs.org/reference/join_/
@@ -3593,24 +3599,24 @@ pub.join = function(array, separator) {
 };
 
 /**
- * The split() function breaks a string into pieces using a
+ * @description The split() function breaks a string into pieces using a
  * character or string as the divider. The delim parameter specifies the
  * character or characters that mark the boundaries between each piece. A
  * String[] array is returned that contains each of the pieces.
- *
+ * <br><br>
  * If the result is a set of numbers, you can convert the String[] array
  * to to a float[] or int[] array using the datatype conversion functions
  * int() and float() (see example above).
- *
+ * <br><br>
  * The splitTokens() function works in a similar fashion, except that it
  * splits using a range of characters instead of a specific character or
  * sequence.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method split
- * @param {String} str the String to be split
- * @param {String} [delim] The string used to separate the data
+ * @param  {String} str the String to be split
+ * @param  {String} [delim] The string used to separate the data
  * @return {Array} Array of strings
  */
  // http://processingjs.org/reference/split_/
@@ -3619,21 +3625,21 @@ pub.split = function(str, delim) {
 };
 
 /**
- * The splitTokens() function splits a String at one or many character
+ * @description The splitTokens() function splits a String at one or many character
  * "tokens." The tokens parameter specifies the character or characters
  * to be used as a boundary.
- *
+ * <br><br>
  * If no tokens character is specified, any whitespace character is used
  * to split. Whitespace characters include tab (\t), line feed (\n),
  * carriage return (\r), form feed (\f), and space. To convert a String
  * to an array of integers or floats, use the datatype conversion functions
  * int() and float() to convert the array of Strings.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method splitTokens
- * @param {String} str the String to be split
- * @param {String} [tokens] list of individual characters that will be used as separators
+ * @param  {String} str the String to be split
+ * @param  {String} [tokens] list of individual characters that will be used as separators
  * @return {Array} Array of strings
  */
  // From: http://processingjs.org/reference/splitTokens_/
@@ -3720,22 +3726,22 @@ function nfCore(value, plus, minus, leftDigits, rightDigits, group) {
 }
 
 /**
- * Utility function for formatting numbers into strings. There
+ * @description Utility function for formatting numbers into strings. There
  * are two versions, one for formatting floats and one for formatting
  * ints. The values for the digits, left, and right parameters should
  * always be positive integers.
-
+ * <br><br>
  * As shown in the above example, nf() is used to add zeros to the
  * left and/or right of a number. This is typically for aligning a list
  * of numbers. To remove digits from a floating-point number, use the
  * int(), ceil(), floor(), or round() functions.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method nf
- * @param {Number} value The Number to convert
- * @param {Number} leftDigits
- * @param {Number} rightDigits
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
  * @return {String} The formatted string
  */
  // From: http://processingjs.org/reference/nf_/
@@ -3744,19 +3750,19 @@ pub.nf = function(value, leftDigits, rightDigits) {
 };
 
 /**
- * Utility function for formatting numbers into strings. Similar to nf()
+ * @description Utility function for formatting numbers into strings. Similar to nf()
  * but leaves a blank space in front of positive numbers so they align
  * with negative numbers in spite of the minus symbol. There are two
  * versions, one for formatting floats and one for formatting ints. The
  * values for the digits, left, and right parameters should always be
  * positive integers.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method nfs
- * @param {Number} value The Number to convert
- * @param {Number} leftDigits
- * @param {Number} rightDigits
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
  * @return {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfs_/
@@ -3765,18 +3771,18 @@ pub.nfs = function(value, leftDigits, rightDigits) {
 };
 
 /**
- * Utility function for formatting numbers into strings. Similar to nf()
+ * @description Utility function for formatting numbers into strings. Similar to nf()
  * but puts a "+" in front of positive numbers and a "-" in front of
  * negative numbers. There are two versions, one for formatting floats
  * and one for formatting ints. The values for the digits, left, and right
  * parameters should always be positive integers.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method nfp
- * @param {Number} value The Number to convert
- * @param {Number} leftDigits
- * @param {Number} rightDigits
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
  * @return {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfp_/
@@ -3785,17 +3791,17 @@ pub.nfp = function(value, leftDigits, rightDigits) {
 };
 
 /**
- * Utility function for formatting numbers into strings and placing
+ * @description Utility function for formatting numbers into strings and placing
  * appropriate commas to mark units of 1000. There are two versions, one
  * for formatting ints and one for formatting an array of ints. The value
  * for the digits parameter should always be a positive integer.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method nfc
- * @param {Number} value The Number to convert
- * @param {Number} leftDigits
- * @param {Number} rightDigits
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
  * @return {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfc_/
@@ -3805,14 +3811,14 @@ pub.nfc = function(value, leftDigits, rightDigits) {
 
 
 /**
- * Removes whitespace characters from the beginning and end of a String.
+ * @description Removes whitespace characters from the beginning and end of a String.
  * In addition to standard whitespace characters such as space, carriage
  * return, and tab, this function also removes the Unicode "nbsp" character.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method trim
- * @param {String|Array} str A string or an array of strings to be trimmed
+ * @param  {String|Array} str A string or an array of strings to be trimmed
  * @return {String|Array} Returns the input in a trimmed way
  */
  // From: http://processingjs.org/reference/trim_/
@@ -3826,12 +3832,12 @@ pub.trim = function(str) {
 };
 
 /**
- * Checks whether an URL string is valid.
+ * @description Checks whether an URL string is valid.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method isURL
- * @param {String} url An url string to be checked
+ * @param  {String} url An url string to be checked
  * @return {Boolean} Returns either true or false
  */
 var isURL = pub.isURL = function(url) {
@@ -3840,13 +3846,13 @@ var isURL = pub.isURL = function(url) {
 };
 
 /**
- * Checks whether a string ends with a specific character or string.
+ * @description Checks whether a string ends with a specific character or string.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method endsWith
- * @param {String} str A string to be checked
- * @param {String} suffix The string to look for
+ * @param  {String} str A string to be checked
+ * @param  {String} suffix The string to look for
  * @return {Boolean} Returns either true or false
  */
 var endsWith = pub.endsWith = function(str, suffix) {
@@ -3857,13 +3863,13 @@ var endsWith = pub.endsWith = function(str, suffix) {
 };
 
 /**
- * Checks whether a string starts with a specific character or string.
+ * @description Checks whether a string starts with a specific character or string.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method startsWith
- * @param {String} str A string to be checked
- * @param {String} prefix The string to look for
+ * @param  {String} str A string to be checked
+ * @param  {String} prefix The string to look for
  * @return {Boolean} Returns either true or false
  */
 var startsWith = pub.startsWith = function(str, prefix) {
@@ -3875,9 +3881,9 @@ var startsWith = pub.startsWith = function(str, prefix) {
 
 
 /**
- * Checks whether a var is an Array, returns true if this is the case
+ * @description Checks whether a var is an Array, returns true if this is the case
  *
- * @cat Data
+ * @cat    Data
  * @subcat Type-Check
  * @method isArray
  * @param  {Object|String|Number|Boolean} obj The object to check
@@ -3888,9 +3894,9 @@ var isArray = pub.isArray = function(obj) {
 };
 
 /**
- * Checks whether a var is a number, returns true if this is the case
+ * @description Checks whether a var is a number, returns true if this is the case
  *
- * @cat Data
+ * @cat    Data
  * @subcat Type-Check
  * @method isNumber
  * @param  {Object|String|Number|Boolean}  num The number to check
@@ -3908,9 +3914,9 @@ var isNumber = pub.isNumber = function(num) {
 
 
 /**
- * Checks whether a var is an integer, returns true if this is the case.
+ * @description Checks whether a var is an integer, returns true if this is the case.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Type-Check
  * @method isInteger
  * @param  {Object|String|Number|Boolean}  num The number to check.
@@ -3921,9 +3927,9 @@ var isInteger = pub.isInteger = function(num) {
 };
 
 /**
- * Checks whether a var is a string, returns true if this is the case
+ * @description Checks whether a var is a string, returns true if this is the case
  *
- * @cat Data
+ * @cat    Data
  * @subcat Type-Check
  * @method isString
  * @param  {Object|String|Number|Boolean} str The string to check
@@ -3934,11 +3940,11 @@ var isString = pub.isString = function(str) {
 };
 
 /**
- * Checks whether a var is an InDesign text object, returns true if this is the case
+ * @description Checks whether a var is an InDesign text object, returns true if this is the case
  * NB: a InDesign TextFrame will return false as it is just a container holding text.
  * So you could say that isText() refers to all the things inside a TextFrame.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Type-Check
  * @method isText
  * @param  {Character|InsertionPoint|Line|Paragraph|TextColumn|TextStyleRange|Word}  obj The object to check
@@ -4061,9 +4067,9 @@ var initExportFile = function(file) {
 };
 
 /**
- * Get the folder of the active document as a Folder object. Use .absoluteURI to access a string representation of the folder path.
+ * @description Get the folder of the active document as a Folder object. Use .absoluteURI to access a string representation of the folder path.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Misc
  * @method projectFolder
  * @return {Folder} The folder of the the active document
@@ -4077,11 +4083,11 @@ pub.projectFolder = function() {
 
 
 /**
- * Executes a shell command and returns the result, currently Mac only.
- *
+ * @description Executes a shell command and returns the result, currently Mac only.
+ * <br><br>
  * BE CAREFUL!
  *
- * @cat Data
+ * @cat    Data
  * @subcat Input
  * @method shellExecute
  * @param  {String} cmd The shell command to execute
@@ -4100,10 +4106,10 @@ pub.shellExecute = function(cmd) {
 };
 
 /**
- * Reads the contents of a file or loads an URL into a String.
+ * @description Reads the contents of a file or loads an URL into a String.
  * If the file is specified by name as String, it must be located in the document's data directory.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Input
  * @method loadString
  * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
@@ -4135,10 +4141,10 @@ var getURL = function(url) {
 };
 
 /**
- * Reads the contents of a file or loads an URL and creates a String array of its individual lines.
+ * @description Reads the contents of a file or loads an URL and creates a String array of its individual lines.
  * If the file is specified by name as String, it must be located in the document's data directory.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Input
  * @method loadStrings
  * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
@@ -4165,7 +4171,7 @@ pub.loadStrings = function(file) {
 // Output
 
 /**
- * Prints a message line to the console output in the ExtendScript editor.
+ * @description Prints a message line to the console output in the ExtendScript editor.
  *
  * @cat Output
  * @method println
@@ -4179,11 +4185,11 @@ var println = pub.println = function() {
 };
 
 /**
- * Prints a message to the console output in the ExtendScript editor, but unlike println() it doesn't return the carriage to a new line at the end.
+ * @description Prints a message to the console output in the ExtendScript editor, but unlike println() it doesn't return the carriage to a new line at the end.
  *
- * @cat Output
+ * @cat    Output
  * @method print
- * @param {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
+ * @param  {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
  */
 pub.print = function() {
   var msg = Array.prototype.slice.call(arguments).join(" ");
@@ -4193,9 +4199,9 @@ pub.print = function() {
 };
 
 /**
- * Print numerous information about the current environment to the console
+ * @description Print numerous information about the current environment to the console
  *
- * @cat Output
+ * @cat    Output
  * @method printInfo
  */
 pub.printInfo = function() {
@@ -4211,10 +4217,10 @@ pub.printInfo = function() {
 };
 
 /**
- * Writes an array of strings to a file, one line per string.
+ * @description Writes an array of strings to a file, one line per string.
  * If the given file exists it gets overridden.
  *
- * @cat Output
+ * @cat    Output
  * @method saveStrings
  * @param  {String|File} file The file name or a File instance
  * @param  {Array} strings The string array to be written
@@ -4236,10 +4242,10 @@ pub.saveStrings = function(file, strings) {
 };
 
 /**
- * Writes a string to a file.
+ * @description Writes a string to a file.
  * If the given file exists it gets overridden.
  *
- * @cat Output
+ * @cat    Output
  * @method saveString
  * @param  {String|File} file The file name or a File instance.
  * @param  {String} string The string to be written.
@@ -4259,9 +4265,9 @@ pub.saveString = function(file, string) {
 };
 
 /**
- * Exports the current document as PDF to the documents folder. Please note, that export options default to the last used export settings.
+ * @description Exports the current document as PDF to the documents folder. Please note, that export options default to the last used export settings.
  *
- * @cat Output
+ * @cat    Output
  * @method savePDF
  * @param  {String|File} file The file name or a File instance.
  * @param  {Boolean} [showOptions] Whether to show the export dialog.
@@ -4280,12 +4286,12 @@ pub.savePDF = function(file, showOptions) {
 };
 
 /**
- * Exports the current document as PNG (or sequence of PNG files) to the documents folder. Please note, that export options default to the last used export settings.
+ * @description Exports the current document as PNG (or sequence of PNG files) to the documents folder. Please note, that export options default to the last used export settings.
  *
- * @cat Output
+ * @cat    Output
  * @method savePNG
- * @param {String|File} file The file name or a File instance
- * @param {Boolean} [showOptions] Whether to show the export dialog
+ * @param  {String|File} file The file name or a File instance
+ * @param  {Boolean} [showOptions] Whether to show the export dialog
  * @return {File} The exported PNG file.
  */
 pub.savePNG = function(file, showOptions) {
@@ -4301,12 +4307,12 @@ pub.savePNG = function(file, showOptions) {
 };
 
 /**
- * Downloads an URL to a file, currently Mac only.
+ * @description Downloads an URL to a file, currently Mac only.
  *
- * @cat Output
+ * @cat    Output
  * @method download
- * @param {String} url The download url
- * @param {String|File} [file] A relative file path in the project folder or a File instance
+ * @param  {String} url The download url
+ * @param  {String|File} [file] A relative file path in the project folder or a File instance
  */
 pub.download = function(url, file) {
   var projPath = pub.projectFolder().fsName.replace(" ", "\\ ");
@@ -4404,16 +4410,16 @@ pub.download = function(url, file) {
 // ----------------------------------------
 
 /**
- * Draws an ellipse (oval) in the display window. An ellipse with an equal width and height is a circle.
+ * @description Draws an ellipse (oval) in the display window. An ellipse with an equal width and height is a circle.
  * The first two parameters set the location, the third sets the width, and the fourth sets the height.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method ellipse
- * @param {Number} x X-coordinate of the ellipse.
- * @param {Number} y Y-coordinate of the ellipse.
- * @param {Number} w Width of the ellipse.
- * @param {Number} h Height of the ellipse.
+ * @param  {Number} x X-coordinate of the ellipse.
+ * @param  {Number} y Y-coordinate of the ellipse.
+ * @param  {Number} w Width of the ellipse.
+ * @param  {Number} h Height of the ellipse.
  * @return {Oval} New Oval (in InDesign Scripting terms the corresponding type is Oval, not Ellipse).
  */
 pub.ellipse = function(x, y, w, h) {
@@ -4467,21 +4473,21 @@ pub.ellipse = function(x, y, w, h) {
 };
 
 /**
- * Draws a line (a direct path between two points) to the page.
+ * @description Draws a line (a direct path between two points) to the page.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method line
- * @param {Number} x1 X-coordinate of Point 1.
- * @param {Number} y1 Y-coordinate of Point 1.
- * @param {Number} x2 X-coordinate of Point 2.
- * @param {Number} y2 Y-coordinate of Point 2.
+ * @param  {Number} x1 X-coordinate of Point 1.
+ * @param  {Number} y1 Y-coordinate of Point 1.
+ * @param  {Number} x2 X-coordinate of Point 2.
+ * @param  {Number} y2 Y-coordinate of Point 2.
  * @return {GraphicLine} New GraphicLine.
  *
- *  @example
- *  var vec1 = new Vector( x1, y1 );
- *  var vec2 = new Vector( x2, y2 );
- *  line( vec1, vec2 );
+ * @example
+ * var vec1 = new Vector( x1, y1 );
+ * var vec2 = new Vector( x2, y2 );
+ * line( vec1, vec2 );
  */
 pub.line = function(x1, y1, x2, y2) {
   if (arguments.length !== 4) {
@@ -4502,16 +4508,16 @@ pub.line = function(x1, y1, x2, y2) {
 };
 
 /**
- * Using the beginShape() and endShape() functions allows to create more complex forms.
+ * @description Using the beginShape() and endShape() functions allows to create more complex forms.
  * beginShape() begins recording vertices for a shape and endShape() stops recording.
  * After calling the beginShape() function, a series of vertex() commands must follow.
  * To stop drawing the shape, call endShape(). The shapeMode parameter allows to close the shape
  * (to connect the beginning and the end).
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method beginShape
- * @param {String} shapeMode Set to CLOSE if the new Path should be auto-closed.
+ * @param  {String} shapeMode Set to CLOSE if the new Path should be auto-closed.
  */
 pub.beginShape = function(shapeMode) {
   currVertexPoints = [];
@@ -4525,15 +4531,15 @@ pub.beginShape = function(shapeMode) {
 };
 
 /**
- * Shapes are constructed by connecting a series of vertices. vertex() is used to
+ * @description Shapes are constructed by connecting a series of vertices. vertex() is used to
  * specify the vertex coordinates of lines and polygons. It is used exclusively between
  * the beginShape() and endShape() functions.
- *
+ * <br><br>
  * Use either vertex(x, y) for drawing straight corners or
  * vertex(x, y, xLeftHandle, yLeftHandle, xRightHandle, yRightHandle) for drawing bezier shapes.
  * You can also mix the two approaches.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method vertex
  * @param  {Number} x X-coordinate of the vertex.
@@ -4561,22 +4567,21 @@ pub.vertex = function() {
 };
 
 /**
- * The arc() function draws an arc. Arcs are drawn along the outer edge of an ellipse
+ * @description The arc() function draws an arc. Arcs are drawn along the outer edge of an ellipse
  * defined by the x, y, width and height parameters.
  * The origin or the arc's ellipse may be changed with the ellipseMode() function.
  * The start and stop parameters specify the angles at which to draw the arc.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method arc
- * @param {Number} cx X-coordinate of the arc's center.
- * @param {Number} cy Y-coordinate of the arc's center.
- * @param {Number} w Width of the arc's ellipse.
- * @param {Number} h Height of the arc's ellipse.
- * @param {Number} startAngle Starting angle of the arc in radians.
- * @param {Number} endAngle Ending angle of the arc in radians.
- * @param {String} [mode] Mode to define the rendering technique of the arc: OPEN (default), CHORD, or PIE.
- *
+ * @param  {Number} cx X-coordinate of the arc's center.
+ * @param  {Number} cy Y-coordinate of the arc's center.
+ * @param  {Number} w Width of the arc's ellipse.
+ * @param  {Number} h Height of the arc's ellipse.
+ * @param  {Number} startAngle Starting angle of the arc in radians.
+ * @param  {Number} endAngle Ending angle of the arc in radians.
+ * @param  {String} [mode] Mode to define the rendering technique of the arc: OPEN (default), CHORD, or PIE.
  * @return {GraphicLine|Polygon} The resulting GraphicLine or Polygon object (in InDesign Scripting terms the corresponding type is GraphicLine or Polygon, not Arc).
  *
  */
@@ -4692,12 +4697,12 @@ function calculateEllipticalArc(w, h, startAngle, endAngle) {
 }
 
 /**
- * addPath() is used to create multi component paths. Call addPath() to add
+ * @description addPath() is used to create multi component paths. Call addPath() to add
  * the vertices drawn so far to a single path. New vertices will then end up in a new path and
  * endShape() will return a multi path object. All component paths will account for
  * the setting (see CLOSE) given in beginShape(shapeMode).
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method addPath
  */
@@ -4707,10 +4712,10 @@ pub.addPath = function() {
 };
 
 /**
- * The endShape() function is the companion to beginShape() and may only be called
+ * @description The endShape() function is the companion to beginShape() and may only be called
  * after beginShape().
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method endShape
  * @return {GraphicLine|Polygon} The GraphicLine or Polygon object that was created.
@@ -4761,11 +4766,11 @@ function notCalledBeginShapeError () {
 }
 
 /**
- * Draws a rectangle on the page.
- * By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, however, may be changed with the rectMode() function.
+ * @description Draws a rectangle on the page.<br>
+ * By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, however, may be changed with the rectMode() function.<br>
  * The fifth, sixth, seventh and eighth parameters, if specified, determine corner radius for the top-right, top-left, lower-right and lower-left corners, respectively. If only a fifth parameter is provided, all corners will be set to this radius.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method rect
  * @param  {Number} x X-coordinate of the rectangle.
@@ -4849,7 +4854,7 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
 // -- Attributes --
 
 /**
- * Modifies the location from which rectangles or text frames draw. The default
+ * @description Modifies the location from which rectangles or text frames draw. The default
  * mode is rectMode(CORNER), which specifies the location to be the upper left
  * corner of the shape and uses the <code>w</code> and <code>h</code> parameters to specify the
  * width and height. The syntax rectMode(CORNERS) uses the <code>x</code> and <code>y</code>
@@ -4861,10 +4866,10 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
  * center point and uses the <code>w</code> and <code>h</code> parameters to specify
  * half of the shape's width and height.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Attributes
  * @method rectMode
- * @param {String} mode The rectMode to switch to: either CORNER, CORNERS, CENTER, or RADIUS.
+ * @param  {String} mode The rectMode to switch to: either CORNER, CORNERS, CENTER, or RADIUS.
  *
  */
 pub.rectMode = function (mode) {
@@ -4878,7 +4883,7 @@ pub.rectMode = function (mode) {
 };
 
 /**
- * The origin of new ellipses is modified by the <code>ellipseMode()</code> function.
+ * @description The origin of new ellipses is modified by the <code>ellipseMode()</code> function.
  * The default configuration is <code>ellipseMode(CENTER)</code>, which specifies the
  * location of the ellipse as the center of the shape. The RADIUS mode is
  * the same, but the <code>w</code> and <code>h</code> parameters to <code>ellipse()</code> specify the
@@ -4887,10 +4892,10 @@ pub.rectMode = function (mode) {
  * mode uses the four parameters to <code>ellipse()</code> to set two opposing corners
  * of the ellipse's bounding box.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Attributes
  * @method ellipseMode
- * @param {String} mode The ellipse mode to switch to: either CENTER, RADIUS, CORNER, or CORNERS.
+ * @param  {String} mode The ellipse mode to switch to: either CENTER, RADIUS, CORNER, or CORNERS.
  */
 pub.ellipseMode = function (mode) {
   if (arguments.length === 0) return currEllipseMode;
@@ -4903,12 +4908,12 @@ pub.ellipseMode = function (mode) {
 };
 
 /**
- * Sets the width of the stroke used for lines and the border around shapes.
+ * @description Sets the width of the stroke used for lines and the border around shapes.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Attributes
  * @method strokeWeight
- * @param {Number} weight The width of the stroke in points.
+ * @param  {Number} weight The width of the stroke in points.
  */
 pub.strokeWeight = function (weight) {
   if (typeof weight === "string" || typeof weight === "number") {
@@ -4919,14 +4924,14 @@ pub.strokeWeight = function (weight) {
 };
 
 /**
- * Returns the object style of a given page item or the object style with the given name. If an
+ * @description Returns the object style of a given page item or the object style with the given name. If an
  * object style of the given name does not exist, it gets created. Optionally a props object of
  * property name/value pairs can be used to set the object style's properties.
  *
- * @cat Typography
+ * @cat    Typography
  * @method objectStyle
  * @param  {PageItem|String} itemOrName A page item whose style to return or the name of the object style to return.
- * @param {Object} [props] An object of property name/value pairs to set the style's properties.
+ * @param  {Object} [props] An object of property name/value pairs to set the style's properties.
  * @return {ObjectStyle} The object style instance.
  */
 pub.objectStyle = function(itemOrName, props) {
@@ -4962,13 +4967,13 @@ pub.objectStyle = function(itemOrName, props) {
 };
 
 /**
- * Applies an object style to the given page item. The object style can be given as
+ * @description Applies an object style to the given page item. The object style can be given as
  * name or as an object style instance.
  *
- * @cat Typography
+ * @cat    Typography
  * @method applyObjectStyle
  * @param  {PageItem} item The page item to apply the style to.
- * @param {ObjectStyle|String} style An object style instance or the name of the object style to apply.
+ * @param  {ObjectStyle|String} style An object style instance or the name of the object style to apply.
  * @return {PageItem} The page item that the style was applied to.
  */
 
@@ -4992,13 +4997,13 @@ pub.applyObjectStyle = function(item, style) {
 };
 
 /**
- * Duplicates the given page after the current page or the given page item to the current page and layer. Use <code>rectMode()</code> to set center point.
+ * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use <code>rectMode()</code> to set center point.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method duplicate
- * @param {PageItem|Page} item The page item or page to duplicate.
- * @returns {Object} The new page item or page.
+ * @param  {PageItem|Page} item The page item or page to duplicate.
+ * @return {Object} The new page item or page.
  */
 pub.duplicate = function(item) {
 
@@ -5025,8 +5030,9 @@ pub.duplicate = function(item) {
 // ----------------------------------------
 
 /**
- * Sets the color or gradient used to fill shapes.
- * @cat Color
+ * @description Sets the color or gradient used to fill shapes.
+ *
+ * @cat    Color
  * @method fill
  * @param  {Color|Gradient|Swatch|Numbers|String} fillColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
  * @param  {String} [name] If created with numbers, a custom swatch name can be given.
@@ -5063,10 +5069,10 @@ pub.fill = function (fillColor) {
 };
 
 /**
- * Disables filling geometry. If both noStroke() and noFill() are called,
+ * @description Disables filling geometry. If both noStroke() and noFill() are called,
  * newly drawn shapes will be invisible.
  *
- * @cat Color
+ * @cat    Color
  * @method noFill
  */
 pub.noFill = function () {
@@ -5074,10 +5080,11 @@ pub.noFill = function () {
 };
 
 /**
- * Sets the color or gradient used to draw lines and borders around shapes.
+ * @description Sets the color or gradient used to draw lines and borders around shapes.
+ *
  * @cat Color
  * @method stroke
- * @param  {Color|Gradient|Swatch|Numbers|String} strokeColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
+ * @param {Color|Gradient|Swatch|Numbers|String} strokeColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
  */
 pub.stroke = function (strokeColor) {
   checkNull(strokeColor);
@@ -5110,10 +5117,10 @@ pub.stroke = function (strokeColor) {
 };
 
 /**
- * Disables drawing the stroke. If both noStroke() and noFill() are called,
+ * @description Disables drawing the stroke. If both noStroke() and noFill() are called,
  * newly drawn shapes will be invisible.
  *
- * @cat Color
+ * @cat    Color
  * @method noStroke
  */
 pub.noStroke = function () {
@@ -5121,9 +5128,9 @@ pub.noStroke = function () {
 };
 
 /**
- * Sets the tint of the color used to fill shapes.
+ * @description Sets the tint of the color used to fill shapes.
  *
- * @cat Color
+ * @cat    Color
  * @method fillTint
  * @param  {Number} tint Number from 0 to 100
  */
@@ -5137,9 +5144,9 @@ pub.fillTint = function (tint) {
 };
 
 /**
- * Sets the tint of the color used to draw lines and borders around shapes.
+ * @description Sets the tint of the color used to draw lines and borders around shapes.
  *
- * @cat Color
+ * @cat    Color
  * @method strokeTint
  * @param  {Number} tint Number from 0 to 100.
  */
@@ -5153,9 +5160,9 @@ pub.strokeTint = function (tint) {
 };
 
 /**
- * Sets the colormode for creating new colors with color() to RGB or CMYK. The default color mode is RGB.
+ * @description Sets the colormode for creating new colors with color() to RGB or CMYK. The default color mode is RGB.
  *
- * @cat Color
+ * @cat    Color
  * @method colorMode
  * @param  {Number} colorMode RGB or CMYK.
  */
@@ -5172,9 +5179,9 @@ pub.colorMode = function(colorMode) {
 };
 
 /**
- * Sets the gradient mode for gradient() to LINEAR or RADIAL. The default gradient mode is LINEAR.
+ * @description Sets the gradient mode for gradient() to LINEAR or RADIAL. The default gradient mode is LINEAR.
  *
- * @cat Color
+ * @cat    Color
  * @method gradientMode
  * @param  {String} gradientMode LINEAR or RADIAL.
  */
@@ -5191,11 +5198,11 @@ pub.gradientMode = function(gradientMode) {
 };
 
 /**
- * Gets a swatch by name.
+ * @description Gets a swatch by name.
  *
- * @cat Color
+ * @cat    Color
  * @method swatch
- * @param {String} swatchName Returns the swatch color/gradient for a given name by string.
+ * @param  {String} swatchName Returns the swatch color/gradient for a given name by string.
  */
 pub.swatch = function(){
   var newSwatch;
@@ -5216,9 +5223,9 @@ pub.swatch = function(){
 }
 
 /**
- * Creates a new RGB / CMYK color and adds it to the document, or gets a color by name from the document. The default color mode is RGB.
+ * @description Creates a new RGB / CMYK color and adds it to the document, or gets a color by name from the document. The default color mode is RGB.
  *
- * @cat Color
+ * @cat    Color
  * @method color
  * @param  {String|Numbers} Get color: the color name. Create new color: GRAY,[name] / R,G,B,[name] / C,M,Y,K,[name]. Name is always optional.
  * @return {Color} Found or new color
@@ -5352,18 +5359,18 @@ pub.color = function() {
 };
 
 /**
- * Creates a new gradient and adds it to the document, or gets a gradient by name from the document.
+ * @description Creates a new gradient and adds it to the document, or gets a gradient by name from the document.<br>
  * If two colors are given as the first two parameters, a gradient is created that blends between these two colors. If an array of colors is used
  * as the first parameter, a gradient with the contained colors will be created. The colors will be distributed evenly. If additionally to this array
  * a second array of gradient stop positions is given, the colors will be positioned at the given gradient stops. Possible gradient stop positions
  * range from 0 to 100. All parameter options allow for an additional name parameter at the end to name the new gradient.
  * If a string is used as the only parameter, the gradient with that name will be returned, if it exists in the document.
  *
- * @cat Color
+ * @cat    Color
  * @method gradient
- * @param {Color|Array|String} c1 First color of the gradient. Alternatively: Array of colors/gradients or name of gradient to get.
- * @param {Color|Array|String} c2 Second color of the gradient. Alternatively: Array of gradient stop positions (if first parameter is an array of colors).
- * @param {String} [name] Optional name of the gradient.
+ * @param  {Color|Array|String} c1 First color of the gradient. Alternatively: Array of colors/gradients or name of gradient to get.
+ * @param  {Color|Array|String} c2 Second color of the gradient. Alternatively: Array of gradient stop positions (if first parameter is an array of colors).
+ * @param  {String} [name] Optional name of the gradient.
  * @return {Gradient} Found or new gradient
  */
 pub.gradient = function() {
@@ -5468,9 +5475,9 @@ pub.gradient = function() {
 };
 
 /**
- * Sets the opacity property of an object.
+ * @description Sets the opacity property of an object.
  *
- * @cat Color
+ * @cat    Color
  * @method opacity
  * @param  {Object} obj The object to set opacity of.
  * @param  {Number} opacity The opacity value from 0 to 100.
@@ -5485,28 +5492,28 @@ pub.opacity = function(obj, opacity) {
 };
 
 /**
- * Sets the Effects blendMode property of an object.
+ * @description Sets the Effects blendMode property of an object.
  *
- * @cat Color
+ * @cat    Color
  * @method blendMode
  * @param  {Object} obj The object to set blendMode of.
  * @param  {Number} blendMode The blendMode must be one of the InDesign BlendMode enum values:
- *                           BlendMode.NORMAL <br />
- *                           BlendMode.MULTIPLY <br />
- *                           BlendMode.SCREEN <br />
- *                           BlendMode.OVERLAY <br />
- *                           BlendMode.SOFT_LIGHT <br />
- *                           BlendMode.HARD_LIGHT <br />
- *                           BlendMode.COLOR_DODGE <br />
- *                           BlendMode.COLOR_BURN <br />
- *                           BlendMode.DARKEN <br />
- *                           BlendMode.LIGHTEN <br />
- *                           BlendMode.DIFFERENCE <br />
- *                           BlendMode.EXCLUSION <br />
- *                           BlendMode.HUE <br />
- *                           BlendMode.SATURATION <br />
- *                           BlendMode.COLOR <br />
- *                           BlendMode.LUMINOSITY <br />
+ *                           BlendMode.NORMAL<br>
+ *                           BlendMode.MULTIPLY<br>
+ *                           BlendMode.SCREEN<br>
+ *                           BlendMode.OVERLAY<br>
+ *                           BlendMode.SOFT_LIGHT<br>
+ *                           BlendMode.HARD_LIGHT<br>
+ *                           BlendMode.COLOR_DODGE<br>
+ *                           BlendMode.COLOR_BURN<br>
+ *                           BlendMode.DARKEN<br>
+ *                           BlendMode.LIGHTEN<br>
+ *                           BlendMode.DIFFERENCE<br>
+ *                           BlendMode.EXCLUSION<br>
+ *                           BlendMode.HUE<br>
+ *                           BlendMode.SATURATION<br>
+ *                           BlendMode.COLOR<br>
+ *                           BlendMode.LUMINOSITY<br>
  */
 pub.blendMode = function(obj, blendMode) {
   checkNull(obj);
@@ -5518,11 +5525,11 @@ pub.blendMode = function(obj, blendMode) {
 };
 
 /**
- * Calculates a color or colors between two colors at a specific increment.
+ * @description Calculates a color or colors between two colors at a specific increment.<br>
  * The amt parameter is the amount to interpolate between the two values where 0.0 equals the first color, 0.5 is half-way in between and 1.0 equals the second color.
  * N.B.: Both colors must be either CMYK or RGB.
  *
- * @cat Color
+ * @cat    Color
  * @method lerpColor
  * @param  {Color} c1   Input color 1.
  * @param  {Color} c2   Input color 2.
@@ -5579,7 +5586,7 @@ pub.lerpColor = function (c1, c2, amt) {
 // ----------------------------------------
 
 /**
- * Creates a text frame on the current layer on the current page in the current document.
+ * @description Creates a text frame on the current layer on the current page in the current document.
  * The text frame gets created in the position specified by the x and y parameters.
  * The default document font will be used unless a font is set with the textFont() function.
  * The default document font size will be used unless a font size is set with the textSize() function.
@@ -5587,7 +5594,7 @@ pub.lerpColor = function (c1, c2, amt) {
  * The text displays in relation to the textAlign() and textYAlign() functions.
  * The width and height parameters define a rectangular area.
  *
- * @cat Typography
+ * @cat    Typography
  * @method text
  * @param  {String} txt The text content to set in the text frame.
  * @param  {Number} x   x-coordinate of text frame
@@ -5657,14 +5664,14 @@ pub.text = function(txt, x, y, w, h) {
 };
 
 /**
- * Sets text properties to the given item. If the item is not an instance the text property can be set to,
+ * @description Sets text properties to the given item. If the item is not an instance the text property can be set to,
  * the property gets set to the direct descendants of the given item, e.g. all stories of a given document.
- *
+ * <br><br>
  * If no value is given and the given property is a string, the function acts as a getter and returns the
  * corresponding value(s) in an array. This can either be an array containing the value of the concrete item
  * (e.g. character) the values of the item's descendants (e.g. paragraphs of given text frame).
  *
- * @cat Typography
+ * @cat    Typography
  * @method typo
  * @param  {Document|Spread|Page|Layer|Story|TextFrame|Text} item  The object to apply the property to.
  * @param  {String|Object} property  The text property name or an object of key/value property/value pairs.
@@ -5744,9 +5751,9 @@ var isValid = function (item) {
 };
 
 /**
- * Returns the current font and sets it if argument fontName is given.
+ * @description Returns the current font and sets it if argument fontName is given.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textFont
  * @param  {String} [fontName] The name of the font to set e.g. Helvetica
  * @param  {String} [fontStyle] The font style e.g. Bold
@@ -5775,9 +5782,9 @@ pub.textFont = function(fontName, fontStyle) {
 };
 
 /**
- * Returns the current font size in points and sets it if argument pointSize is given.
+ * @description Returns the current font size in points and sets it if argument pointSize is given.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textSize
  * @param  {Number} [pointSize] The size in points to set.
  * @return {Number}             The current point size.
@@ -5790,24 +5797,24 @@ pub.textSize = function(pointSize) {
 };
 
 /**
- * Sets the current horizontal and vertical text alignment.
+ * @description Sets the current horizontal and vertical text alignment.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textAlign
  * @param  {String} align    The horizontal text alignment to set. Must be one of the InDesign Justification enum values:
- *                           Justification.AWAY_FROM_BINDING_SIDE <br />
- *                           Justification.CENTER_ALIGN <br />
- *                           Justification.CENTER_JUSTIFIED <br />
- *                           Justification.FULLY_JUSTIFIED <br />
- *                           Justification.LEFT_ALIGN <br />
- *                           Justification.RIGHT_ALIGN <br />
- *                           Justification.RIGHT_JUSTIFIED <br />
- *                           Justification.TO_BINDING_SIDE <br />
+ *                           Justification.AWAY_FROM_BINDING_SIDE<br>
+ *                           Justification.CENTER_ALIGN<br>
+ *                           Justification.CENTER_JUSTIFIED<br>
+ *                           Justification.FULLY_JUSTIFIED<br>
+ *                           Justification.LEFT_ALIGN<br>
+ *                           Justification.RIGHT_ALIGN<br>
+ *                           Justification.RIGHT_JUSTIFIED<br>
+ *                           Justification.TO_BINDING_SIDE<br>
  * @param  {String} [yAlign] The vertical text alignment to set. Must be one of the InDesign VerticalJustification enum values:
- *                           VerticalJustification.BOTTOM_ALIGN <br />
- *                           VerticalJustification.CENTER_ALIGN <br />
- *                           VerticalJustification.JUSTIFY_ALIGN <br />
- *                           VerticalJustification.TOP_ALIGN <br />
+ *                           VerticalJustification.BOTTOM_ALIGN<br>
+ *                           VerticalJustification.CENTER_ALIGN<br>
+ *                           VerticalJustification.JUSTIFY_ALIGN<br>
+ *                           VerticalJustification.TOP_ALIGN<br>
  */
 pub.textAlign = function(align, yAlign) {
   currAlign = align;
@@ -5815,9 +5822,9 @@ pub.textAlign = function(align, yAlign) {
 };
 
 /**
- * Returns the spacing between lines of text in units of points and sets it if argument leading is given.
+ * @description Returns the spacing between lines of text in units of points and sets it if argument leading is given.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textLeading
  * @param  {Number|String} [leading] The spacing between lines of text in units of points or the default InDesign enum
  *                                   value Leading.AUTO.
@@ -5831,9 +5838,9 @@ pub.textLeading = function(leading) {
 };
 
 /**
- * Returns the current kerning and sets it if argument kerning is given.
+ * @description Returns the current kerning and sets it if argument kerning is given.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textKerning
  * @param  {Number} [kerning] The value to set.
  * @return {Number}           The current kerning.
@@ -5846,9 +5853,9 @@ pub.textKerning = function(kerning) {
 };
 
 /**
- * Returns the current tracking and sets it if argument tracking is given.
+ * @description Returns the current tracking and sets it if argument tracking is given.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textTracking
  * @param  {Number} [tracking] The value to set.
  * @return {Number}            The current tracking.
@@ -5861,14 +5868,14 @@ pub.textTracking = function(tracking) {
 };
 
 /**
- * Returns the character style of a given text object or the character style with the given name. If a
+ * @description Returns the character style of a given text object or the character style with the given name. If a
  * character style of the given name does not exist, it gets created. Optionally a props object of
  * property name/value pairs can be used to set the character style's properties.
  *
- * @cat Typography
+ * @cat    Typography
  * @method characterStyle
  * @param  {Text|String} textOrName  A text object whose style to return or the name of the character style to return.
- * @param {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
+ * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
  * @return {CharacterStyle}  The character style instance.
  */
 pub.characterStyle = function(textOrName, props) {
@@ -5904,13 +5911,13 @@ pub.characterStyle = function(textOrName, props) {
 };
 
 /**
- * Applies a character style to the given text object, text frame or story. The character style
+ * @description Applies a character style to the given text object, text frame or story. The character style
  * can be given as name or as character style instance.
  *
- * @cat Typography
+ * @cat    Typography
  * @method applyCharacterStyle
  * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
- * @param {CharacterStyle|String} style  A character style instance or the name of the character style to apply.
+ * @param  {CharacterStyle|String} style  A character style instance or the name of the character style to apply.
  * @return {Text}  The text that the style was applied to.
  */
 
@@ -5938,14 +5945,14 @@ pub.applyCharacterStyle = function(text, style) {
 };
 
 /**
- * Returns the paragraph style of a given text object or the paragraph style with the given name. If a
+ * @description Returns the paragraph style of a given text object or the paragraph style with the given name. If a
  * paragraph style of the given name does not exist, it gets created. Optionally a props object of
  * property name/value pairs can be used to set the paragraph style's properties.
  *
- * @cat Typography
+ * @cat    Typography
  * @method paragraphStyle
  * @param  {Text|String} textOrName  A text object whose style to return or the name of the paragraph style to return.
- * @param {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
+ * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
  * @return {ParagraphStyle}  The paragraph style instance.
  */
 pub.paragraphStyle = function(textOrName, props) {
@@ -5981,13 +5988,13 @@ pub.paragraphStyle = function(textOrName, props) {
 };
 
 /**
- * Applies a paragraph style to the given text object, text frame or story. The paragraph style
+ * @description Applies a paragraph style to the given text object, text frame or story. The paragraph style
  * can be given as name or as paragraph style instance.
  *
- * @cat Typography
+ * @cat    Typography
  * @method applyParagraphStyle
  * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
- * @param {ParagraphStyle|String} style  A paragraph style instance or the name of the paragraph style to apply.
+ * @param  {ParagraphStyle|String} style  A paragraph style instance or the name of the paragraph style to apply.
  * @return {Text}  The text that the style was applied to.
  */
 
@@ -6015,9 +6022,9 @@ pub.applyParagraphStyle = function(text, style) {
 };
 
 /**
- * Links the stories of two textframes to one story. Text of first textframe overflows to second one.
+ * @description Links the stories of two textframes to one story. Text of first textframe overflows to second one.
  *
- * @cat Story
+ * @cat    Story
  * @method linkTextFrames
  * @param  {TextFrame} textFrameA
  * @param  {TextFrame} textFrameB
@@ -6031,9 +6038,9 @@ pub.linkTextFrames = function (textFrameA, textFrameB) {
 };
 
 /**
- * Fills the given textFrame and all linked textFrame with random placeholder text. The placeholder text will be added at the end of any already existing text in the text frame.
+ * @description Fills the given textFrame and all linked textFrame with random placeholder text. The placeholder text will be added at the end of any already existing text in the text frame.
  *
- * @cat Story
+ * @cat    Story
  * @method placeholder
  * @param  {TextFrame} textFrame
  * @return {Text} The inserted placeholder text.
@@ -6053,14 +6060,14 @@ pub.placeholder = function (textFrame) {
 // ----------------------------------------
 
 /**
- * Adds an image to the document. If the image argument is given as a string the image file must be in the document's
+ * @description Adds an image to the document. If the image argument is given as a string the image file must be in the document's
  * data directory which is in the same directory where the document is saved in. The image argument can also be a File
  * instance which can be placed even before the document was saved.
  * The second argument can either be the x position of the frame to create or an instance of a rectangle,
  * oval or polygon to place the image in. If an x position is given, a y position must be given, too.
  * If x and y positions are given and width and height are not given, the frame's size gets set to the original image size.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Image
  * @method image
  * @param  {String|File} img The image file name in the document's data directory or a File instance.
@@ -6150,13 +6157,13 @@ pub.image = function(img, x, y, w, h) {
 };
 
 /**
- * Modifies the location from which images draw. The default mode is imageMode(CORNER), which specifies the location to be the upper left corner and uses the fourth and fifth parameters of image() to set the image's width and height. The syntax imageMode(CORNERS) uses the second and third parameters of image() to set the location of one corner of the image and uses the fourth and fifth parameters to set the opposite corner. Use imageMode(CENTER) to draw images centered at the given x and y position.
+ * @description Modifies the location from which images draw. The default mode is imageMode(CORNER), which specifies the location to be the upper left corner and uses the fourth and fifth parameters of image() to set the image's width and height. The syntax imageMode(CORNERS) uses the second and third parameters of image() to set the location of one corner of the image and uses the fourth and fifth parameters to set the opposite corner. Use imageMode(CENTER) to draw images centered at the given x and y position.
  * If no parameter is passed the currently set mode is returned as String.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Image
  * @method imageMode
- * @param {String} [mode] Either CORNER, CORNERS, or CENTER.
+ * @param  {String} [mode] Either CORNER, CORNERS, or CENTER.
  * @return {String} The current mode.
  */
 pub.imageMode = function(mode) {
@@ -6177,17 +6184,17 @@ pub.imageMode = function(mode) {
 var Vector = pub.Vector = function() {
 
   /**
-   * A class to describe a two or three dimensional vector. This datatype stores two or three variables that are commonly used as a position, velocity, and/or acceleration. Technically, position is a point and velocity and acceleration are vectors, but this is often simplified to consider all three as vectors. For example, if you consider a rectangle moving across the screen, at any given instant it has a position (the object's location, expressed as a point.), a velocity (the rate at which the object's position changes per time unit, expressed as a vector), and acceleration (the rate at which the object's velocity changes per time unit, expressed as a vector). Since vectors represent groupings of values, we cannot simply use traditional addition/multiplication/etc. Instead, we'll need to do some "vector" math, which is made easy by the methods inside the Vector class.
-   *
+   * @description A class to describe a two or three dimensional vector. This datatype stores two or three variables that are commonly used as a position, velocity, and/or acceleration. Technically, position is a point and velocity and acceleration are vectors, but this is often simplified to consider all three as vectors. For example, if you consider a rectangle moving across the screen, at any given instant it has a position (the object's location, expressed as a point.), a velocity (the rate at which the object's position changes per time unit, expressed as a vector), and acceleration (the rate at which the object's velocity changes per time unit, expressed as a vector). Since vectors represent groupings of values, we cannot simply use traditional addition/multiplication/etc. Instead, we'll need to do some "vector" math, which is made easy by the methods inside the Vector class.
+   * <br><br>
    * Constructor of Vector, can be two- or three-dimensional.
    *
-   * @constructor
-   * @cat Math
+   * @cat    Math
    * @subcat Vector
    * @method Vector
-   * @param {Number} x The first vector.
-   * @param {Number} y The second vector.
-   * @param {Number} [z] The third vector.
+   * @param  {Number} x The first vector.
+   * @param  {Number} y The second vector.
+   * @param  {Number} [z] The third vector.
+   * @constructor
    */
   function Vector(x, y, z) {
     this.x = x || 0;
@@ -6195,60 +6202,64 @@ var Vector = pub.Vector = function() {
     this.z = z || 0;
   }
   /**
-   * Static function. Calculates the Euclidean distance between two points (considering a point as a vector object).
+   * @description Static function. Calculates the Euclidean distance between two points (considering a point as a vector object).
    * Is meant to be called "static" i.e. Vector.dist(v1, v2);
-   * @cat Math
+   *
+   * @cat    Math
    * @subcat Vector
    * @method Vector.dist
-   * @static
-   * @param {Vector} v1 The first vector.
-   * @param {Vector} v2 The second vector.
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
    * @return {Number} The distance.
+   * @static
    */
   Vector.dist = function(v1, v2) {
     return v1.dist(v2);
   };
 
   /**
-   * Static function. Calculates the dot product of two vectors.
+   * @description Static function. Calculates the dot product of two vectors.
    * Is meant to be called "static" i.e. Vector.dot(v1, v2);
-   * @method Vector.dot
-   * @cat Math
+   *
+   * @cat    Math
    * @subcat Vector
-   * @static
-   * @param {Vector} v1 The first vector.
-   * @param {Vector} v2 The second vector.
+   * @method Vector.dot
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
    * @return {Number} The dot product.
+   * @static
    */
   Vector.dot = function(v1, v2) {
     return v1.dot(v2);
   };
 
   /**
-   * Static function. Calculates the cross product of two vectors.
+   * @description Static function. Calculates the cross product of two vectors.
    * Is meant to be called "static" i.e. Vector.cross(v1, v2);
-   * @method Vector.cross
-   * @cat Math
+   *
+   * @cat    Math
    * @subcat Vector
-   * @static
-   * @param {Vector} v1 The first vector.
-   * @param {Vector} v2 The second vector.
+   * @method Vector.cross
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
    * @return {Number} The cross product.
+   * @static
    */
   Vector.cross = function(v1, v2) {
     return v1.cross(v2);
   };
 
   /**
-   * Static function. Calculates the angle between two vectors.
+   * @description Static function. Calculates the angle between two vectors.
    * Is meant to be called "static" i.e. Vector.angleBetween(v1, v2);
-   * @method Vector.angleBetween
-   * @cat Math
+   *
+   * @cat    Math
    * @subcat Vector
-   * @static
-   * @param {Vector} v1 The first vector.
-   * @param {Vector} v2 The second vector.
+   * @method Vector.angleBetween
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
    * @return {Number} The angle.
+   * @static
    */
   Vector.angleBetween = function(v1, v2) {
     return Math.acos(v1.dot(v2) / (v1.mag() * v2.mag()));
@@ -6257,13 +6268,14 @@ var Vector = pub.Vector = function() {
   Vector.prototype = {
 
     /**
-     * Sets the x, y, and z component of the vector using three separate variables, the data from a Vector, or the values from a float array.
-     * @method Vector.set
-     * @cat Math
+     * @description Sets the x, y, and z component of the vector using three separate variables, the data from a Vector, or the values from a float array.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Number|Array|Vector} v Either a vector, array or x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.set
+     * @param  {Number|Array|Vector} v Either a vector, array or x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      */
     set: function(v, y, z) {
       if (arguments.length === 1) this.set(v.x || v[0] || 0, v.y || v[1] || 0, v.z || v[2] || 0);
@@ -6274,20 +6286,22 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * Gets a copy of the vector, returns a Vector object.
-     * @method Vector.get
-     * @cat Math
+     * @description Gets a copy of the vector, returns a Vector object.
+     *
+     * @cat    Math
      * @subcat Vector
+     * @method Vector.get
      * @return {Vector} A copy of the vector.
      */
     get: function() {
       return new Vector(this.x, this.y, this.z);
     },
     /**
-     * Calculates the magnitude (length) of the vector and returns the result as a float
-     * @method Vector.mag
-     * @cat Math
+     * @description Calculates the magnitude (length) of the vector and returns the result as a float
+     *
+     * @cat    Math
      * @subcat Vector
+     * @method Vector.mag
      * @return {Number} The length.
      */
     mag: function() {
@@ -6297,13 +6311,14 @@ var Vector = pub.Vector = function() {
       return Math.sqrt(x * x + y * y + z * z);
     },
     /**
-     * Adds x, y, and z components to a vector, adds one vector to another.
-     * @method Vector.add
-     * @cat Math
+     * @description Adds x, y, and z components to a vector, adds one vector to another.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.add
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      */
     add: function(v, y, z) {
       if (arguments.length === 1) {
@@ -6317,13 +6332,14 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * Substract x, y, and z components or a full vector from this vector
-     * @method Vector.sub
-     * @cat Math
+     * @description Substract x, y, and z components or a full vector from this vector
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.sub
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      */
     sub: function(v, y, z) {
       if (arguments.length === 1) {
@@ -6337,13 +6353,14 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * Multiplies this vector with x, y, and z components or another vector.
-     * @method Vector.mult
-     * @cat Math
+     * @description Multiplies this vector with x, y, and z components or another vector.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.mult
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      */
     mult: function(v) {
       if (typeof v === "number") {
@@ -6357,13 +6374,14 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * Divides this vector through x, y, and z components or another vector.
-     * @method Vector.div
-     * @cat Math
+     * @description Divides this vector through x, y, and z components or another vector.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.div
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      */
     div: function(v) {
       if (typeof v === "number") {
@@ -6377,13 +6395,14 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * Calculates the distance from this vector to another as x, y, and z components or full vector.
-     * @method Vector.dist
-     * @cat Math
+     * @description Calculates the distance from this vector to another as x, y, and z components or full vector.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.dist
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      * @return {Number} The distance.
      */
     dist: function(v) {
@@ -6393,13 +6412,14 @@ var Vector = pub.Vector = function() {
       return Math.sqrt(dx * dx + dy * dy + dz * dz);
     },
     /**
-     * Calculates the dot product from this vector to another as x, y, and z components or full vector.
-     * @method Vector.dot
-     * @cat Math
+     * @description Calculates the dot product from this vector to another as x, y, and z components or full vector.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.dot
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      * @return {Number} The dot product.
      */
     dot: function(v, y, z) {
@@ -6407,13 +6427,14 @@ var Vector = pub.Vector = function() {
       return this.x * v + this.y * y + this.z * z;
     },
     /**
-     * Calculates the cross product from this vector to another as x, y, and z components or full vector.
-     * @method Vector.cross
-     * @cat Math
+     * @description Calculates the cross product from this vector to another as x, y, and z components or full vector.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.cross
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      * @return {Number} The cross product.
      */
     cross: function(v) {
@@ -6423,8 +6444,9 @@ var Vector = pub.Vector = function() {
       return new Vector(y * v.z - v.y * z, z * v.x - v.z * x, x * v.y - v.x * y);
     },
     /**
-     * Normalizes the length of this vector to 1.
-     * @cat Math
+     * @description Normalizes the length of this vector to 1.
+     *
+     * @cat    Math
      * @subcat Vector
      * @method Vector.normalize
      */
@@ -6433,11 +6455,12 @@ var Vector = pub.Vector = function() {
       if (m > 0) this.div(m);
     },
     /**
-     * Normalizes the length of this vector to the given parameter.
-     * @method Vector.limit
-     * @cat Math
+     * @description Normalizes the length of this vector to the given parameter.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Number} high The value to scale to.
+     * @method Vector.limit
+     * @param  {Number} high The value to scale to.
      */
     limit: function(high) {
       if (this.mag() > high) {
@@ -6446,30 +6469,33 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * The 2D orientation (heading) of this vector in radian.
-     * @method Vector.heading
-     * @cat Math
+     * @description The 2D orientation (heading) of this vector in radian.
+     *
+     * @cat    Math
      * @subcat Vector
+     * @method Vector.heading
      * @return {Number} A radian angle value.
      */
     heading: function() {
       return -Math.atan2(-this.y, this.x);
     },
     /**
-     * Returns data about this vector as a string.
-     * @method Vector.toString
-     * @cat Math
+     * @description Returns data about this vector as a string.
+     *
+     * @cat    Math
      * @subcat Vector
+     * @method Vector.toString
      * @return {String} The x, y and z components as a string.
      */
     toString: function() {
       return "[" + this.x + ", " + this.y + ", " + this.z + "]";
     },
     /**
-     * Returns this vector as an array [x,y,z].
-     * @method Vector.array
-     * @cat Math
+     * @description Returns this vector as an array [x,y,z].
+     *
+     * @cat    Math
      * @subcat Vector
+     * @method Vector.array
      * @return {Array} The x, y and z components as  an Array of [x,y,z].
      */
     array: function() {
@@ -6492,36 +6518,36 @@ var Vector = pub.Vector = function() {
 // -- Calculation --
 
 /**
- * Calculates the absolute value (magnitude) of a number. The absolute value of a number is always positive.
+ * @description Calculates the absolute value (magnitude) of a number. The absolute value of a number is always positive.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method abs
- * @param {Number} val A number.
+ * @param  {Number} val A number.
  * @return {Number} The absolute value of that number.
  */
 pub.abs = Math.abs;
 
 /**
- * Calculates the closest int value that is greater than or equal to the value of the parameter. For example, ceil(9.03) returns the value 10.
+ * @description Calculates the closest int value that is greater than or equal to the value of the parameter. For example, ceil(9.03) returns the value 10.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method ceil
- * @param {Number} val An arbitrary number.
+ * @param  {Number} val An arbitrary number.
  * @return {Number} The next highest integer value.
  */
 pub.ceil = Math.ceil;
 
 /**
- * Constrains a value to not exceed a maximum and minimum value.
+ * @description Constrains a value to not exceed a maximum and minimum value.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method constrain
- * @param {Number} aNumber The value to constrain.
- * @param {Number} aMin Minimum limit.
- * @param {Number} aMax Maximum limit.
+ * @param  {Number} aNumber The value to constrain.
+ * @param  {Number} aMin Minimum limit.
+ * @param  {Number} aMax Maximum limit.
  * @return {Number} The constrained value.
  */
 pub.constrain = function(aNumber, aMin, aMax) {
@@ -6532,15 +6558,15 @@ pub.constrain = function(aNumber, aMin, aMax) {
 };
 
 /**
- * Calculates the distance between two points.
+ * @description Calculates the distance between two points.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method dist
- * @param {Number} x1 The x-coordinate of the first point.
- * @param {Number} y1 The y-coordinate of the first point.
- * @param {Number} x2 The x-coordinate of the second point.
- * @param {Number} y2 The y-coordinate of the second point.
+ * @param  {Number} x1 The x-coordinate of the first point.
+ * @param  {Number} y1 The y-coordinate of the first point.
+ * @param  {Number} x2 The x-coordinate of the second point.
+ * @param  {Number} y2 The y-coordinate of the second point.
  * @return {Number} The distance.
  */
 pub.dist = function() {
@@ -6555,36 +6581,36 @@ pub.dist = function() {
 };
 
 /**
- * The Math.exp() function returns ex, where x is the argument, and e is Euler's number (also known as Napier's constant), the base of the natural logarithms.
+ * @description The Math.exp() function returns ex, where x is the argument, and e is Euler's number (also known as Napier's constant), the base of the natural logarithms.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method exp
- * @param {Number} x A number.
+ * @param  {Number} x A number.
  * @return {Number} A number representing ex.
  */
 pub.exp = Math.exp;
 
 /**
- * Calculates the closest int value that is less than or equal to the value of the parameter.
+ * @description Calculates the closest int value that is less than or equal to the value of the parameter.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method floor
- * @param {Number} a A number.
+ * @param  {Number} a A number.
  * @return {Number} Integer number.
  */
 pub.floor = Math.floor;
 
 /**
- * Calculates a number between two numbers at a specific increment. The amt parameter is the amount to interpolate between the two values where 0.0 equal to the first point, 0.1 is very near the first point, 0.5 is half-way in between, etc. The lerp function is convenient for creating motion along a straight path and for drawing dotted lines.
+ * @description Calculates a number between two numbers at a specific increment. The amt parameter is the amount to interpolate between the two values where 0.0 equal to the first point, 0.1 is very near the first point, 0.5 is half-way in between, etc. The lerp function is convenient for creating motion along a straight path and for drawing dotted lines.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method lerp
- * @param {Number} value1 First value.
- * @param {Number} value2 Second value.
- * @param {Number} amt Amount between 0.0 and 1.0.
+ * @param  {Number} value1 First value.
+ * @param  {Number} value2 Second value.
+ * @param  {Number} amt Amount between 0.0 and 1.0.
  * @return {Number} The mapped value.
  */
 pub.lerp = function(value1, value2, amt) {
@@ -6593,25 +6619,25 @@ pub.lerp = function(value1, value2, amt) {
 };
 
 /**
- * Calculates the natural logarithm (the base-e logarithm) of a number. This function expects the values greater than 0.0.
+ * @description Calculates the natural logarithm (the base-e logarithm) of a number. This function expects the values greater than 0.0.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method log
- * @param {Number} x A number, must be greater then 0.0.
+ * @param  {Number} x A number, must be greater then 0.0.
  * @return {Number} The natural logarithm.
  */
 pub.log = Math.log;
 
 /**
- * Calculates the magnitude (or length) of a vector. A vector is a direction in space commonly used in computer graphics and linear algebra. Because it has no "start" position, the magnitude of a vector can be thought of as the distance from coordinate (0,0) to its (x,y) value. Therefore, mag() is a shortcut for writing "dist(0, 0, x, y)".
+ * @description Calculates the magnitude (or length) of a vector. A vector is a direction in space commonly used in computer graphics and linear algebra. Because it has no "start" position, the magnitude of a vector can be thought of as the distance from coordinate (0,0) to its (x,y) value. Therefore, mag() is a shortcut for writing "dist(0, 0, x, y)".
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method mag
- * @param {Number} x Coordinate.
- * @param {Number} y Coordinate.
- * @param {Number} [z] Coordinate, optional.
+ * @param  {Number} x Coordinate.
+ * @param  {Number} y Coordinate.
+ * @param  {Number} [z] Coordinate, optional.
  * @return {Number} The magnitude.
  */
 pub.mag = function(a, b, c) {
@@ -6621,18 +6647,17 @@ pub.mag = function(a, b, c) {
 };
 
 /**
- * Re-maps a number from one range to another.
- *
+ * @description Re-maps a number from one range to another.<br>
  * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method map
- * @param {Number} value The value to be mapped.
- * @param {Number} istart The start of the input range.
- * @param {Number} istop The end of the input range.
- * @param {Number} ostart The start of the output range.
- * @param {Number} ostop The end of the output range.
+ * @param  {Number} value The value to be mapped.
+ * @param  {Number} istart The start of the input range.
+ * @param  {Number} istop The end of the input range.
+ * @param  {Number} ostart The start of the output range.
+ * @param  {Number} ostop The end of the output range.
  * @return {Number} The mapped value.
  */
 pub.map = function(value, istart, istop, ostart, ostop) {
@@ -6641,14 +6666,14 @@ pub.map = function(value, istart, istop, ostart, ostop) {
 };
 
 /**
- * Determines the largest value in a sequence of numbers.
+ * @description Determines the largest value in a sequence of numbers.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method max
- * @param {Number|Array} a A value or an array of Numbers.
- * @param {Number} [b] Another value to be compared.
- * @param {Number} [c] Another value to be compared.
+ * @param  {Number|Array} a A value or an array of Numbers.
+ * @param  {Number} [b] Another value to be compared.
+ * @param  {Number} [c] Another value to be compared.
  * @return {Number} The highest value.
  */
 pub.max = function() {
@@ -6662,14 +6687,14 @@ pub.max = function() {
 };
 
 /**
- * Determines the smallest value in a sequence of numbers.
+ * @description Determines the smallest value in a sequence of numbers.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method min
- * @param {Number|Array} a A value or an array of Numbers.
- * @param {Number} [b] Another value to be compared.
- * @param {Number} [c] Another value to be compared.
+ * @param  {Number|Array} a A value or an array of Numbers.
+ * @param  {Number} [b] Another value to be compared.
+ * @param  {Number} [c] Another value to be compared.
  * @return {Number} The lowest value.
  */
 pub.min = function() {
@@ -6683,18 +6708,16 @@ pub.min = function() {
 };
 
 /**
- * Normalizes a number from another range into a value between 0 and 1.
- *
- * Identical to map(value, low, high, 0, 1);
- *
+ * @description Normalizes a number from another range into a value between 0 and 1.<br>
+ * Identical to map(value, low, high, 0, 1);<br>
  * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method norm
- * @param {Number} aNumber The value to be normed.
- * @param {Number} low The lowest value to be expected.
- * @param {Number} high The highest value to be expected.
+ * @param  {Number} aNumber The value to be normed.
+ * @param  {Number} low The lowest value to be expected.
+ * @param  {Number} high The highest value to be expected.
  * @return {Number} The normalized value.
  */
 pub.norm = function(aNumber, low, high) {
@@ -6703,35 +6726,35 @@ pub.norm = function(aNumber, low, high) {
 };
 
 /**
- * Facilitates exponential expressions. The pow() function is an efficient way of multiplying numbers by themselves (or their reciprocal) in large quantities. For example, pow(3, 5) is equivalent to the expression 3*3*3*3*3 and pow(3, -5) is equivalent to 1 / 3*3*3*3*3
+ * @description Facilitates exponential expressions. The pow() function is an efficient way of multiplying numbers by themselves (or their reciprocal) in large quantities. For example, pow(3, 5) is equivalent to the expression 3*3*3*3*3 and pow(3, -5) is equivalent to 1 / 3*3*3*3*3
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method pow
- * @param {Number} num Base of the exponential expression.
- * @param {Number} exponent Power of which to raise the base.
+ * @param  {Number} num Base of the exponential expression.
+ * @param  {Number} exponent Power of which to raise the base.
  * @return {Number} the result
  */
 pub.pow = Math.pow;
 
 /**
- * Calculates the integer closest to the value parameter. For example, round(9.2) returns the value 9.
+ * @description Calculates the integer closest to the value parameter. For example, round(9.2) returns the value 9.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method round
- * @param {Number} value The value to be rounded.
+ * @param  {Number} value The value to be rounded.
  * @return {Number} The rounded value.
  */
 pub.round = Math.round;
 
 /**
- * Squares a number (multiplies a number by itself). The result is always a positive number, as multiplying two negative numbers always yields a positive result. For example, -1 * -1 = 1.
+ * @description Squares a number (multiplies a number by itself). The result is always a positive number, as multiplying two negative numbers always yields a positive result. For example, -1 * -1 = 1.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method sq
- * @param {Number} aNumber The value to be squared.
+ * @param  {Number} aNumber The value to be squared.
  * @return {Number} Squared number.
  */
 pub.sq = function(aNumber) {
@@ -6742,79 +6765,79 @@ pub.sq = function(aNumber) {
 // -- Trigonometry --
 
 /**
- * Calculates the square root of a number. The square root of a number is always positive, even though there may be a valid negative root. The square root s of number a is such that s*s = a. It is the opposite of squaring.
+ * @description Calculates the square root of a number. The square root of a number is always positive, even though there may be a valid negative root. The square root s of number a is such that s*s = a. It is the opposite of squaring.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method sqrt
- * @param {Number} val A value.
+ * @param  {Number} val A value.
  * @return {Number} Square root.
  */
 pub.sqrt = Math.sqrt;
 
 /**
- * The inverse of cos(), returns the arc cosine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of cos(), returns the arc cosine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method acos
- * @param {Number} value The value whose arc cosine is to be returned.
+ * @param  {Number} value The value whose arc cosine is to be returned.
  * @return {Number} The arc cosine.
  */
 pub.acos = Math.acos;
 
 /**
- * The inverse of sin(), returns the arc sine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of sin(), returns the arc sine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method asin
- * @param {Number} value The value whose arc sine is to be returned.
+ * @param  {Number} value The value whose arc sine is to be returned.
  * @return {Number} The arc sine.
  */
 pub.asin = Math.asin;
 
 /**
- * The inverse of tan(), returns the arc tangent of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of tan(), returns the arc tangent of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method atan
- * @param {Number} value The value whose arc tangent is to be returned.
+ * @param  {Number} value The value whose arc tangent is to be returned.
  * @return {Number} The arc tangent.
  */
 pub.atan = Math.atan;
 
 /**
- * Calculates the angle (in radians) from a specified point to the coordinate origin as measured from the positive x-axis. Values are returned as a float in the range from PI to -PI. The atan2() function is most often used for orienting geometry to the position of the cursor. Note: The y-coordinate of the point is the first parameter and the x-coordinate is the second due the the structure of calculating the tangent.
+ * @description Calculates the angle (in radians) from a specified point to the coordinate origin as measured from the positive x-axis. Values are returned as a float in the range from PI to -PI. The atan2() function is most often used for orienting geometry to the position of the cursor. Note: The y-coordinate of the point is the first parameter and the x-coordinate is the second due the the structure of calculating the tangent.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method atan2
- * @param {Number} y The y coordinate.
- * @param {Number} x The x coordinate.
+ * @param  {Number} y The y coordinate.
+ * @param  {Number} x The x coordinate.
  * @return {Number} The atan2 value.
  */
 pub.atan2 = Math.atan2;
 
 /**
- * Calculates the cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range -1 to 1.
+ * @description Calculates the cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range -1 to 1.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method cos
- * @param {Number} rad A value in radians.
+ * @param  {Number} rad A value in radians.
  * @return {Number} The cosine.
  */
 pub.cos = Math.cos;
 
 /**
- * Converts a radian measurement to its corresponding value in degrees. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
+ * @description Converts a radian measurement to its corresponding value in degrees. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method degrees
- * @param {Number} aAngle An angle in radians.
+ * @param  {Number} aAngle An angle in radians.
  * @return {Number} The given angle in degree.
  */
 pub.degrees = function(aAngle) {
@@ -6822,12 +6845,12 @@ pub.degrees = function(aAngle) {
 };
 
 /**
- * Converts a degree measurement to its corresponding value in radians. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
+ * @description Converts a degree measurement to its corresponding value in radians. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method radians
- * @param {Number} aAngle An angle in degree.
+ * @param  {Number} aAngle An angle in degree.
  * @return {Number} The given angle in radians.
  */
 pub.radians = function(aAngle) {
@@ -6835,23 +6858,23 @@ pub.radians = function(aAngle) {
 };
 
 /**
- * Calculates the sine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to 6.28). Values are returned in the range -1 to 1.
+ * @description Calculates the sine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to 6.28). Values are returned in the range -1 to 1.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method sin
- * @param {Number} rad A value in radians.
+ * @param  {Number} rad A value in radians.
  * @return {Number} The sine value.
  */
 pub.sin = Math.sin;
 
 /**
- * Calculates the ratio of the sine and cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range infinity to -infinity.
+ * @description Calculates the ratio of the sine and cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range infinity to -infinity.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method tan
- * @param {Number} rad A value in radians.
+ * @param  {Number} rad A value in radians.
  * @return {Number} The tangent value.
  */
 pub.tan = Math.tan;
@@ -6861,15 +6884,14 @@ pub.tan = Math.tan;
 var currentRandom = Math.random;
 
 /**
- * Generates random numbers. Each time the random() function is called, it returns an unexpected value within the specified range. If one parameter is passed to the function it will return a float between zero and the value of the high parameter. The function call random(5) returns values between 0 and 5. If two parameters are passed, it will return a float with a value between the the parameters. The function call random(-5, 10.2) returns values between -5 and 10.2.
- *
+ * @description Generates random numbers. Each time the random() function is called, it returns an unexpected value within the specified range. If one parameter is passed to the function it will return a float between zero and the value of the high parameter. The function call random(5) returns values between 0 and 5. If two parameters are passed, it will return a float with a value between the the parameters. The function call random(-5, 10.2) returns values between -5 and 10.2.<br>
  * One parameter sets the range from 0 to the given parameter, while with two parameters present you set the range from val1 - val2.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Random
  * @method random
- * @param {Number} [low] The low border of the range.
- * @param {Number} [high] The high border of the range.
+ * @param  {Number} [low] The low border of the range.
+ * @param  {Number} [high] The high border of the range.
  * @return {Number} A random number.
  */
 pub.random = function() {
@@ -6899,10 +6921,10 @@ Marsaglia.createRandomized = function() {
   return new Marsaglia(now / 6E4 & 4294967295, now & 4294967295);
 };
 /**
- * Sets the seed value for random().
- *
+ * @description Sets the seed value for random().<br>
  * By default, random() produces different results each time the program is run. Set the seed parameter to a constant to return the same pseudo-random numbers each time the software is run.
- * @cat Math
+ *
+ * @cat    Math
  * @subcat Random
  * @method randomSeed
  * @param  {Number} seed The seed value.
@@ -6911,12 +6933,13 @@ pub.randomSeed = function(seed) {
   currentRandom = (new Marsaglia(seed)).nextDouble;
 };
 /**
- * Random Generator with Gaussian distribution.
- * @constructor
- * @cat Math
+ * @description Random Generator with Gaussian distribution.
+ *
+ * @cat    Math
  * @subcat Random
  * @method Random
- * @param {Number} seed The seed value.
+ * @param  {Number} seed The seed value.
+ * @constructor
  */
 pub.Random = function(seed) {
   var haveNextNextGaussian = false,
@@ -7021,20 +7044,20 @@ var noiseProfile = {
 };
 
 /**
- * Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural ordered, harmonic succession of numbers compared to the standard random() function. It was invented by Ken Perlin in the 1980s and been used since in graphical applications to produce procedural textures, natural motion, shapes, terrains etc.
- *
+ * @description Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural ordered, harmonic succession of numbers compared to the standard random() function. It was invented by Ken Perlin in the 1980s and been used since in graphical applications to produce procedural textures, natural motion, shapes, terrains etc.
+ * <br><br>
  * The main difference to the random() function is that Perlin noise is defined in an infinite n-dimensional space where each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. basil.js can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space. The 2nd and 3rd dimension can also be interpreted as time.
- *
+ * <br><br>
  * The actual noise is structured similar to an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, perlin noise is computed over several octaves which are added together for the final result.
- *
+ * <br><br>
  * Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space the value of the coordinates doesn't matter as such, only the distance between successive coordinates does (eg. when using noise() within a loop). As a general rule the smaller the difference between coordinates, the smoother the resulting noise sequence will be. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Random
  * @method noise
- * @param {Number} x Coordinate in x space.
- * @param {Number} [y] Coordinate in y space.
- * @param {Number} [z] Coordinate in z space.
+ * @param  {Number} x Coordinate in x space.
+ * @param  {Number} [y] Coordinate in y space.
+ * @param  {Number} [z] Coordinate in z space.
  * @return {Number} The noise value.
  */
 pub.noise = function(x, y, z) {
@@ -7062,15 +7085,15 @@ pub.noise = function(x, y, z) {
 };
 
 /**
- * Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overal intensity of the noise, whereas higher octaves create finer grained details in the noise sequence. By default, noise is computed over 4 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the 1st octave. This falloff amount can be changed by adding an additional function parameter. Eg. a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. Any value between 0.0 and 1.0 is valid, however note that values greater than 0.5 might result in greater than 1.0 values returned by noise().
- *
+ * @description Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overal intensity of the noise, whereas higher octaves create finer grained details in the noise sequence. By default, noise is computed over 4 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the 1st octave. This falloff amount can be changed by adding an additional function parameter. Eg. a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. Any value between 0.0 and 1.0 is valid, however note that values greater than 0.5 might result in greater than 1.0 values returned by noise().
+ * <br><br>
  * By changing these parameters, the signal created by the noise() function can be adapted to fit very specific needs and characteristics.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Random
  * @method noiseDetail
- * @param {Number} octaves Number of octaves to be used by the noise() function.
- * @param {Number} fallout Falloff factor for each octave.
+ * @param  {Number} octaves Number of octaves to be used by the noise() function.
+ * @param  {Number} fallout Falloff factor for each octave.
  */
 pub.noiseDetail = function(octaves, fallout) {
   noiseProfile.octaves = octaves;
@@ -7078,12 +7101,12 @@ pub.noiseDetail = function(octaves, fallout) {
 };
 
 /**
- * Sets the seed value for noise(). By default, noise() produces different results each time the program is run. Set the value parameter to a constant to return the same pseudo-random numbers each time the software is run.
+ * @description Sets the seed value for noise(). By default, noise() produces different results each time the program is run. Set the value parameter to a constant to return the same pseudo-random numbers each time the software is run.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Random
  * @method noiseSeed
- * @param {Number} seed Noise seed value.
+ * @param  {Number} seed Noise seed value.
  */
 pub.noiseSeed = function(seed) {
   noiseProfile.seed = seed;
@@ -7100,10 +7123,10 @@ var precision = function(num, dec) {
 };
 
 /**
- * The function calculates the geometric bounds of any given page item or text. Use the <code>transforms()</code> function to modify page items.
+ * @description The function calculates the geometric bounds of any given page item or text. Use the <code>transforms()</code> function to modify page items.
  * In case the object is any kind of text, additional typographic information baseline and xHeight are calculated.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method bounds
  * @param  {PageItem|Text} obj The page item or text to calculate the geometric bounds.
@@ -7176,15 +7199,15 @@ pub.bounds = function (obj) {
 /* global precision */
 
 /**
- * @description Sets the reference point for transformations using the <code>transform()</code> function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.
- * Arguments can be the basil constants <code>TOP_LEFT</code>, <code>TOP_CENTER</code>, <code>TOP_RIGHT</code>, <code>CENTER_LEFT</code>, <code>CENTER</code>, <code>CENTER_RIGHT</code>, <code>BOTTOM_LEFT</code>, <code>BOTTOM_CENTER</code> or <code>BOTTOM_RIGHT</code>. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.
+ * @description Sets the reference point for transformations using the <code>transform()</code> function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.<br>
+ * Arguments can be the basil constants <code>TOP_LEFT</code>, <code>TOP_CENTER</code>, <code>TOP_RIGHT</code>, <code>CENTER_LEFT</code>, <code>CENTER</code>, <code>CENTER_RIGHT</code>, <code>BOTTOM_LEFT</code>, <code>BOTTOM_CENTER</code> or <code>BOTTOM_RIGHT</code>. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.<br>
  * If the function is used without any arguments the currently set reference point will be returned.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method referencePoint
- * @param {String} [referencePoint] The reference point to set.
- * @returns {String} Current reference point setting.
+ * @param  {String} [referencePoint] The reference point to set.
+ * @return {String} Current reference point setting.
  */
 pub.referencePoint = function(rp) {
   if(!arguments.length) {
@@ -7247,13 +7270,13 @@ pub.referencePoint = function(rp) {
  * <li> <code>"y"</code>: Sets the y-position of the page item's anchor point to the given value. Returns the y-coordinate of the page item's anchor point.</li>
  * </ul>
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method transform
- * @param {PageItem} pItem The page item to transform.
- * @param {String} type The type of transformation.
- * @param {Number|Array} [value] The value(s) of the transformation.
- * @returns {Number|Array} The current value(s) of the specified transformation.
+ * @param  {PageItem} pItem The page item to transform.
+ * @param  {String} type The type of transformation.
+ * @param  {Number|Array} [value] The value(s) of the transformation.
+ * @return {Number|Array} The current value(s) of the specified transformation.
  *
  * @example <caption>Rotating a rectangle to a 25 degrees angle</caption>
  * var r = rect(20, 40, 200, 100);
@@ -7269,7 +7292,6 @@ pub.referencePoint = function(rp) {
  * referencePoint(BOTTOM_RIGHT);
  * transform(r, "position", [40, 40]);
  */
-
 pub.transform = function(pItem, type, value) {
 
   if(!pItem || !pItem.hasOwnProperty("geometricBounds")) {
@@ -7594,12 +7616,12 @@ Matrix2D.prototype = {
 };
 
 /**
- *@description Multiplies the current matrix by the one specified through the parameters.
+ * @description Multiplies the current matrix by the one specified through the parameters.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method applyMatrix
- * @param {Matrix2D} matrix The matrix to be applied.
+ * @param  {Matrix2D} matrix The matrix to be applied.
  */
 pub.applyMatrix = function (matrix) {
   currMatrix.apply(matrix);
@@ -7608,7 +7630,7 @@ pub.applyMatrix = function (matrix) {
 /**
  * @description Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires understanding the concept of a matrix stack. The <code>pushMatrix()</code> function saves the current coordinate system to the stack and <code>popMatrix()</code> restores the prior coordinate system. <code>pushMatrix()</code> and <code>popMatrix()</code> are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method popMatrix
  */
@@ -7621,9 +7643,9 @@ pub.popMatrix = function () {
 };
 
 /**
- * Prints the current matrix to the console window.
+ * @description Prints the current matrix to the console window.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method printMatrix
  */
@@ -7634,7 +7656,7 @@ pub.printMatrix = function () {
 /**
  * @description Pushes the current transformation matrix onto the matrix stack. Understanding <code>pushMatrix()</code> and <code>popMatrix()</code> requires understanding the concept of a matrix stack. The <code>pushMatrix()</code> function saves the current coordinate system to the stack and <code>popMatrix()</code> restores the prior coordinate system. <code>pushMatrix()</code> and <code>popMatrix()</code> are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method pushMatrix
  */
@@ -7643,9 +7665,9 @@ pub.pushMatrix = function () {
 };
 
 /**
- * Replaces the current matrix with the identity matrix.
+ * @description Replaces the current matrix with the identity matrix.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method resetMatrix
  */
@@ -7659,10 +7681,10 @@ pub.resetMatrix = function () {
 /**
  * @description Rotates an object the amount specified by the angle parameter. Angles should be specified in radians (values from 0 to <code>PI</code>*2) or converted to radians with the <code>radians()</code> function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a clockwise direction with 0 radians or degrees being up and <code>HALF_PI</code> being to the right etc. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <code>rotate(PI/2)</code> and then <code>rotate(PI/2)</code> is the same as <code>rotate(PI)</code>. If <code>rotate()</code> is called within the <code>draw()</code>, the transformation is reset when the loop begins again. Technically, <code>rotate()</code> multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by the <code>pushMatrix()</code> and <code>popMatrix()</code>.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method rotate
- * @param {Number} angle The angle specified in radians
+ * @param  {Number} angle The angle specified in radians
  */
 pub.rotate = function (angle) {
   if(typeof arguments[0] === "undefined") {
@@ -7675,11 +7697,11 @@ pub.rotate = function (angle) {
  * @description Increasing and decreasing the size of an object by expanding and contracting vertices. Scale values are specified as decimal percentages. The function call <code>scale(2.0)</code> increases the dimension of a shape by 200%. Objects always scale from their relative origin to the coordinate system. Transformations apply to everything that happens after and subsequent calls to the function multiply the effect. For example, calling <code>scale(2.0)</code> and then <code>scale(1.5)</code> is the same as <code>scale(3.0)</code>. If <code>scale()</code> is called within <code>draw()</code>, the transformation is reset when the loop begins again. This function can be further controlled by <code>pushMatrix()</code> and <code>popMatrix()</code>.
  * If only one parameter is given, it is applied on X and Y axis.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method scale
- * @param {Number} scaleX The amount to scale the X axis.
- * @param {Number} scaleY The amount to scale the Y axis.
+ * @param  {Number} scaleX The amount to scale the X axis.
+ * @param  {Number} scaleY The amount to scale the Y axis.
  */
 pub.scale = function (scaleX, scaleY) {
   if(typeof arguments[0] != "number" || (arguments.length === 2 && typeof arguments[1] != "number")) {
@@ -7691,11 +7713,11 @@ pub.scale = function (scaleX, scaleY) {
 /**
  * @description Specifies an amount to displace objects within the page. The x parameter specifies left/right translation, the y parameter specifies up/down translation. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <code>translate(50, 0)</code> and then <code>translate(20, 0)</code> is the same as <code>translate(70, 0)</code>. This function can be further controlled by the <code>pushMatrix()</code> and <code>popMatrix()</code>.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method translate
- * @param {Number} tx The amount of offset on the X axis.
- * @param {Number} ty The amount of offset on the Y axis.
+ * @param  {Number} tx The amount of offset on the X axis.
+ * @param  {Number} ty The amount of offset on the Y axis.
  */
 pub.translate = function (tx, ty) {
   if(typeof arguments[0] === "undefined" || typeof arguments[1] === "undefined") {

--- a/basil.js
+++ b/basil.js
@@ -654,14 +654,21 @@ if (!Array.prototype.map) {
 }
 
 /**
-* @description Used to run a function on all elements of an array. Please note the existance of the convenience methods `stories()`, `paragraphs()`, `lines()`, `words()` and `characters()` that are used to iterate through all instances of the given type in the given document.
-*
-* @cat    Data
-* @subcat Array
-* @method Array.forEach
-* @param  {Array} collection The array to be processed.
-* @param  {Function} cb The function that will be called on each element. The call will be like function(item,i) where i is the current index of the item within the array.
-*/
+ * @description Used to run a function on all elements of an array. Please note
+ *          the existance of the convenience methods `stories()`,
+ *          `paragraphs()`, `lines()`, `words()` and `characters()` that are
+ *          used to iterate through all instances of the given type in the given
+ *          document.
+ *
+ * @cat     Data
+ * @subcat  Array
+ * @method  Array.forEach
+ *
+ * @param   {Array} collection The array to be processed.
+ * @param   {Function} cb The function that will be called on each element. The
+ *          call will be like function(item,i) where i is the current index of
+ *          the item within the array.
+ */
 forEach = function(collection, cb) {
   for (var i = 0, len = collection.length; i < len; i++) {
 
@@ -678,12 +685,15 @@ forEach = function(collection, cb) {
 };
 
 /**
- * @description HashList is a data container that allows you to store information as key - value pairs. As usual in JavaScript mixed types of keys and values are accepted in one HashList instance.
+ * @description HashList is a data container that allows you to store
+ *          information as key - value pairs. As usual in JavaScript mixed types
+ *          of keys and values are accepted in one HashList instance.
  *
- * @cat    Data
- * @subcat HashList
- * @method HashList
- * @constructor
+ * @cat     Data
+ * @subcat  HashList
+ * @method  HashList
+ *
+ * @class
  */
 // taken from http://pbrajkumar.wordpress.com/2011/01/17/hashmap-in-javascript/
 HashList = function () {
@@ -703,14 +713,14 @@ HashList = function () {
   }
 
   /**
-   *
    * @description This removes a key - value pair by its key.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.remove
-   * @param  {String} key The key to delete.
-   * @return {Object} The value before deletion.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.remove
+   *
+   * @param   {String} key The key to delete.
+   * @return  {Object} The value before deletion.
    */
   that.remove = function(key) {
     var tmp_previous;
@@ -725,25 +735,29 @@ HashList = function () {
   /**
    * @description This gets a value by its key.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.get
-   * @param  {String} key The key to look for.
-   * @return {Object} The value.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.get
+   *
+   * @param   {String} key The key to look for.
+   * @return  {Object} The value.
    */
   that.get = function(key) {
     return that.items[key];
   };
 
   /**
-   * @description This sets a key - value pair. If a key is already existing, the value will be updated. Please note that Functions are currently not supported as values.
+   * @description This sets a key - value pair. If a key is already existing,
+   *          the value will be updated. Please note that Functions are
+   *          currently not supported as values.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.set
-   * @param  {String} key The key to use.
-   * @param  {Object|String|Number|Boolean} value The value to set.
-   * @return {Object} The value after setting.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.set
+   *
+   * @param   {String} key The key to use.
+   * @param   {Object|String|Number|Boolean} value The value to set.
+   * @return  {Object} The value after setting.
    */
   that.set = function(key, value) {
 
@@ -761,11 +775,12 @@ HashList = function () {
   /**
    * @description Checks for the existence of a given key.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.hasKey
-   * @param  {String} key The key to check.
-   * @return {Boolean} Returns true or false.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.hasKey
+   *
+   * @param   {String} key The key to check.
+   * @return  {Boolean} Returns true or false.
    */
   that.hasKey = function(key) {
     checkKey(key);
@@ -773,13 +788,15 @@ HashList = function () {
   };
 
   /**
-   * @description Checks if a certain value exists at least once in all of the key - value pairs.
+   * @description Checks if a certain value exists at least once in all of the
+   *          key - value pairs.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.hasValue
-   * @param  {Object|String|Number|Boolean} value The value to check.
-   * @return {Boolean} Returns true or false.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.hasValue
+   *
+   * @param   {Object|String|Number|Boolean} value The value to check.
+   * @return  {Boolean} Returns true or false.
    */
   that.hasValue = function(value) {
     var obj = that.items;
@@ -794,12 +811,15 @@ HashList = function () {
   };
 
   /**
-   * @description Returns an array of all keys that are sorted by their values from highest to lowest. Please note that this only works if you have conistently used Numbers for values.
+   * @description Returns an array of all keys that are sorted by their values
+   *          from highest to lowest. Please note that this only works if you
+   *          have conistently used Numbers for values.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getKeysByValues
-   * @return {Array} An array with all the keys.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.getKeysByValues
+   *
+   * @return  {Array} An array with all the keys.
    */
   that.getKeysByValues = function() {
     var obj = that.items;
@@ -813,12 +833,14 @@ HashList = function () {
   };
 
   /**
-   * @description Returns an array with all keys in a sorted order from higher to lower magnitude.
+   * @description Returns an array with all keys in a sorted order from higher
+   *          to lower magnitude.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getSortedKeys
-   * @return {Array} An array with all the keys sorted.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.getSortedKeys
+   *
+   * @return  {Array} An array with all the keys sorted.
    */
   that.getSortedKeys = function () {
     return that.getKeys().sort(); // ["a", "b", "z"]
@@ -827,10 +849,11 @@ HashList = function () {
   /**
    * @description Returns an array with all keys.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getKeys
-   * @return {Array} An array with all the keys.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.getKeys
+   *
+   * @return  {Array} An array with all the keys.
    */
   that.getKeys = function () {
     var keys = [];
@@ -848,10 +871,11 @@ HashList = function () {
   /**
    * @description Returns an array with all values.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getValues
-   * @return {Array} An array with all the values.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.getValues
+   *
+   * @return  {Array} An array with all the values.
    */
   that.getValues = function () {
 
@@ -868,9 +892,9 @@ HashList = function () {
   /**
    * @description Deletes all the key - value pairs in this HashList.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.clear
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.clear
    */
   that.clear = function() {
     for (var i in that.items) {
@@ -1622,25 +1646,31 @@ var textCollection = function(collection, legalContainers, container, cb) {
 };
 /**
  * @description Suspends the calling thread for a number of milliseconds.<br>
- * During a sleep period, checks at 100 millisecond intervals to see whether the sleep should be terminated.
+ *          During a sleep period, checks at 100 millisecond intervals to see
+ *          whether the sleep should be terminated.
  *
- * @cat    Environment
- * @method delay
- * @param  {Number} milliseconds  The delay time in milliseconds.
+ * @cat     Environment
+ * @method  delay
+ * @param   {Number} milliseconds The delay time in milliseconds.
  */
 pub.delay = function (milliseconds) {
   $.sleep(milliseconds);
 };
 
 /**
- * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function with each story of the given document.
+ * @description If no callback function is given it returns a Collection of
+ *          items otherwise calls the given callback function with each story of
+ *          the given document.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method stories
- * @param  {Document} doc The document instance to iterate the stories in
- * @param  {Function} [cb] The callback function to call with each story. When this function returns false the loop stops. Passed arguments: story, loopCount.
- * @return {Stories} A collection of Story objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  stories
+ *
+ * @param   {Document} doc The document instance to iterate the stories in
+ * @param   {Function} [cb] The callback function to call with each story. When
+ *          this function returns `false` the loop stops. Passed arguments:
+ *          `story`, `loopCount`.
+ * @return  {Stories} A collection of Story objects.
  *
  * @example
  * stories(doc(), function(story, loopCount){
@@ -1662,14 +1692,21 @@ pub.stories = function(doc, cb) {
 };
 
 /**
- * @description If no callback function is given it returns a Collection of paragraphs in the container otherwise calls the given callback function with each paragraph of the given document, page, story or textFrame.
+ * @description If no callback function is given it returns a Collection of
+ *          paragraphs in the container otherwise calls the given callback
+ *          function with each paragraph of the given document, page, story or
+ *          textFrame.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method paragraphs
- * @param  {Document|Page|Story|TextFrame} container The document, story, page or textFrame instance to iterate the paragraphs in.
- * @param  {Function} [cb]  Optional: The callback function to call with each paragraph. When this function returns false the loop stops. Passed arguments: para, loopCount.
- * @return {Paragraphs} A collection of Paragraph objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  paragraphs
+ *
+ * @param   {Document|Page|Story|TextFrame} container The document, story, page
+ *          or textFrame instance to iterate the paragraphs in.
+ * @param   {Function} [cb] Optional: The callback function to call with each
+ *          paragraph. When this function returns false the loop stops. Passed
+ *          arguments: `para`, `loopCount`.
+ * @return  {Paragraphs} A collection of Paragraph objects.
  */
 pub.paragraphs = function(container, cb) {
 
@@ -1679,14 +1716,22 @@ pub.paragraphs = function(container, cb) {
 };
 
 /**
- * @description If no callback function is given it returns a Collection of lines in the container otherwise calls the given callback function with each line of the given document, page, story, textFrame or paragraph.
+ * @description If no callback function is given it returns a Collection of
+ *          lines in the container otherwise calls the given callback function
+ *          with each line of the given document, page, story, textFrame or
+ *          paragraph.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method lines
- * @param  {Document|Page|Story|TextFrame|Paragraph} container The document, page, story, textFrame or paragraph instance to iterate the lines in.
- * @param  {Function} [cb] Optional: The callback function to call with each line. When this function returns false the loop stops. Passed arguments: line, loopCount.
- * @return {Lines} A collection of Line objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  lines
+ *
+ * @param   {Document|Page|Story|TextFrame|Paragraph} container The document,
+ *          page, story, textFrame or paragraph instance to iterate the lines
+ *          in.
+ * @param   {Function} [cb] Optional: The callback function to call with each
+ *          line. When this function returns false the loop stops. Passed
+ *          arguments: `line`, `loopCount`.
+ * @return  {Lines} A collection of Line objects.
  */
 pub.lines = function(container, cb) {
 
@@ -1696,14 +1741,22 @@ pub.lines = function(container, cb) {
 };
 
 /**
- * @description If no callback function is given it returns a Collection of words in the container otherwise calls the given callback function with each word of the given document, page, story, textFrame, paragraph or line.
+ * @description If no callback function is given it returns a Collection of
+ *          words in the container otherwise calls the given callback function
+ *          with each word of the given document, page, story, textFrame,
+ *          paragraph or line.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method words
- * @param  {Document|Page|Story|TextFrame|Paragraph|Line} container The document, page, story, textFrame, paragraph or line instance to iterate the words in.
- * @param  {Function} [cb] The callback function to call with each word. When this function returns false the loop stops. Passed arguments: word, loopCount.
- * @return {Words} A collection of Word objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  words
+ *
+ * @param   {Document|Page|Story|TextFrame|Paragraph|Line} container The
+ *          document, page, story, textFrame, paragraph or line instance to
+ *          iterate the words in.
+ * @param   {Function} [cb] The callback function to call with each word. When
+ *          this function returns false the loop stops. Passed arguments:
+ *          `word`, `loopCount`.
+ * @return  {Words} A collection of Word objects.
  */
 pub.words = function(container, cb) {
 
@@ -1713,14 +1766,22 @@ pub.words = function(container, cb) {
 };
 
 /**
- * @description If no callback function is given it returns a Collection of characters in the container otherwise calls the given callback function with each character of the given document, page, story, textFrame, paragraph, line or word.
+ * @description If no callback function is given it returns a Collection of
+ *          characters in the container otherwise calls the given callback
+ *          function with each character of the given document, page, story,
+ *          textFrame, paragraph, line or word.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method characters
- * @param  {Document|Page|Story|TextFrame|Paragraph|Line|Word} container The document, page, story, textFrame, paragraph, line or word instance to  iterate the characters in.
- * @param  {Function} [cb] Optional: The callback function to call with each character. When this function returns false the loop stops. Passed arguments: character, loopCount
- * @return {Characters} A collection of Character objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  characters
+ *
+ * @param   {Document|Page|Story|TextFrame|Paragraph|Line|Word} container The
+ *          document, page, story, textFrame, paragraph, line or word instance
+ *          to  iterate the characters in.
+ * @param   {Function} [cb] Optional: The callback function to call with each
+ *          character. When this function returns false the loop stops. Passed
+ *          arguments: `character`, `loopCount`
+ * @return  {Characters} A collection of Character objects.
  */
 pub.characters = function(container, cb) {
 
@@ -1731,14 +1792,20 @@ pub.characters = function(container, cb) {
 
 
 /**
- * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function for each of the PageItems in the given Document, Page, Layer or Group.
+ * @description If no callback function is given it returns a Collection of
+ *          items otherwise calls the given callback function for each of the
+ *          PageItems in the given Document, Page, Layer or Group.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method items
- * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in
- * @param  {Function|Boolean} [cb] Optional: The callback function to call for each PageItem. When this function returns false the loop stops. Passed arguments: item, loopCount.
- * @return {PageItems} A collection of PageItem objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  items
+ *
+ * @param   {Document|Page|Layer|Group} container The container where the
+ *          PageItems sit in
+ * @param   {Function|Boolean} [cb] Optional: The callback function to call for
+ *          each PageItem. When this function returns false the loop stops.
+ *          Passed arguments: `item`, `loopCount`.
+ * @return  {PageItems} A collection of PageItem objects.
  */
 pub.items = function(container, cb) {
 
@@ -1759,11 +1826,15 @@ pub.items = function(container, cb) {
 
 
 /**
- * @description Removes all PageItems (including locked ones) in the given Document, Page, Layer or Group. If the selected container is a Group, the Group itself will be removed as well.
+ * @description Removes all page items (including locked ones) in the given
+ *          Document, Page, Layer or Group. If the selected container is a
+ *          group, the group itself will be removed as well.
  *
- * @cat    Document
- * @method clear
- * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in.
+ * @cat     Document
+ * @method  clear
+ *
+ * @param   {Document|Page|Layer|Group} container The container where the
+ *          PageItems sit in.
  */
 pub.clear = function(container) {
 
@@ -1787,9 +1858,10 @@ pub.clear = function(container) {
 /**
  * @description Removes the provided Page, Layer, PageItem, Swatch, etc.
  *
- * @cat    Document
- * @method remove
- * @param  {PageItem} obj The object to be removed.
+ * @cat     Document
+ * @method  remove
+ *
+ * @param   {PageItem} obj The object to be removed.
  */
 pub.remove = function(obj) {
 
@@ -1805,14 +1877,16 @@ pub.remove = function(obj) {
 // ----------------------------------------
 
 /**
- * @description Sets or possibly creates the current document and returns it.
- * If the param doc is not given the current document gets set to the active document
- * in the application. If no document at all is open, a new document gets created.
+ * @description Sets or possibly creates the current document and returns it. If
+ *          the `doc` parameter is not given, the current document gets set to
+ *          the active document in the application. If no document at all is
+ *          open, a new document gets created.
  *
- * @cat    Document
- * @method doc
- * @param  {Document} [doc] The document to set the current document to.
- * @return {Document} The current document instance.
+ * @cat     Document
+ * @method  doc
+ *
+ * @param   {Document} [doc] The document to set the current document to.
+ * @return  {Document} The current document instance.
  */
 pub.doc = function(doc) {
   if (doc instanceof Document) {
@@ -1825,16 +1899,25 @@ pub.doc = function(doc) {
 
 /**
  * @description Sets the size of the current document, if arguments are given.
- * If only one argument is given, both the width and the height are set to this value.
- * Alternatively, a string can be given as the first argument to apply an existing page size preset ("A4", "Letter" etc.).
- * In this case, either PORTRAIT or LANDSCAPE can be used as a second argument to determine the orientation of the page.
- * If no argument is given, an object containing the current document's width and height is returned.
+ *          If only one argument is given, both the width and the height are set
+ *          to this value. Alternatively, a string can be given as the first
+ *          argument to apply an existing page size preset (`"A4"`, `"Letter"`
+ *          etc.). In this case, either `PORTRAIT` or `LANDSCAPE` can be used as
+ *          a second argument to determine the orientation of the page. If no
+ *          argument is given, an object containing the current document's width
+ *          and height is returned.
  *
- * @cat    Document
- * @method size
- * @param  {Number|String} [widthOrPageSize] The desired width of the current document or the name of a page size preset.
- * @param  {Number|String} [heightOrOrientation] The desired height of the current document. If not provided the width will be used as the height. If the first argument is a page size preset, the second argument can be used to set the orientation.
- * @return {Object} Object containing the current `width` and `height` of the document.
+ * @cat     Document
+ * @method  size
+ *
+ * @param   {Number|String} [widthOrPageSize] The desired width of the current
+ *          document or the name of a page size preset.
+ * @param   {Number|String} [heightOrOrientation] The desired height of the
+ *          current document. If not provided the width will be used as the
+ *          height. If the first argument is a page size preset, the second
+ *          argument can be used to set the orientation.
+ * @return  {Object} Object containing the current `width` and `height` of the
+ *          document.
  *
  * @example <caption>Sets the document size to 70 x 100 units</caption>
  * size(70, 100);
@@ -1842,10 +1925,12 @@ pub.doc = function(doc) {
  * @example <caption>Sets the document size to 70 x 70</caption>
  * size(70);
  *
- * @example <caption>Sets the document size to A4, keeps the current orientation in place</caption>
+ * @example <caption>Sets the document size to A4, keeps the current orientation
+ *          in place</caption>
  * size("A4");
  *
- * @example <caption>Sets the document size to A4, set the orientation to landscape</caption>
+ * @example <caption>Sets the document size to A4, set the orientation to
+ *          landscape</caption>
  * size("A4", LANDSCAPE);
  */
 pub.size = function(widthOrPageSize, heightOrOrientation) {
@@ -1894,12 +1979,16 @@ pub.size = function(widthOrPageSize, heightOrOrientation) {
 };
 
 /**
- * @description Closes the current document. If no saveOptions argument is used, the user will be asked if they want to save or not.
+ * @description Closes the current document. If no `saveOptions` argument is
+ *          used, the user will be asked if they want to save or not.
  *
- * @cat    Document
- * @method close
- * @param  {Object|Boolean} [saveOptions] The InDesign SaveOptions constant or either true for triggering saving before closing or false for closing without saving.
- * @param  {File} [file] The InDesign file instance to save the document to.
+ * @cat     Document
+ * @method  close
+ *
+ * @param   {Object|Boolean} [saveOptions] The InDesign SaveOptions constant or
+ *          either true for triggering saving before closing or false for
+ *          closing without saving.
+ * @param   {File} [file] The InDesign file instance to save the document to.
  */
 pub.close = function(saveOptions, file) {
   if (currDoc) {
@@ -1928,11 +2017,16 @@ pub.close = function(saveOptions, file) {
 };
 
 /**
- * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
+ * @description Reverts the document to its last saved state. If the current
+ *          document is not saved yet, this function will close the document
+ *          without saving it and reopen a fresh document so as to "revert" the
+ *          unsaved document. This function is helpful during development stage
+ *          to start from a new or default document each time the script is run.
  *
- * @cat    Document
- * @method revert
- * @return {Document} The reverted document.
+ * @cat     Document
+ * @method  revert
+ *
+ * @return  {Document} The reverted document.
  */
 pub.revert = function() {
 
@@ -1953,14 +2047,21 @@ pub.revert = function() {
 };
 
 /**
- * @description Use this to set the dimensions of the canvas. Choose between PAGE (default), MARGIN, BLEED resp. FACING_PAGES, FACING_MARGINS and FACING_BLEEDS for book setups with facing page. Please note: Setups with more than two facing pages are not yet supported.<br>
- * Please note that you will loose your current MatrixTransformation. You should set the canvasMode before you attempt to use translate(), rotate() and scale();
+ * @description Use this to set the dimensions of the canvas. Choose between
+ *          `PAGE` (default), `MARGIN`, `BLEED` resp. `FACING_PAGES`,
+ *          `FACING_MARGINS` and `FACING_BLEEDS` for book setups with facing
+ *          page. Please note: Setups with more than two facing pages are not
+ *          yet supported.<br>
+ *          Please note that you will loose your current
+ *          MatrixTransformation. You should set the canvasMode before you
+ *          attempt to use `translate()`, `rotate()` and `scale()`.
  *
- * @cat    Document
- * @subcat Page
- * @method canvasMode
- * @param  {String} mode The canvas mode to set.
- * @return {String} The current canvas mode.
+ * @cat     Document
+ * @subcat  Page
+ * @method  canvasMode
+ *
+ * @param   {String} mode The canvas mode to set.
+ * @return  {String} The current canvas mode.
  */
 pub.canvasMode = function (m) {
   if(arguments.length === 0) {
@@ -1981,14 +2082,16 @@ pub.canvasMode = function (m) {
 
 
 /**
- * @description Returns the current horizontal and vertical pasteboard margins and sets them if both arguements are given.
+ * @description Returns the current horizontal and vertical pasteboard margins
+ *          and sets them if both arguements are given.
  *
- * @cat    Document
- * @subcat Page
- * @method pasteboard
- * @param  {Number} h The desired horizontal pasteboard margin.
- * @param  {Number} v The desired vertical pasteboard margin.
- * @return {Array} The current horizontal, vertical pasteboard margins.
+ * @cat     Document
+ * @subcat  Page
+ * @method  pasteboard
+ *
+ * @param   {Number} h The desired horizontal pasteboard margin.
+ * @param   {Number} v The desired vertical pasteboard margin.
+ * @return  {Array} The current horizontal, vertical pasteboard margins.
  */
 pub.pasteboard = function (h, v) {
   if(arguments.length == 0) {
@@ -2004,13 +2107,17 @@ pub.pasteboard = function (h, v) {
 };
 
 /**
- * @description Returns the current page and sets it if argument page is given. Numbering starts with 1.
+ * @description Returns the current page and sets it if argument page is given.
+ *          Numbering starts with 1.
  *
- * @cat    Document
- * @subcat Page
- * @method page
- * @param  {Page|Number|PageItem} [page] The page object or page number to set the current page to. If you pass a PageItem the current page will be set to it's containing page.
- * @return {Page} The current page instance.
+ * @cat     Document
+ * @subcat  Page
+ * @method  page
+ *
+ * @param   {Page|Number|PageItem} [page] The page object or page number to set
+ *          the current page to. If you pass a page item the current page will
+ *          be set to its containing page.
+ * @return  {Page} The current page instance.
  */
 pub.page = function(page) {
   if (page instanceof Page) {
@@ -2041,13 +2148,17 @@ pub.page = function(page) {
 };
 
 /**
- * @description Adds a new page to the document. Set the optional location parameter to either AT_END (default), AT_BEGINNING, AFTER or BEFORE. AFTER and BEFORE will use the current page as insertion point.
+ * @description Adds a new page to the document. Set the optional location
+ *          parameter to either `AT_END` (default), `AT_BEGINNING`, `AFTER` or
+ *          `BEFORE`. `AFTER` and `BEFORE` will use the current page as
+ *          insertion point.
  *
- * @cat    Document
- * @subcat Page
- * @method addPage
- * @param  {String} [location] The location placement mode.
- * @return {Page} The new page.
+ * @cat     Document
+ * @subcat  Page
+ * @method  addPage
+ *
+ * @param   {String} [location] The location placement mode.
+ * @return  {Page} The new page.
  */
 pub.addPage = function(location) {
 
@@ -2093,12 +2204,16 @@ pub.addPage = function(location) {
 
 
 /**
- * @description Removes a page from the current document. This will either be the current Page if the parameter page is left empty, or the given Page object or page number.
+ * @description Removes a page from the current document. This will either be
+ *          the current page if the parameter page is left empty, or the given
+ *          page object or page number.
  *
- * @cat    Document
- * @subcat Page
- * @method removePage
- * @param  {Page|Number} [page] The page to be removed as Page object or page number.
+ * @cat     Document
+ * @subcat  Page
+ *
+ * @method  removePage
+ * @param   {Page|Number} [page] The page to be removed as Page object or page
+ *          number.
  */
 pub.removePage = function (page) {
   checkNull(page);
@@ -2113,13 +2228,15 @@ pub.removePage = function (page) {
 };
 
 /**
- * @description Returns the current page number of either the current page or the given Page object.
+ * @description Returns the current page number of either the current page or
+ *          the given page object.
  *
- * @cat    Document
- * @subcat Page
- * @method pageNumber
- * @param  {Page} [pageObj] The page you want to know the number of.
- * @return {Number} The page number within the document.
+ * @cat     Document
+ * @subcat  Page
+ * @method  pageNumber
+ *
+ * @param   {Page} [pageObj] The page you want to know the number of.
+ * @return  {Number} The page number within the document.
  */
 pub.pageNumber = function (pageObj) {
   checkNull(pageObj);
@@ -2133,12 +2250,14 @@ pub.pageNumber = function (pageObj) {
 };
 
 /**
- * @description Set the next page of the document to be the active one. Returns new active page.
+ * @description Set the next page of the document to be the active one. Returns
+ *          new active page.
  *
- * @cat    Document
- * @subcat Page
- * @method nextPage
- * @return {Page} The active page.
+ * @cat     Document
+ * @subcat  Page
+ * @method  nextPage
+ *
+ * @return  {Page} The active page.
  */
 pub.nextPage = function () {
   var p = pub.doc().pages.nextItem(currentPage());
@@ -2147,12 +2266,14 @@ pub.nextPage = function () {
 
 
 /**
- * @description Set the previous page of the document to be the active one. Returns new active page.
+ * @description Set the previous page of the document to be the active one.
+ *          Returns new active page.
  *
- * @cat    Document
- * @subcat Page
- * @method previousPage
- * @return {Page} The active page.
+ * @cat     Document
+ * @subcat  Page
+ * @method  previousPage
+ *
+ * @return  {Page} The active page.
  */
 pub.previousPage = function () {
   var p = pub.doc().pages.previousItem(currentPage());
@@ -2161,16 +2282,19 @@ pub.previousPage = function () {
 
 
 /**
- * @description Returns the number of all pages in the current document. If a number is given as an argument,
- * it will set the document's page count to the given number by either adding pages or removing
- * pages until the number is reached. If pages are added, the master page of the document's last
- * page will be applied to the new pages.
+ * @description Returns the number of all pages in the current document. If a
+ *          number is given as an argument, it will set the document's page
+ *          count to the given number by either adding pages or removing pages
+ *          until the number is reached. If pages are added, the master page of
+ *          the document's last page will be applied to the new pages.
  *
- * @cat    Document
- * @subcat Page
- * @method pageCount
- * @param  {Number} [pageCount] New page count of the document (integer between 1 and 9999).
- * @return {Number} The amount of pages.
+ * @cat     Document
+ * @subcat  Page
+ * @method  pageCount
+ *
+ * @param   {Number} [pageCount] New page count of the document (integer between
+ *          1 and 9999).
+ * @return  {Number} The amount of pages.
  */
 pub.pageCount = function(pageCount) {
   if(arguments.length) {
@@ -2187,24 +2311,30 @@ pub.pageCount = function(pageCount) {
 /**
  * @description The number of all stories in the current document.
  *
- * @cat    Document
- * @subcat Story
- * @method storyCount
- * @return {Number} count The amount of stories.
+ * @cat     Document
+ * @subcat  Story
+ * @method  storyCount
+ *
+ * @return  {Number} count The amount of stories.
  */
 pub.storyCount = function() {
   return currentDoc().stories.count();
 };
 
 /**
- * @description Adds a page item or a string to an existing story. You can control the position of the insert via the last parameter. It accepts either an InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
+ * @description Adds a page item or a string to an existing story. You can
+ *          control the position of the insert via the last parameter. It
+ *          accepts either an insertion point or one the following constants:
+ *          `AT_BEGINNING` and `AT_END`.
  *
- * @cat    Document
- * @subcat Story
- * @method addToStory
- * @param  {Story} story The story.
- * @param  {PageItem|String} itemOrString The itemOrString either a PageItem, a String or one the following constants: AT_BEGINNING and AT_END.
- * @param  {InsertionPoint|String} insertionPointOrMode InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
+ * @cat     Document
+ * @subcat  Story
+ * @method  addToStory
+ *
+ * @param   {Story} story The story.
+ * @param   {PageItem|String} itemOrString Either a page item or a string.
+ * @param   {InsertionPoint|String} insertionPointOrMode Insertion point object
+ *          or one the following constants: `AT_BEGINNING` and `AT_END`.
  */
 pub.addToStory = function(story, itemOrString, insertionPointorMode) {
 
@@ -2259,13 +2389,17 @@ pub.addToStory = function(story, itemOrString, insertionPointorMode) {
 
 
 /**
- * @description Returns the current layer if no argument is given. Sets active layer if layer object or name of existing layer is given. Newly creates layer and sets it to active if new name is given.
+ * @description Returns the current layer if no argument is given. Sets active
+ *          layer if layer object or name of existing layer is given. Newly
+ *          creates layer and sets it to active if new name is given.
  *
- * @cat    Document
- * @subcat Page
- * @method layer
- * @param  {Layer|String} [layer] The layer or layer name to set the current layer to.
- * @return {Layer} The current layer instance.
+ * @cat     Document
+ * @subcat  Page
+ * @method  layer
+ *
+ * @param   {Layer|String} [layer] The layer or layer name to set the current
+ *          layer to.
+ * @return  {Layer} The current layer instance.
  */
 pub.layer = function(layer) {
   checkNull(layer);
@@ -2288,15 +2422,24 @@ pub.layer = function(layer) {
 
 
 /**
- * @description Arranges a page item or a layer before or behind other page items or layers. If using the constants `FORWARD` or `BACKWARD` the object is sent forward or back one step. The constants `FRONT` or `BACK` send the object to the very front or very back. Using `FRONT` or `BACK` together with the optional reference object, sends the object in front or behind this reference object.
+ * @description Arranges a page item or a layer before or behind other page
+ *          items or layers. If using the constants `FORWARD` or `BACKWARD` the
+ *          object is sent forward or back one step. The constants `FRONT` or
+ *          `BACK` send the object to the very front or very back. Using `FRONT`
+ *          or `BACK` together with the optional reference object, sends the
+ *          object in front or behind this reference object.
  *
- * @cat    Document
- * @subcat Page
- * @method arrange
- * @param  {PageItem|Layer} pItemOrLayer The page item or layer to be moved to a new position.
- * @param  {String} positionOrDirection The position or direction to move the page item or layer. Can be `FRONT`, `BACK`, `FORWARD` or `BACKWARD`.
- * @param  {PageItem|Layer} [reference] A reference object to move the page item or layer behind or in front of.
- * @return {PageItem|Layer} The newly arranged page item or layer.
+ * @cat     Document
+ * @subcat  Page
+ * @method  arrange
+ *
+ * @param   {PageItem|Layer} pItemOrLayer The page item or layer to be moved to
+ *          a new position.
+ * @param   {String} positionOrDirection The position or direction to move the
+ *          page item or layer. Can be `FRONT`, `BACK`, `FORWARD` or `BACKWARD`.
+ * @param   {PageItem|Layer} [reference] A reference object to move the page
+ *          item or layer behind or in front of.
+ * @return  {PageItem|Layer} The newly arranged page item or layer.
  */
 pub.arrange = function(pItemOrLayer, positionOrDirection, reference) {
   checkNull(pItemOrLayer);
@@ -2344,16 +2487,20 @@ pub.arrange = function(pItemOrLayer, positionOrDirection, reference) {
 
 
 /**
- *  @description Returns the Group instance and sets it if argument Group is given.
- *  Groups items to a new group. Returns the resulting group instance. If a string is given as the only
- *  argument, the group by the given name will be returned.
+ * @description Returns the Group instance and sets it if argument Group is
+ *          given. Groups items to a new group. Returns the resulting group
+ *          instance. If a string is given as the only argument, the group by
+ *          the given name will be returned.
  *
- *  @cat    Document
- *  @subCat Page
- *  @method group
- *  @param  {Array} pItems An array of page items (must contain at least two items) or name of group instance.
- *  @param  {String} [name] The name of the group, only when creating a group from page items.
- *  @return {Group} The group instance.
+ * @cat     Document
+ * @subCat  Page
+ * @method  group
+ *
+ * @param   {Array} pItems An array of page items (must contain at least two
+ *          items) or name of group instance.
+ * @param   {String} [name] The name of the group, only when creating a group
+ *          from page items.
+ * @return  {Group} The group instance.
  */
 pub.group = function (pItems, name) {
   checkNull(pItems);
@@ -2382,13 +2529,16 @@ pub.group = function (pItems, name) {
 
 
 /**
- *  @description Ungroups an existing group. Returns an array of the items that were within the group before ungroup() was called.
+ * @description Ungroups an existing group. Returns an array of the items that
+ *          were within the group before ungroup() was called.
  *
- *  @cat    Document
- *  @subCat Page
- *  @method ungroup
- *  @param  {Group|String} group The group instance or name of the group to ungroup.
- *  @return {Array} An array of the ungrouped page items.
+ * @cat     Document
+ * @subCat  Page
+ * @method  ungroup
+ *
+ * @param   {Group|String} group The group instance or name of the group to
+ *          ungroup.
+ * @return  {Array} An array of the ungrouped page items.
  */
 pub.ungroup = function(group) {
   checkNull(group);
@@ -2412,14 +2562,19 @@ pub.ungroup = function(group) {
 
 
 /**
- * @description Returns items tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label).
+ * @description Returns items tagged with the given label in the InDesign Script
+ *          Label pane (`Window -> Utilities -> Script Label`).
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method labels
- * @param  {String} label The label identifier.
- * @param  {Function} [cb] The callback function to call with each item in the search result. When this function returns false the loop stops. Passed arguments: item, loopCount.
- * @return {Array} Array of concrete PageItem instances, e.g. TextFrame or SplineItem.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  labels
+ *
+ * @param   {String} label The label identifier.
+ * @param   {Function} [cb] The callback function to call with each item in the
+ *          search result. When this function returns `false`, the loop stops.
+ *          Passed arguments: `item`, `loopCount`.
+ * @return  {Array} Array of concrete page item instances, e.g. text frame or
+ *          spline item.
  */
 pub.labels = function(label, cb) {
   checkNull(label);
@@ -2443,13 +2598,18 @@ pub.labels = function(label, cb) {
 
 
 /**
- * @description Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of `labels()`, when you know you just have one thing with that label and don't want to deal with a single-element array.
+ * @description Returns the first item that is tagged with the given label in
+ *          the InDesign Script Label pane (`Window -> Utilities -> Script
+ *          Label`). Use this instead of `labels()`, when you know you just have
+ *          one thing with that label and don't want to deal with a
+ *          single-element array.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method label
- * @param  {String} label The label identifier.
- * @return {PageItem} The first PageItem with the given label.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  label
+ *
+ * @param   {String} label The label identifier.
+ * @return  {PageItem} The first page item with the given label.
  */
 pub.label = function(label) {
   checkNull(label);
@@ -2465,12 +2625,15 @@ pub.label = function(label) {
 
 
 /**
- * @description Returns the first currently selected object. Use this if you know you only have one selected item and don't want to deal with an array.
+ * @description Returns the first currently selected object. Use this if you
+ *          know you only have one selected item and don't want to deal with an
+ *          array.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method selection
- * @return {Object} The first selected object.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  selection
+ *
+ * @return  {Object} The first selected object.
  */
 pub.selection = function() {
   if(app.selection.length === 0) {
@@ -2482,11 +2645,14 @@ pub.selection = function() {
 /**
  * @description Returns the currently selected object(s)
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method selections
- * @param  {Function} [cb] The callback function to call with each item in the selection. When this function returns false the loop stops. Passed arguments: item, loopCount.
- * @return {Array} Array of selected object(s).
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  selections
+ *
+ * @param   {Function} [cb] The callback function to call with each item in the
+ *          selection. When this function returns false the loop stops. Passed
+ *          arguments: item, loopCount.
+ * @return  {Array} Array of selected object(s).
  */
 pub.selections = function(cb) {
   if(app.selection.length === 0) {
@@ -2499,12 +2665,14 @@ pub.selections = function(cb) {
 };
 
 /**
- * @description Returns the first item on the active page that is named by the given name in the Layers pane (Window -> Layer).
+ * @description Returns the first item on the active page that is named by the
+ *          given name in the Layers pane (`Window -> Layer`).
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method nameOnPage
- * @return {Object} The first object on the active page with the given name.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  nameOnPage
+ *
+ * @return  {Object} The first object on the active page with the given name.
  */
 pub.nameOnPage = function(name) {
   checkNull(name);
@@ -2525,12 +2693,15 @@ pub.nameOnPage = function(name) {
 
 
 /**
- * @description Sets the units of the document (like right clicking the rulers). By default basil uses the units of the user's document or the user's default units.
+ * @description Sets the units of the document (like right clicking the rulers).
+ *          By default basil uses the units of the user's document or the user's
+ *          default units.
  *
- * @cat    Document
- * @method units
- * @param  {String} [units] Supported units: PT, PX, CM, MM or IN.
- * @return {String} Current unit setting.
+ * @cat     Document
+ * @method  units
+ *
+ * @param   {String} [units] Supported units: PT, PX, CM, MM or IN.
+ * @return  {String} Current unit setting.
  */
 var unitsCalledCounter = 0;
 pub.units = function (units) {
@@ -2577,12 +2748,14 @@ pub.units = function (units) {
 };
 
 /**
- * @description Creates a vertical guide line at the current spread and current layer.
+ * @description Creates a vertical guide line at the current spread and current
+ *          layer.
  *
- * @cat    Document
- * @method guideX
- * @param  {Number} x Position of the new guide line.
- * @return {Guide} New guide line.
+ * @cat     Document
+ * @method  guideX
+ *
+ * @param   {Number} x Position of the new guide line.
+ * @return  {Guide} New guide line.
  */
 pub.guideX = function (x) {
   checkNull(x);
@@ -2596,12 +2769,14 @@ pub.guideX = function (x) {
 
 
 /**
- * @description Creates a horizontal guide line at the current spread and current layer.
+ * @description Creates a horizontal guide line at the current spread and
+ *          current layer.
  *
- * @cat    Document
- * @method guideY
- * @param  {Number} y Position of the new guide line.
- * @return {Guide} New guide line.
+ * @cat     Document
+ * @method  guideY
+ *
+ * @param   {Number} y Position of the new guide line.
+ * @return  {Guide} New guide line.
  */
 pub.guideY = function (y) {
   checkNull(y);
@@ -2615,17 +2790,24 @@ pub.guideY = function (y) {
 
 
 /**
- * @description Sets the margins of a given page. If 1 value is given, all 4 sides are set equally. If 4 values are given, the current page will be adjusted. Adding a 5th value will set the margin of a given page. Calling the function without any values, will return the margins for the current page.
+ * @description Sets the margins of a given page. If 1 value is given, all 4
+ *          sides are set equally. If 4 values are given, the current page will
+ *          be adjusted. Adding a 5th value will set the margin of a given page.
+ *          Calling the function without any values, will return the margins for
+ *          the current page.
  *
- * @cat    Document
- * @subcat Page
- * @method margins
- * @param  {Number} [top] Top margin or all if only one.
- * @param  {Number} [right] Right margin.
- * @param  {Number} [bottom] Bottom margin.
- * @param  {Number} [left] Left margin.
- * @param  {Number} [pageNumber] Sets margins to selected page, currentPage() if left blank.
- * @return {Object} Current page margins with the properties: top, right, bottom, left.
+ * @cat     Document
+ * @subcat  Page
+ * @method  margins
+ *
+ * @param   {Number} [top] Top margin or all if only one.
+ * @param   {Number} [right] Right margin.
+ * @param   {Number} [bottom] Bottom margin.
+ * @param   {Number} [left] Left margin.
+ * @param   {Number} [pageNumber] Sets margins to selected page, currentPage()
+ *          if left blank.
+ * @return  {Object} Current page margins with the properties: `top`, `right`,
+ *          `bottom`, `left`.
  */
 pub.margins = function(top, right, bottom, left, pageNumber) {
   if (arguments.length === 0) {
@@ -2652,16 +2834,20 @@ pub.margins = function(top, right, bottom, left, pageNumber) {
 
 
 /**
- * @description Sets the document bleeds. If one value is given, all 4 are set equally. If 4 values are given, the top/right/bottom/left document bleeds will be adjusted. Calling the function without any values, will return the document bleed settings.
+ * @description Sets the document bleeds. If one value is given, all 4 are set
+ *          equally. If 4 values are given, the top/right/bottom/left document
+ *          bleeds will be adjusted. Calling the function without any values,
+ *          will return the document bleed settings.
  *
- * @cat    Document
- * @subcat Page
- * @method bleeds
- * @param  {Number} [top] Top bleed or all if only one.
- * @param  {Number} [right] Right bleed.
- * @param  {Number} [bottom] Bottom bleed.
- * @param  {Number} [left] Left bleed.
- * @return {Object} Current document bleeds settings.
+ * @cat     Document
+ * @subcat  Page
+ * @method  bleeds
+ *
+ * @param   {Number} [top] Top bleed or all if only one.
+ * @param   {Number} [right] Right bleed.
+ * @param   {Number} [bottom] Bottom bleed.
+ * @param   {Number} [left] Left bleed.
+ * @return  {Object} Current document bleeds settings.
  */
 pub.bleeds = function(top, right, bottom, left) {
   if (arguments.length === 0) {
@@ -2683,31 +2869,48 @@ pub.bleeds = function(top, right, bottom, left) {
 
 
 /**
- * @description Inspects a given object or any other data item and prints the result to the console. This is useful for inspecting or debugging any kind of variable or data item. The optional settings object allows to control the function's output. The following parameters can be set in the settings object:<br>
- * `showProps`: Show or hide properties. Default: `true`<br>
- * `showValues`: Show or hide values. Default: `true`<br>
- * `showMethods`: Show or hide methods. Default: `false`<br>
- * `maxLevel`: Chooses how many levels of properties should be inspected recursively. Default: `1`<br>
- * `propList`: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: `[]` (no propList)<br>
- * If no settings object is set, the default values will be used.
+ * @description Inspects a given object or any other data item and prints the
+ *          result to the console. This is useful for inspecting or debugging
+ *          any kind of variable or data item. The optional settings object
+ *          allows to control the function's output. The following parameters
+ *          can be set in the settings object:
  *
- * @cat    Output
- * @method inspect
- * @param  {Object} obj An object or any other data item to be inspected.
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {Boolean} [settings.showProps] Show or hide properties. Default: `true`
- * @param  {Boolean} [settings.showValues] Show or hide values. Default: `true`
- * @param  {Boolean} [settings.showMethods] Show or hide methods. Default: `false`
- * @param  {Number} [settings.maxLevel] How many levels of properties should be inspected recursively. Default: `1`
- * @param  {Array} [settings.propList] Array of properties to show. Default: `[]` (no propList)
+ *      - `showProps`: Show or hide properties. Default: `true`
+ *      - `showValues`: Show or hide values. Default: `true`
+ *      - `showMethods`: Show or hide methods. Default: `false`
+ *      - `maxLevel`: Chooses how many levels of properties should be inspected
+ *        recursively. Default: `1`
+ *      - `propList`: Allows to pass an array of property names to show. If
+ *        `propList` is not set all properties will be shown. Default: `[]`
+ *        (no propList)
+ *
+ *      If no settings object is set, the default values will be used.
+ *
+ * @cat     Output
+ * @method  inspect
+ *
+ * @param   {Object} obj An object or any other data item to be inspected.
+ * @param   {Object} [settings] A settings object to control the function's
+ *          behavior.
+ * @param   {Boolean} [settings.showProps] Show or hide properties. Default:
+ *          `true`
+ * @param   {Boolean} [settings.showValues] Show or hide values. Default: `true`
+ * @param   {Boolean} [settings.showMethods] Show or hide methods. Default:
+ *          `false`
+ * @param   {Number} [settings.maxLevel] How many levels of properties should be
+ *          inspected recursively. Default: `1`
+ * @param   {Array} [settings.propList] Array of properties to show. Default:
+ *          `[]` (no propList)
  *
  * @example <caption>Inspecting a string</caption>
  * inspect("foo");
  *
- * @example <caption>Inspecting the current page, its methods and an additional level of properties</caption>
+ * @example <caption>Inspecting the current page, its methods and an additional
+ *          level of properties</caption>
  * inspect(page(), {showMethods: true, maxLevel: 2})
  *
- * @example <caption>Inspecting an ellipse, listing only the properties "geometricBounds" and "strokeWeight"</caption>
+ * @example <caption>Inspecting an ellipse, listing only the properties
+ *          "geometricBounds" and "strokeWeight"</caption>
  * var myEllipse = ellipse(0, 0, 10, 10);
  * inspect(myEllipse, {maxLevel: 2, propList: ["geometricBounds, strokeWeight"]});
  */
@@ -2876,14 +3079,19 @@ pub.inspect = function (obj, settings, level, branchArray, branchEnd) {
 
 /**
  * @description Returns a file object.<br>
- * Note that the resulting file object can either refer to an already existing file or if the file does not exist, it can create a preliminary "virtual" file that refers to a file that could be created later (i.e. by an export command).
+ *          Note that the resulting file object
+ *          can either refer to an already existing file or if the file does not
+ *          exist, it can create a preliminary "virtual" file that refers to a
+ *          file that could be created later (i.e. by an export command).
  *
- * @cat    Files
- * @method file
- * @param  {String} filePath The file path.
- * @return {File} File at the given path.
+ * @cat     Files
+ * @method  file
  *
- * @example <caption>Get an image file from the desktop and place it in the document</caption>
+ * @param   {String} filePath The file path.
+ * @return  {File} File at the given path.
+ *
+ * @example <caption>Get an image file from the desktop and place it in the
+ *          document</caption>
  * var myImage = file("~/Desktop/myImage.jpg");
  * image(myImage, 0, 0);
  *
@@ -2914,18 +3122,25 @@ pub.file = function(filePath) {
 
 /**
  * @description Returns a folder object.<br>
- * Note that the resulting folder object can either refer to an already existing folder or if the folder does not exist, it can create a preliminary "virtual" folder that refers to a folder that could be created later.
+ *          Note that the resulting folder
+ *          object can either refer to an already existing folder or if the
+ *          folder does not exist, it can create a preliminary "virtual" folder
+ *          that refers to a folder that could be created later.
  *
- * @cat    Files
- * @method folder
- * @param  {String} [folderPath] The path of the folder.
- * @return {Folder} Folder at the given path. If no path is given, but the document is already saved, the document's data folder will be returned.
+ * @cat     Files
+ * @method  folder
+ *
+ * @param   {String} [folderPath] The path of the folder.
+ * @return  {Folder} Folder at the given path. If no path is given, but the
+ *          document is already saved, the document's data folder will be
+ *          returned.
  *
  * @example <caption>Get a folder from the desktop and load its files</caption>
  * var myImageFolder = folder("~/Desktop/myImages/");
  * var myImageFiles = files(myImageFolder);
  *
- * @example <caption>Get the data folder, if the document is already saved</caption>
+ * @example <caption>Get the data folder, if the document is already
+ *          saved</caption>
  * var myDataFolder = folder();
  */
 pub.folder = function(folderPath) {
@@ -2957,23 +3172,34 @@ pub.folder = function(folderPath) {
 };
 
 /**
- * @description Gets all files of a folder and returns them in an array of file objects.
- * The settings object can be used to restrict the search to certain file types only, to include hidden files and to include files in subfolders.
+ * @description Gets all files of a folder and returns them in an array of file
+ *          objects. The settings object can be used to restrict the search to
+ *          certain file types only, to include hidden files and to include
+ *          files in subfolders.
  *
- * @cat    Files
- * @method files
- * @param  {Folder|String} [folder] The folder that holds the files or a string describing the path to that folder.
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String|Array} [settings.filter] Suffix(es) of file types to include. Default: `"*"` (include all file types)
- * @param  {Boolean} [settings.hidden] Hidden files will be included. Default: `false`
- * @param  {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: `false`
- * @return {Array} Array of the resulting file(s). If no files are found, an empty array will be returned.
+ * @cat     Files
+ * @method  files
  *
- * @example <caption>Get a folder from the desktop and load all its JPEG files</caption>
+ * @param   {Folder|String} [folder] The folder that holds the files or a string
+ *          describing the path to that folder.
+ * @param   {Object} [settings] A settings object to control the function's
+ *          behavior.
+ * @param   {String|Array} [settings.filter] Suffix(es) of file types to
+ *          include. Default: `"*"` (include all file types)
+ * @param   {Boolean} [settings.hidden] Hidden files will be included. Default:
+ *          `false`
+ * @param   {Boolean} [settings.recursive] Searches subfolders recursively for
+ *          matching files. Default: `false`
+ * @return  {Array} Array of the resulting file(s). If no files are found, an
+ *          empty array will be returned.
+ *
+ * @example <caption>Get a folder from the desktop and load all its JPEG
+ *          files</caption>
  * var myImageFolder = folder("~/Desktop/myImages/");
  * var myImageFiles = files(myImageFolder, {filter: ["jpeg", "jpg"]});
  *
- * @example <caption>If the document is saved, load all files from its data folder, including from its subfolders</caption>
+ * @example <caption>If the document is saved, load all files from its data
+ *          folder, including from its subfolders</caption>
  * var myDataFolder = folder();
  * var allMyDataFiles = files(myDataFolder, {recursive: true});
  */
@@ -3037,20 +3263,32 @@ pub.files = function(folder, settings, collectedFiles) {
 };
 
 /**
- * @description Opens a selection dialog that allows to select one file. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select one file. The
+ *          settings object can be used to add a prompt text at the top of the
+ *          dialog, to restrict the selection to certain file types and to set
+ *          the dialog's starting folder.
  *
- * @cat    Files
- * @method selectFile
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
- * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
- * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {File|Null} The selected file. If the user cancels, `null` will be returned.
+ * @cat     Files
+ * @method  selectFile
+ *
+ * @param   {Object} [settings] A settings object to control the function's
+ *          behavior.
+ * @param   {String} [settings.prompt] The prompt text at the top of the file
+ *          selection dialog. Default: `""` (no prompt)
+ * @param   {String|Array} [settings.filter] String or an array containing
+ *          strings of file endings to include in the dialog. Default: `""`
+ *          (include all)
+ * @param   {Folder|String} [settings.folder] Folder or a folder path string
+ *          defining the start location of the dialog. Default: most recent
+ *          dialog folder or main user folder.
+ * @return  {File|Null} The selected file. If the user cancels, `null` will be
+ *          returned.
  *
  * @example <caption>Open file selection dialog with a prompt text</caption>
  * selectFile({prompt: "Please select a file."});
  *
- * @example <caption>Open selection dialog starting at the user's desktop, allowing to only select PNG or JPEG files</caption>
+ * @example <caption>Open selection dialog starting at the user's desktop,
+ *          allowing to only select PNG or JPEG files</caption>
  * selectFile({folder: "~/Desktop/", filter: ["jpeg", "jpg", "png"]});
  */
 pub.selectFile = function(settings) {
@@ -3058,20 +3296,32 @@ pub.selectFile = function(settings) {
 };
 
 /**
- * @description Opens a selection dialog that allows to select one or multiple files. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select one or multiple
+ *          files. The settings object can be used to add a prompt text at the
+ *          top of the dialog, to restrict the selection to certain file types
+ *          and to set the dialog's starting folder.
  *
- * @cat    Files
- * @method selectFiles
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
- * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
- * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {Array} Array of the selected file(s). If the user cancels, an empty array will be returned.
+ * @cat     Files
+ * @method  selectFiles
+ *
+ * @param   {Object} [settings] A settings object to control the function's
+ *          behavior.
+ * @param   {String} [settings.prompt] The prompt text at the top of the file
+ *          selection dialog. Default: `""` (no prompt)
+ * @param   {String|Array} [settings.filter] String or an array containing
+ *          strings of file endings to include in the dialog. Default: `""`
+ *          (include all)
+ * @param   {Folder|String} [settings.folder] Folder or a folder path string
+ *          defining the start location of the dialog. Default: most recent
+ *          dialog folder or main user folder.
+ * @return  {Array} Array of the selected file(s). If the user cancels, an empty
+ *          array will be returned.
  *
  * @example <caption>Open file selection dialog with a prompt text</caption>
  * selectFiles({prompt: "Please select your files."});
  *
- * @example <caption>Open selection dialog starting at the user's desktop, allowing to only select PNG or JPEG files</caption>
+ * @example <caption>Open selection dialog starting at the user's desktop,
+ *          allowing to only select PNG or JPEG files</caption>
  * selectFiles({folder: "~/Desktop/", filter: ["jpeg", "jpg", "png"]});
  */
 pub.selectFiles = function(settings) {
@@ -3084,19 +3334,28 @@ pub.selectFiles = function(settings) {
 };
 
 /**
- * @description Opens a selection dialog that allows to select a folder. The settings object can be used to add a prompt text at the top of the dialog and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select a folder. The
+ *          settings object can be used to add a prompt text at the top of the
+ *          dialog and to set the dialog's starting folder.
  *
- * @cat    Files
- * @method selectFolder
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: `""` (no prompt)
- * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {Folder|Null} The selected folder. If the user cancels, `null` will be returned.
+ * @cat     Files
+ * @method  selectFolder
+ *
+ * @param   {Object} [settings] A settings object to control the function's
+ *          behavior.
+ * @param   {String} [settings.prompt] The prompt text at the top of the folder
+ *          selection dialog. Default: `""` (no prompt)
+ * @param   {Folder|String} [settings.folder] Folder or a folder path string
+ *          defining the start location of the dialog. Default: most recent
+ *          dialog folder or main user folder.
+ * @return  {Folder|Null} The selected folder. If the user cancels, `null` will
+ *          be returned.
  *
  * @example <caption>Open folder selection dialog with a prompt text</caption>
  * selectFolder({prompt: "Please select a folder."});
  *
- * @example <caption>Open folder selection dialog starting at the user's desktop</caption>
+ * @example <caption>Open folder selection dialog starting at the user's
+ *          desktop</caption>
  * selectFolder({folder: "~/Desktop/"});
  */
 pub.selectFolder = function(settings) {
@@ -3113,12 +3372,14 @@ pub.selectFolder = function(settings) {
 // Date
 
 /**
- * @description The year() function returns the current year as an integer (2012, 2013 etc).
+ * @description The `year()` function returns the current year as a number
+ *          (`2018`, `2019` etc).
  *
- * @cat    Environment
- * @subcat Date
- * @method year
- * @return {Number} The current year.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  year
+ *
+ * @return  {Number} The current year.
  */
 pub.year = function() {
   return (new Date()).getFullYear();
@@ -3126,12 +3387,14 @@ pub.year = function() {
 
 
 /**
- * @description The month() function returns the current month as a value from 1 - 12.
+ * @description The `month()` function returns the current month as a value from
+ *          `1`-`12`.
  *
- * @cat    Environment
- * @subcat Date
- * @method month
- * @return {Number} The current month number.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  month
+ *
+ * @return  {Number} The current month number.
  */
 pub.month = function() {
   return (new Date()).getMonth() + 1;
@@ -3139,12 +3402,14 @@ pub.month = function() {
 
 
 /**
- * @description The day() function returns the current day as a value from 1 - 31.
+ * @description The `day()` function returns the current day as a value from
+ *          `1`-`31`.
  *
- * @cat    Environment
- * @subcat Date
- * @method day
- * @return {Number} The current day number.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  day
+ *
+ * @return  {Number} The current day number.
  */
 pub.day = function() {
   return (new Date()).getDate();
@@ -3152,12 +3417,14 @@ pub.day = function() {
 
 
 /**
- * @description The weekday() function returns the current weekday as a string from Sunday, Monday, Tuesday...
+ * @description The `weekday()` function returns the current weekday as a string
+ *          from `Sunday`, `Monday`, `Tuesday` ...
  *
- * @cat    Environment
- * @subcat Date
- * @method weekday
- * @return {String} The current weekday name.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  weekday
+ *
+ * @return  {String} The current weekday name.
  */
 pub.weekday = function() {
   var weekdays = new Array("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday");
@@ -3166,12 +3433,14 @@ pub.weekday = function() {
 
 
 /**
- * @description The hour() function returns the current hour as a value from 0 - 23.
+ * @description The `hour()` function returns the current hour as a value from
+ *          `0` - `23`.
  *
- * @cat    Environment
- * @subcat Date
- * @method hour
- * @return {Number} The current hour.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  hour
+ *
+ * @return  {Number} The current hour.
  */
 pub.hour = function() {
   return (new Date()).getHours();
@@ -3179,12 +3448,14 @@ pub.hour = function() {
 
 
 /**
- * @description The minute() function returns the current minute as a value from 0 - 59.
+ * @description The `minute()` function returns the current minute as a value
+ *          from `0` - `59`.
  *
- * @cat    Environment
- * @subcat Date
- * @method minute
- * @return {Number} The current minute.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  minute
+ *
+ * @return  {Number} The current minute.
  */
 pub.minute = function() {
   return (new Date()).getMinutes();
@@ -3192,12 +3463,14 @@ pub.minute = function() {
 
 
 /**
- * @description The second() function returns the current second as a value from 0 - 59.
+ * @description The `second()` function returns the current second as a value
+ *          from `0` - `59`.
  *
- * @cat    Environment
- * @subcat Date
- * @method second
- * @return {Number} The current second.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  second
+ *
+ * @return  {Number} The current second.
  */
 pub.second = function() {
   return (new Date()).getSeconds();
@@ -3205,12 +3478,14 @@ pub.second = function() {
 
 
 /**
- * @description Returns the number of milliseconds (thousandths of a second) since starting an applet.
+ * @description Returns the number of milliseconds (thousandths of a second)
+ *          since starting the script.
  *
- * @cat    Environment
- * @subcat Date
- * @method millis
- * @return {Number} The current milli.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  millis
+ *
+ * @return  {Number} The current milli.
  */
 pub.millis = function() {
   return Date.now() - startTime;
@@ -3218,12 +3493,15 @@ pub.millis = function() {
 
 
 /**
- * @description The millisecond() function differs from millis(), in that it returns the exact millisecond (thousandths of a second) of the current time.
+ * @description The `millisecond()` function differs from `millis()`, in that it
+ *          returns the exact millisecond (thousandths of a second) of the
+ *          current time.
  *
- * @cat    Environment
- * @subcat Date
- * @method millisecond
- * @return {Number} The current millisecond.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  millisecond
+ *
+ * @return  {Number} The current millisecond.
  */
 pub.millisecond = function() {
   return (new Date()).getMilliseconds();
@@ -3231,12 +3509,14 @@ pub.millisecond = function() {
 
 
 /**
- * @description The timestamp() function returns the current date formatted as YYYYMMDD_HHMMSS for useful unique filenaming.
+ * @description The `timestamp()` function returns the current date formatted as
+ *          `YYYYMMDD_HHMMSS` for useful unique filenaming.
  *
- * @cat    Environment
- * @subcat Date
- * @method timestamp
- * @return {String} The current time in YYYYMMDD_HHMMSS.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  timestamp
+ *
+ * @return  {String} The current time in `YYYYMMDD_HHMMSS`.
  */
 pub.timestamp = function() {
   var dt = new Date();
@@ -4514,17 +4794,21 @@ pub.download = function(url, file) {
 // ----------------------------------------
 
 /**
- * @description Draws an ellipse (oval) in the display window. An ellipse with an equal width and height is a circle.
- * The first two parameters set the location, the third sets the width, and the fourth sets the height.
+ * @description Draws an ellipse (oval) in the display window. An ellipse with
+ *          an equal width and height is a circle. The first two parameters set
+ *          the location, the third sets the width, and the fourth sets the
+ *          height.
  *
- * @cat    Document
- * @subcat Primitives
- * @method ellipse
- * @param  {Number} x X-coordinate of the ellipse.
- * @param  {Number} y Y-coordinate of the ellipse.
- * @param  {Number} w Width of the ellipse.
- * @param  {Number} h Height of the ellipse.
- * @return {Oval} New Oval (in InDesign Scripting terms the corresponding type is Oval, not Ellipse).
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  ellipse
+ *
+ * @param   {Number} x X-coordinate of the ellipse.
+ * @param   {Number} y Y-coordinate of the ellipse.
+ * @param   {Number} w Width of the ellipse.
+ * @param   {Number} h Height of the ellipse.
+ * @return  {Oval} New Oval (in InDesign Scripting terms the corresponding type
+ *          is Oval, not Ellipse).
  */
 pub.ellipse = function(x, y, w, h) {
   if (arguments.length !== 4) error("ellipse(), not enough parameters to draw an ellipse! Use: x, y, w, h");
@@ -4579,18 +4863,19 @@ pub.ellipse = function(x, y, w, h) {
 /**
  * @description Draws a line (a direct path between two points) to the page.
  *
- * @cat    Document
- * @subcat Primitives
- * @method line
- * @param  {Number} x1 X-coordinate of Point 1.
- * @param  {Number} y1 Y-coordinate of Point 1.
- * @param  {Number} x2 X-coordinate of Point 2.
- * @param  {Number} y2 Y-coordinate of Point 2.
- * @return {GraphicLine} New GraphicLine.
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  line
+ *
+ * @param   {Number} x1 X-coordinate of Point 1.
+ * @param   {Number} y1 Y-coordinate of Point 1.
+ * @param   {Number} x2 X-coordinate of Point 2.
+ * @param   {Number} y2 Y-coordinate of Point 2.
+ * @return  {GraphicLine} New GraphicLine.
  *
  * @example
- * var vec1 = new Vector( x1, y1 );
- * var vec2 = new Vector( x2, y2 );
+ * var vec1 = new Vector(x1, y1);
+ * var vec2 = new Vector(x2, y2);
  * line( vec1, vec2 );
  */
 pub.line = function(x1, y1, x2, y2) {
@@ -4612,16 +4897,20 @@ pub.line = function(x1, y1, x2, y2) {
 };
 
 /**
- * @description Using the beginShape() and endShape() functions allows to create more complex forms.
- * beginShape() begins recording vertices for a shape and endShape() stops recording.
- * After calling the beginShape() function, a series of vertex() commands must follow.
- * To stop drawing the shape, call endShape(). The shapeMode parameter allows to close the shape
- * (to connect the beginning and the end).
+ * @description Using the `beginShape()` and `endShape()` functions allows to
+ *          create more complex forms. `beginShape()` begins recording vertices
+ *          for a shape and `endShape()` stops recording. After calling the
+ *          `beginShape()` function, a series of `vertex()` commands must
+ *          follow. To stop drawing the shape, call `endShape()`. The shapeMode
+ *          parameter allows to close the shape (to connect the beginning and
+ *          the end).
  *
- * @cat    Document
- * @subcat Primitives
- * @method beginShape
- * @param  {String} shapeMode Set to CLOSE if the new Path should be auto-closed.
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  beginShape
+ *
+ * @param   {String} shapeMode Set to `CLOSE` if the new path should be
+ *          auto-closed.
  */
 pub.beginShape = function(shapeMode) {
   currVertexPoints = [];
@@ -4635,23 +4924,24 @@ pub.beginShape = function(shapeMode) {
 };
 
 /**
- * @description Shapes are constructed by connecting a series of vertices. vertex() is used to
- * specify the vertex coordinates of lines and polygons. It is used exclusively between
- * the beginShape() and endShape() functions.
- * <br><br>
- * Use either vertex(x, y) for drawing straight corners or
- * vertex(x, y, xLeftHandle, yLeftHandle, xRightHandle, yRightHandle) for drawing bezier shapes.
- * You can also mix the two approaches.
+ * @description Shapes are constructed by connecting a series of vertices.
+ *          `vertex()` is used to specify the vertex coordinates of lines and
+ *          polygons. It is used exclusively between the `beginShape()` and
+ *          `endShape()` functions. <br><br> Use either `vertex(x, y)` for
+ *          drawing straight corners or `vertex(x, y, xLeftHandle, yLeftHandle,
+ *          xRightHandle, yRightHandle)` for drawing bezier shapes. You can also
+ *          mix the two approaches.
  *
- * @cat    Document
- * @subcat Primitives
- * @method vertex
- * @param  {Number} x X-coordinate of the vertex.
- * @param  {Number} y Y-coordinate of the vertex.
- * @param  {Number} [xLeftHandle] X-coordinate of the left-direction point.
- * @param  {Number} [yLeftHandle] Y-coordinate of the left-direction point.
- * @param  {Number} [xRightHandle] X-coordinate of the right-direction point.
- * @param  {Number} [yRightHandle] Y-coordinate of the right-direction point.
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  vertex
+ *
+ * @param   {Number} x X-coordinate of the vertex.
+ * @param   {Number} y Y-coordinate of the vertex.
+ * @param   {Number} [xLeftHandle] X-coordinate of the left-direction point.
+ * @param   {Number} [yLeftHandle] Y-coordinate of the left-direction point.
+ * @param   {Number} [xRightHandle] X-coordinate of the right-direction point.
+ * @param   {Number} [yRightHandle] Y-coordinate of the right-direction point.
  */
 pub.vertex = function() {
   if (isArray(currVertexPoints)) {
@@ -4671,23 +4961,27 @@ pub.vertex = function() {
 };
 
 /**
- * @description The arc() function draws an arc. Arcs are drawn along the outer edge of an ellipse
- * defined by the x, y, width and height parameters.
- * The origin or the arc's ellipse may be changed with the ellipseMode() function.
- * The start and stop parameters specify the angles at which to draw the arc.
+ * @description The `arc()` function draws an arc. Arcs are drawn along the
+ *          outer edge of an ellipse defined by the `x`, `y`, `width` and
+ *          `height` parameters. The origin or the arc's ellipse may be changed
+ *          with the `ellipseMode()` function. The start and stop parameters
+ *          specify the angles at which to draw the arc.
  *
- * @cat    Document
- * @subcat Primitives
- * @method arc
- * @param  {Number} cx X-coordinate of the arc's center.
- * @param  {Number} cy Y-coordinate of the arc's center.
- * @param  {Number} w Width of the arc's ellipse.
- * @param  {Number} h Height of the arc's ellipse.
- * @param  {Number} startAngle Starting angle of the arc in radians.
- * @param  {Number} endAngle Ending angle of the arc in radians.
- * @param  {String} [mode] Mode to define the rendering technique of the arc: OPEN (default), CHORD, or PIE.
- * @return {GraphicLine|Polygon} The resulting GraphicLine or Polygon object (in InDesign Scripting terms the corresponding type is GraphicLine or Polygon, not Arc).
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  arc
  *
+ * @param   {Number} cx X-coordinate of the arc's center.
+ * @param   {Number} cy Y-coordinate of the arc's center.
+ * @param   {Number} w Width of the arc's ellipse.
+ * @param   {Number} h Height of the arc's ellipse.
+ * @param   {Number} startAngle Starting angle of the arc in radians.
+ * @param   {Number} endAngle Ending angle of the arc in radians.
+ * @param   {String} [mode] Mode to define the rendering technique of the arc:
+ *          `OPEN` (default), `CHORD`, or `PIE`.
+ * @return  {GraphicLine|Polygon} The resulting GraphicLine or Polygon object
+ *          (in InDesign Scripting terms the corresponding type is GraphicLine
+ *          or Polygon, not Arc).
  */
 pub.arc = function(cx, cy, w, h, startAngle, endAngle, mode) {
   if (w <= 0 || endAngle < startAngle) {
@@ -4760,16 +5054,12 @@ pub.arc = function(cx, cy, w, h, startAngle, endAngle, mode) {
 /*
  * Cubic bezier approximation of a eliptical arc
  *
- * intial source code:
- * Golan Levin
- * golan@flong.com
+ * intial source code: Golan Levin golan@flong.com
  * http://www.flong.com/blog/2009/bezier-approximation-of-a-circular-arc-in-processing/
  *
  * The solution is taken from this PDF by Richard DeVeneza:
- * http://www.tinaja.com/glib/bezcirc2.pdf
- * linked from this excellent site by Don Lancaster:
- * http://www.tinaja.com/cubic01.asp
- *
+ * http://www.tinaja.com/glib/bezcirc2.pdf linked from this excellent site by
+ * Don Lancaster: http://www.tinaja.com/cubic01.asp
  */
 function calculateEllipticalArc(w, h, startAngle, endAngle) {
   var theta = (endAngle - startAngle);
@@ -4801,14 +5091,15 @@ function calculateEllipticalArc(w, h, startAngle, endAngle) {
 }
 
 /**
- * @description addPath() is used to create multi component paths. Call addPath() to add
- * the vertices drawn so far to a single path. New vertices will then end up in a new path and
- * endShape() will return a multi path object. All component paths will account for
- * the setting (see CLOSE) given in beginShape(shapeMode).
+ * @description `addPath()` is used to create multi component paths. Call
+ *          `addPath()` to add the vertices drawn so far to a single path. New
+ *          vertices will then end up in a new path and `endShape()` will return
+ *          a multi path object. All component paths will account for the
+ *          setting (see `CLOSE`) given in `beginShape(shapeMode)`.
  *
- * @cat    Document
- * @subcat Primitives
- * @method addPath
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  addPath
  */
 pub.addPath = function() {
   doAddPath();
@@ -4816,13 +5107,15 @@ pub.addPath = function() {
 };
 
 /**
- * @description The endShape() function is the companion to beginShape() and may only be called
- * after beginShape().
+ * @description The `endShape()` function is the companion to `beginShape()` and
+ *          may only be called after `beginShape()`.
  *
- * @cat    Document
- * @subcat Primitives
- * @method endShape
- * @return {GraphicLine|Polygon} The GraphicLine or Polygon object that was created.
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  endShape
+ *
+ * @return  {GraphicLine|Polygon} The GraphicLine or Polygon object that was
+ *          created.
  */
 pub.endShape = function() {
   doAddPath();
@@ -4871,21 +5164,30 @@ function notCalledBeginShapeError () {
 
 /**
  * @description Draws a rectangle on the page.<br>
- * By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, however, may be changed with the rectMode() function.<br>
- * The fifth, sixth, seventh and eighth parameters, if specified, determine corner radius for the top-right, top-left, lower-right and lower-left corners, respectively. If only a fifth parameter is provided, all corners will be set to this radius.
+ *          By default, the first two
+ *          parameters set the location of the upper-left corner, the third sets
+ *          the width, and the fourth sets the height. The way these parameters
+ *          are interpreted, however, may be changed with the `rectMode()`
+ *          function.<br>
+ *          The fifth, sixth, seventh and eighth parameters, if
+ *          specified, determine corner radius for the top-right, top-left,
+ *          lower-right and lower-left corners, respectively. If only a fifth
+ *          parameter is provided, all corners will be set to this radius.
  *
- * @cat    Document
- * @subcat Primitives
- * @method rect
- * @param  {Number} x X-coordinate of the rectangle.
- * @param  {Number} y Y-coordinate of the rectangle.
- * @param  {Number} w Width of the rectangle.
- * @param  {Number} h Height of the rectangle.
- * @param  {Number} [tl] Radius of top left corner or radius of all 4 corners (optional).
- * @param  {Number} [tr] Radius of top right corner (optional).
- * @param  {Number} [br] Radius of bottom right corner (optional).
- * @param  {Number} [bl] Radius of bottom left corner (optional).
- * @return {Rectangle} The rectangle that was created.
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  rect
+ *
+ * @param   {Number} x X-coordinate of the rectangle.
+ * @param   {Number} y Y-coordinate of the rectangle.
+ * @param   {Number} w Width of the rectangle.
+ * @param   {Number} h Height of the rectangle.
+ * @param   {Number} [tl] Radius of top left corner or radius of all 4 corners
+ *          (optional).
+ * @param   {Number} [tr] Radius of top right corner (optional).
+ * @param   {Number} [br] Radius of bottom right corner (optional).
+ * @param   {Number} [bl] Radius of bottom left corner (optional).
+ * @return  {Rectangle} The rectangle that was created.
  */
 pub.rect = function(x, y, w, h, tl, tr, br, bl) {
   if (w === 0 || h === 0) {
@@ -4958,23 +5260,25 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
 // -- Attributes --
 
 /**
- * @description Modifies the location from which rectangles or text frames draw. The default
- * mode is rectMode(CORNER), which specifies the location to be the upper left
- * corner of the shape and uses the `w` and `h` parameters to specify the
- * width and height. The syntax rectMode(CORNERS) uses the `x` and `y`
- * parameters of `rect()` or `text()` to set the location of one corner
- * and uses the `w` and `h` parameters to set the opposite corner.
- * The syntax `rectMode(CENTER)` draws the shape from its center point and
- * uses the `w` and `h` parameters to specify the shape's
- * width and height. The syntax `rectMode(RADIUS)` draws the shape from its
- * center point and uses the `w` and `h` parameters to specify
- * half of the shape's width and height.
+ * @description Modifies the location from which rectangles or text frames draw.
+ *          The default mode is rectMode(CORNER), which specifies the location
+ *          to be the upper left corner of the shape and uses the `w` and `h`
+ *          parameters to specify the width and height. The syntax
+ *          rectMode(CORNERS) uses the `x` and `y` parameters of `rect()` or
+ *          `text()` to set the location of one corner and uses the `w` and `h`
+ *          parameters to set the opposite corner. The syntax `rectMode(CENTER)`
+ *          draws the shape from its center point and uses the `w` and `h`
+ *          parameters to specify the shape's width and height. The syntax
+ *          `rectMode(RADIUS)` draws the shape from its center point and uses
+ *          the `w` and `h` parameters to specify half of the shape's width and
+ *          height.
  *
- * @cat    Document
- * @subcat Attributes
- * @method rectMode
- * @param  {String} mode The rectMode to switch to: either CORNER, CORNERS, CENTER, or RADIUS.
+ * @cat     Document
+ * @subcat  Attributes
+ * @method  rectMode
  *
+ * @param   {String} mode The rectMode to switch to: either CORNER, CORNERS,
+ *          CENTER, or RADIUS.
  */
 pub.rectMode = function (mode) {
   if (arguments.length === 0) return currRectMode;
@@ -4987,19 +5291,22 @@ pub.rectMode = function (mode) {
 };
 
 /**
- * @description The origin of new ellipses is modified by the `ellipseMode()` function.
- * The default configuration is `ellipseMode(CENTER)`, which specifies the
- * location of the ellipse as the center of the shape. The RADIUS mode is
- * the same, but the `w` and `h` parameters to `ellipse()` specify the
- * radius of the ellipse, rather than the diameter. The CORNER mode draws
- * the shape from the upper-left corner of its bounding box. The CORNERS
- * mode uses the four parameters to `ellipse()` to set two opposing corners
- * of the ellipse's bounding box.
+ * @description The origin of new ellipses is modified by the `ellipseMode()`
+ *          function. The default configuration is `ellipseMode(CENTER)`, which
+ *          specifies the location of the ellipse as the center of the shape.
+ *          The RADIUS mode is the same, but the `w` and `h` parameters to
+ *          `ellipse()` specify the radius of the ellipse, rather than the
+ *          diameter. The CORNER mode draws the shape from the upper-left corner
+ *          of its bounding box. The CORNERS mode uses the four parameters to
+ *          `ellipse()` to set two opposing corners of the ellipse's bounding
+ *          box.
  *
- * @cat    Document
- * @subcat Attributes
- * @method ellipseMode
- * @param  {String} mode The ellipse mode to switch to: either CENTER, RADIUS, CORNER, or CORNERS.
+ * @cat     Document
+ * @subcat  Attributes
+ * @method  ellipseMode
+ *
+ * @param   {String} mode The ellipse mode to switch to: either CENTER, RADIUS,
+ *          CORNER, or CORNERS.
  */
 pub.ellipseMode = function (mode) {
   if (arguments.length === 0) return currEllipseMode;
@@ -5012,12 +5319,14 @@ pub.ellipseMode = function (mode) {
 };
 
 /**
- * @description Sets the width of the stroke used for lines and the border around shapes.
+ * @description Sets the width of the stroke used for lines and the border
+ *          around shapes.
  *
- * @cat    Document
- * @subcat Attributes
- * @method strokeWeight
- * @param  {Number} weight The width of the stroke in points.
+ * @cat     Document
+ * @subcat  Attributes
+ * @method  strokeWeight
+ *
+ * @param   {Number} weight The width of the stroke in points.
  */
 pub.strokeWeight = function (weight) {
   if (typeof weight === "string" || typeof weight === "number") {
@@ -5028,15 +5337,19 @@ pub.strokeWeight = function (weight) {
 };
 
 /**
- * @description Returns the object style of a given page item or the object style with the given name. If an
- * object style of the given name does not exist, it gets created. Optionally a props object of
- * property name/value pairs can be used to set the object style's properties.
+ * @description Returns the object style of a given page item or the object
+ *          style with the given name. If an object style of the given name does
+ *          not exist, it gets created. Optionally a props object of property
+ *          name/value pairs can be used to set the object style's properties.
  *
- * @cat    Typography
- * @method objectStyle
- * @param  {PageItem|String} itemOrName A page item whose style to return or the name of the object style to return.
- * @param  {Object} [props] An object of property name/value pairs to set the style's properties.
- * @return {ObjectStyle} The object style instance.
+ * @cat     Typography
+ * @method  objectStyle
+ *
+ * @param   {PageItem|String} itemOrName A page item whose style to return or
+ *          the name of the object style to return.
+ * @param   {Object} [props] An object of property name/value pairs to set the
+ *          style's properties.
+ * @return  {ObjectStyle} The object style instance.
  */
 pub.objectStyle = function(itemOrName, props) {
   var styleErrorMsg = "objectStyle(), wrong parameters. Use: pageItem|name and props. Props is optional.";
@@ -5071,14 +5384,16 @@ pub.objectStyle = function(itemOrName, props) {
 };
 
 /**
- * @description Applies an object style to the given page item. The object style can be given as
- * name or as an object style instance.
+ * @description Applies an object style to the given page item. The object style
+ *          can be given as name or as an object style instance.
  *
- * @cat    Typography
- * @method applyObjectStyle
- * @param  {PageItem} item The page item to apply the style to.
- * @param  {ObjectStyle|String} style An object style instance or the name of the object style to apply.
- * @return {PageItem} The page item that the style was applied to.
+ * @cat     Typography
+ * @method  applyObjectStyle
+ *
+ * @param   {PageItem} item The page item to apply the style to.
+ * @param   {ObjectStyle|String} style An object style instance or the name of
+ *          the object style to apply.
+ * @return  {PageItem} The page item that the style was applied to.
  */
 
 pub.applyObjectStyle = function(item, style) {
@@ -5101,13 +5416,16 @@ pub.applyObjectStyle = function(item, style) {
 };
 
 /**
- * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use `rectMode()` to set center point.
+ * @description Duplicates the given page after the current page or the given
+ *          page item to the current page and layer. Use `rectMode()` to set
+ *          center point.
  *
- * @cat    Document
- * @subcat Transformation
- * @method duplicate
- * @param  {PageItem|Page} item The page item or page to duplicate.
- * @return {Object} The new page item or page.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  duplicate
+ *
+ * @param   {PageItem|Page} item The page item or page to duplicate.
+ * @return  {Object} The new page item or page.
  */
 pub.duplicate = function(item) {
 
@@ -5638,22 +5956,22 @@ pub.opacity = function(obj, opacity) {
  * @param   {Object} obj The object to set blendMode of.
  * @param   {Number} blendMode The blendMode must be one of the InDesign
  *          BlendMode enum values:
- *      - `BlendMode.NORMAL`
- *      - `BlendMode.MULTIPLY`
- *      - `BlendMode.SCREEN`
- *      - `BlendMode.OVERLAY`
- *      - `BlendMode.SOFT_LIGHT`
- *      - `BlendMode.HARD_LIGHT`
- *      - `BlendMode.COLOR_DODGE`
- *      - `BlendMode.COLOR_BURN`
- *      - `BlendMode.DARKEN`
- *      - `BlendMode.LIGHTEN`
- *      - `BlendMode.DIFFERENCE`
- *      - `BlendMode.EXCLUSION`
- *      - `BlendMode.HUE`
- *      - `BlendMode.SATURATION`
- *      - `BlendMode.COLOR`
- *      - `BlendMode.LUMINOSITY`
+ *   - `BlendMode.NORMAL`
+ *   - `BlendMode.MULTIPLY`
+ *   - `BlendMode.SCREEN`
+ *   - `BlendMode.OVERLAY`
+ *   - `BlendMode.SOFT_LIGHT`
+ *   - `BlendMode.HARD_LIGHT`
+ *   - `BlendMode.COLOR_DODGE`
+ *   - `BlendMode.COLOR_BURN`
+ *   - `BlendMode.DARKEN`
+ *   - `BlendMode.LIGHTEN`
+ *   - `BlendMode.DIFFERENCE`
+ *   - `BlendMode.EXCLUSION`
+ *   - `BlendMode.HUE`
+ *   - `BlendMode.SATURATION`
+ *   - `BlendMode.COLOR`
+ *   - `BlendMode.LUMINOSITY`
  */
 pub.blendMode = function(obj, blendMode) {
   checkNull(obj);
@@ -5730,22 +6048,25 @@ pub.lerpColor = function (c1, c2, amt) {
 // ----------------------------------------
 
 /**
- * @description Creates a text frame on the current layer on the current page in the current document.
- * The text frame gets created in the position specified by the x and y parameters.
- * The default document font will be used unless a font is set with the textFont() function.
- * The default document font size will be used unless a font size is set with the textSize() function.
- * Change the color of the text with the fill() function.
- * The text displays in relation to the textAlign() and textYAlign() functions.
- * The width and height parameters define a rectangular area.
+ * @description Creates a text frame on the current layer on the current page in
+ *          the current document. The text frame gets created in the position
+ *          specified by the `x` and `y` parameters. The default document font
+ *          will be used unless a font is set with the `textFont()` function.
+ *          The default document font size will be used unless a font size is
+ *          set with the `textSize()` function. Change the color of the text
+ *          with the `fill()` function. The text displays in relation to the
+ *          `textAlign()` and `textYAlign()` functions. The `width` and `height`
+ *          parameters define a rectangular area.
  *
- * @cat    Typography
- * @method text
- * @param  {String} txt The text content to set in the text frame.
- * @param  {Number} x   x-coordinate of text frame
- * @param  {Number} y   y-coordinate of text frame
- * @param  {Number} w   width of text frame
- * @param  {Number} h   height of text frame
- * @return {TextFrame}  The created text frame instance
+ * @cat     Typography
+ * @method  text
+ *
+ * @param   {String} txt The text content to set in the text frame.
+ * @param   {Number} x x-coordinate of text frame
+ * @param   {Number} y y-coordinate of text frame
+ * @param   {Number} w width of text frame
+ * @param   {Number} h height of text frame
+ * @return  {TextFrame} The created text frame instance
  */
 pub.text = function(txt, x, y, w, h) {
   if (arguments.length !== 5) {
@@ -5808,21 +6129,29 @@ pub.text = function(txt, x, y, w, h) {
 };
 
 /**
- * @description Sets text properties to the given item. If the item is not an instance the text property can be set to,
- * the property gets set to the direct descendants of the given item, e.g. all stories of a given document.
- * <br><br>
- * If no value is given and the given property is a string, the function acts as a getter and returns the
- * corresponding value(s) in an array. This can either be an array containing the value of the concrete item
- * (e.g. character) the values of the item's descendants (e.g. paragraphs of given text frame).
+ * @description Sets text properties to the given item. If the item is not an
+ *          instance the text property can be set to, the property gets set to
+ *          the direct descendants of the given item, e.g. all stories of a
+ *          given document.
+ *          <br><br>
+ *          If no value is given and the given property
+ *          is a string, the function acts as a getter and returns the
+ *          corresponding value(s) in an array. This can either be an array
+ *          containing the value of the concrete item (e.g. character) the
+ *          values of the item's descendants (e.g. paragraphs of given text
+ *          frame).
  *
- * @cat    Typography
- * @method typo
- * @param  {Document|Spread|Page|Layer|Story|TextFrame|Text} item  The object to apply the property to.
- * @param  {String|Object} property  The text property name or an object of key/value property/value pairs.
- *                                   If property is a string and no value is given, the function acts as getter.
- * @param  {String|Number|Object} [value]  The value to apply to the property.
- * @return {String[]|Number[]|Object[]}  The property value(s) if the function acts as getter or the items the property
- *                                       was assigned to.
+ * @cat     Typography
+ * @method  typo
+ *
+ * @param   {Document|Spread|Page|Layer|Story|TextFrame|Text} item The object to
+ *          apply the property to.
+ * @param   {String|Object} property The text property name or an object of
+ *          key/value property/value pairs. If property is a string and no value
+ *          is given, the function acts as getter.
+ * @param   {String|Number|Object} [value] The value to apply to the property.
+ * @return  {String[]|Number[]|Object[]} The property value(s) if the function
+ *          acts as getter or the items the property was assigned to.
  */
 pub.typo = function(item, property, value) {
   var result = [],
@@ -5895,13 +6224,15 @@ var isValid = function (item) {
 };
 
 /**
- * @description Returns the current font and sets it if argument fontName is given.
+ * @description Returns the current font and sets it if argument `fontName` is
+ *          given.
  *
- * @cat    Typography
- * @method textFont
- * @param  {String} [fontName] The name of the font to set e.g. Helvetica
- * @param  {String} [fontStyle] The font style e.g. Bold
- * @return {Font} The current font object
+ * @cat     Typography
+ * @method  textFont
+ *
+ * @param   {String} [fontName] The name of the font to set e.g. Helvetica
+ * @param   {String} [fontStyle] The font style e.g. Bold
+ * @return  {Font} The current font object
  */
 pub.textFont = function(fontName, fontStyle) {
 
@@ -5926,12 +6257,14 @@ pub.textFont = function(fontName, fontStyle) {
 };
 
 /**
- * @description Returns the current font size in points and sets it if argument pointSize is given.
+ * @description Returns the current font size in points and sets it if argument
+ *          `pointSize` is given.
  *
- * @cat    Typography
- * @method textSize
- * @param  {Number} [pointSize] The size in points to set.
- * @return {Number}             The current point size.
+ * @cat     Typography
+ * @method  textSize
+ *
+ * @param   {Number} [pointSize] The size in points to set.
+ * @return  {Number} The current point size.
  */
 pub.textSize = function(pointSize) {
   if (arguments.length === 1) {
@@ -5943,22 +6276,25 @@ pub.textSize = function(pointSize) {
 /**
  * @description Sets the current horizontal and vertical text alignment.
  *
- * @cat    Typography
- * @method textAlign
- * @param  {String} align    The horizontal text alignment to set. Must be one of the InDesign Justification enum values:
- *                           Justification.AWAY_FROM_BINDING_SIDE<br>
- *                           Justification.CENTER_ALIGN<br>
- *                           Justification.CENTER_JUSTIFIED<br>
- *                           Justification.FULLY_JUSTIFIED<br>
- *                           Justification.LEFT_ALIGN<br>
- *                           Justification.RIGHT_ALIGN<br>
- *                           Justification.RIGHT_JUSTIFIED<br>
- *                           Justification.TO_BINDING_SIDE<br>
- * @param  {String} [yAlign] The vertical text alignment to set. Must be one of the InDesign VerticalJustification enum values:
- *                           VerticalJustification.BOTTOM_ALIGN<br>
- *                           VerticalJustification.CENTER_ALIGN<br>
- *                           VerticalJustification.JUSTIFY_ALIGN<br>
- *                           VerticalJustification.TOP_ALIGN<br>
+ * @cat     Typography
+ * @method  textAlign
+ *
+ * @param   {String} align The horizontal text alignment to set. Must be one of
+ *          the InDesign Justification enum values:
+ *      - `Justification.AWAY_FROM_BINDING_SIDE`
+ *      - `Justification.CENTER_ALIGN`
+ *      - `Justification.CENTER_JUSTIFIED`
+ *      - `Justification.FULLY_JUSTIFIED`
+ *      - `Justification.LEFT_ALIGN`
+ *      - `Justification.RIGHT_ALIGN`
+ *      - `Justification.RIGHT_JUSTIFIED`
+ *      - `Justification.TO_BINDING_SIDE`
+ * @param   {String} [yAlign] The vertical text alignment to set. Must be one of
+ *          the InDesign VerticalJustification enum values:
+ *      - `VerticalJustification.BOTTOM_ALIGN`
+ *      - `VerticalJustification.CENTER_ALIGN`
+ *      - `VerticalJustification.JUSTIFY_ALIGN`
+ *      - `VerticalJustification.TOP_ALIGN`
  */
 pub.textAlign = function(align, yAlign) {
   currAlign = align;
@@ -5966,13 +6302,15 @@ pub.textAlign = function(align, yAlign) {
 };
 
 /**
- * @description Returns the spacing between lines of text in units of points and sets it if argument leading is given.
+ * @description Returns the spacing between lines of text in units of points and
+ *          sets it if argument `leading` is given.
  *
- * @cat    Typography
- * @method textLeading
- * @param  {Number|String} [leading] The spacing between lines of text in units of points or the default InDesign enum
- *                                   value Leading.AUTO.
- * @return {Number|String}           The current leading.
+ * @cat     Typography
+ * @method  textLeading
+ *
+ * @param   {Number|String} [leading] The spacing between lines of text in units
+ *          of points or the default InDesign enum value `Leading.AUTO`.
+ * @return  {Number|String} The current leading.
  */
 pub.textLeading = function(leading) {
   if (arguments.length === 1) {
@@ -5982,12 +6320,14 @@ pub.textLeading = function(leading) {
 };
 
 /**
- * @description Returns the current kerning and sets it if argument kerning is given.
+ * @description Returns the current kerning and sets it if argument `kerning` is
+ *          given.
  *
- * @cat    Typography
- * @method textKerning
- * @param  {Number} [kerning] The value to set.
- * @return {Number}           The current kerning.
+ * @cat     Typography
+ * @method  textKerning
+ *
+ * @param   {Number} [kerning] The value to set.
+ * @return  {Number} The current kerning.
  */
 pub.textKerning = function(kerning) {
   if (arguments.length === 1) {
@@ -5997,12 +6337,14 @@ pub.textKerning = function(kerning) {
 };
 
 /**
- * @description Returns the current tracking and sets it if argument tracking is given.
+ * @description Returns the current tracking and sets it if argument `tracking`
+ *          is given.
  *
- * @cat    Typography
- * @method textTracking
- * @param  {Number} [tracking] The value to set.
- * @return {Number}            The current tracking.
+ * @cat     Typography
+ * @method  textTracking
+ *
+ * @param   {Number} [tracking] The value to set.
+ * @return  {Number} The current tracking.
  */
 pub.textTracking = function(tracking) {
   if (arguments.length === 1) {
@@ -6012,15 +6354,20 @@ pub.textTracking = function(tracking) {
 };
 
 /**
- * @description Returns the character style of a given text object or the character style with the given name. If a
- * character style of the given name does not exist, it gets created. Optionally a props object of
- * property name/value pairs can be used to set the character style's properties.
+ * @description Returns the character style of a given text object or the
+ *          character style with the given name. If a character style of the
+ *          given name does not exist, it gets created. Optionally a props
+ *          object of property name/value pairs can be used to set the character
+ *          style's properties.
  *
- * @cat    Typography
- * @method characterStyle
- * @param  {Text|String} textOrName  A text object whose style to return or the name of the character style to return.
- * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
- * @return {CharacterStyle}  The character style instance.
+ * @cat     Typography
+ * @method  characterStyle
+ *
+ * @param   {Text|String} textOrName A text object whose style to return or the
+ *          name of the character style to return.
+ * @param   {Object} [props] Optional: An object of property name/value pairs to
+ *          set the style's properties.
+ * @return  {CharacterStyle} The character style instance.
  */
 pub.characterStyle = function(textOrName, props) {
   var styleErrorMsg = "characterStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
@@ -6055,14 +6402,18 @@ pub.characterStyle = function(textOrName, props) {
 };
 
 /**
- * @description Applies a character style to the given text object, text frame or story. The character style
- * can be given as name or as character style instance.
+ * @description Applies a character style to the given text object, text frame
+ *          or story. The character style can be given as name or as character
+ *          style instance.
  *
- * @cat    Typography
- * @method applyCharacterStyle
- * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
- * @param  {CharacterStyle|String} style  A character style instance or the name of the character style to apply.
- * @return {Text}  The text that the style was applied to.
+ * @cat     Typography
+ * @method  applyCharacterStyle
+ *
+ * @param   {TextFrame|TextObject|Story} text The text frame, text object or
+ *          story to apply the style to.
+ * @param   {CharacterStyle|String} style A character style instance or the name
+ *          of the character style to apply.
+ * @return  {Text} The text that the style was applied to.
  */
 
 pub.applyCharacterStyle = function(text, style) {
@@ -6089,15 +6440,20 @@ pub.applyCharacterStyle = function(text, style) {
 };
 
 /**
- * @description Returns the paragraph style of a given text object or the paragraph style with the given name. If a
- * paragraph style of the given name does not exist, it gets created. Optionally a props object of
- * property name/value pairs can be used to set the paragraph style's properties.
+ * @description Returns the paragraph style of a given text object or the
+ *          paragraph style with the given name. If a paragraph style of the
+ *          given name does not exist, it gets created. Optionally a props
+ *          object of property name/value pairs can be used to set the paragraph
+ *          style's properties.
  *
- * @cat    Typography
- * @method paragraphStyle
- * @param  {Text|String} textOrName  A text object whose style to return or the name of the paragraph style to return.
- * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
- * @return {ParagraphStyle}  The paragraph style instance.
+ * @cat     Typography
+ * @method  paragraphStyle
+ *
+ * @param   {Text|String} textOrName A text object whose style to return or the
+ *          name of the paragraph style to return.
+ * @param   {Object} [props] Optional: An object of property name/value pairs to
+ *          set the style's properties.
+ * @return  {ParagraphStyle} The paragraph style instance.
  */
 pub.paragraphStyle = function(textOrName, props) {
   var styleErrorMsg = "paragraphStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
@@ -6132,14 +6488,18 @@ pub.paragraphStyle = function(textOrName, props) {
 };
 
 /**
- * @description Applies a paragraph style to the given text object, text frame or story. The paragraph style
- * can be given as name or as paragraph style instance.
+ * @description Applies a paragraph style to the given text object, text frame
+ *          or story. The paragraph style can be given as name or as paragraph
+ *          style instance.
  *
- * @cat    Typography
- * @method applyParagraphStyle
- * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
- * @param  {ParagraphStyle|String} style  A paragraph style instance or the name of the paragraph style to apply.
- * @return {Text}  The text that the style was applied to.
+ * @cat     Typography
+ * @method  applyParagraphStyle
+ *
+ * @param   {TextFrame|TextObject|Story} text The text frame, text object or
+ *          story to apply the style to.
+ * @param   {ParagraphStyle|String} style A paragraph style instance or the name
+ *          of the paragraph style to apply.
+ * @return  {Text} The text that the style was applied to.
  */
 
 pub.applyParagraphStyle = function(text, style) {
@@ -6166,12 +6526,14 @@ pub.applyParagraphStyle = function(text, style) {
 };
 
 /**
- * @description Links the stories of two textframes to one story. Text of first textframe overflows to second one.
+ * @description Links the stories of two textframes to one story. Text of first
+ *          textframe overflows to second one.
  *
- * @cat    Story
- * @method linkTextFrames
- * @param  {TextFrame} textFrameA
- * @param  {TextFrame} textFrameB
+ * @cat     Story
+ * @method  linkTextFrames
+ *
+ * @param   {TextFrame} textFrameA
+ * @param   {TextFrame} textFrameB
  */
 pub.linkTextFrames = function (textFrameA, textFrameB) {
   if (textFrameA instanceof TextFrame && textFrameB instanceof TextFrame) {
@@ -6182,12 +6544,15 @@ pub.linkTextFrames = function (textFrameA, textFrameB) {
 };
 
 /**
- * @description Fills the given textFrame and all linked textFrame with random placeholder text. The placeholder text will be added at the end of any already existing text in the text frame.
+ * @description Fills the given text frame and all linked text frames with
+ *          random placeholder text. The placeholder text will be added at the
+ *          end of any already existing text in the text frame.
  *
- * @cat    Story
- * @method placeholder
- * @param  {TextFrame} textFrame
- * @return {Text} The inserted placeholder text.
+ * @cat     Story
+ * @method  placeholder
+ *
+ * @param   {TextFrame} textFrame The text frame to fill.
+ * @return  {Text} The inserted placeholder text.
  */
 pub.placeholder = function (textFrame) {
   if (textFrame instanceof TextFrame) {
@@ -6204,22 +6569,32 @@ pub.placeholder = function (textFrame) {
 // ----------------------------------------
 
 /**
- * @description Adds an image to the document. If the image argument is given as a string the image file must be in the document's
- * data directory which is in the same directory where the document is saved in. The image argument can also be a File
- * instance which can be placed even before the document was saved.
- * The second argument can either be the x position of the frame to create or an instance of a rectangle,
- * oval or polygon to place the image in. If an x position is given, a y position must be given, too.
- * If x and y positions are given and width and height are not given, the frame's size gets set to the original image size.
+ * @description Adds an image to the document. If the image argument is given as
+ *          a string the image file must be in the document's data directory
+ *          which is in the same directory where the document is saved in. The
+ *          image argument can also be a File instance which can be placed even
+ *          before the document was saved. The second argument can either be the
+ *          x position of the frame to create or an instance of a rectangle,
+ *          oval or polygon to place the image in. If an x position is given, a
+ *          y position must be given, too. If x and y positions are given and
+ *          width and height are not given, the frame's size gets set to the
+ *          original image size.
  *
- * @cat    Document
- * @subcat Image
- * @method image
- * @param  {String|File} img The image file name in the document's data directory or a File instance.
- * @param  {Number|Rectangle|Oval|Polygon} x The x position on the current page or the item instance to place the image in.
- * @param  {Number} [y] The y position on the current page. Ignored if x is not a number.
- * @param  {Number} [w] The width of the rectangle to add the image to. Ignored if x is not a number.
- * @param  {Number} [h] The height of the rectangle to add the image to. Ignored if x is not a number.
- * @return {Rectangle|Oval|Polygon} The item instance the image was placed in.
+ * @cat     Document
+ * @subcat  Image
+ * @method  image
+ *
+ * @param   {String|File} img The image file name in the document's data
+ *          directory or a File instance.
+ * @param   {Number|Rectangle|Oval|Polygon} x The x position on the current page
+ *          or the item instance to place the image in.
+ * @param   {Number} [y] The y position on the current page. Ignored if x is not
+ *          a number.
+ * @param   {Number} [w] The width of the rectangle to add the image to. Ignored
+ *          if x is not a number.
+ * @param   {Number} [h] The height of the rectangle to add the image to.
+ *          Ignored if x is not a number.
+ * @return  {Rectangle|Oval|Polygon} The item instance the image was placed in.
  */
 pub.image = function(img, x, y, w, h) {
   var file = initDataFile(img),
@@ -6301,14 +6676,22 @@ pub.image = function(img, x, y, w, h) {
 };
 
 /**
- * @description Modifies the location from which images draw. The default mode is imageMode(CORNER), which specifies the location to be the upper left corner and uses the fourth and fifth parameters of image() to set the image's width and height. The syntax imageMode(CORNERS) uses the second and third parameters of image() to set the location of one corner of the image and uses the fourth and fifth parameters to set the opposite corner. Use imageMode(CENTER) to draw images centered at the given x and y position.
- * If no parameter is passed the currently set mode is returned as String.
+ * @description Modifies the location from which images draw. The default mode
+ *          is `CORNER`, which specifies the location to be the upper left
+ *          corner and uses the fourth and fifth parameters of `image()` to set
+ *          the image's width and height. The syntax `imageMode(CORNERS)` uses
+ *          the second and third parameters of `image()` to set the location of
+ *          one corner of the image and uses the fourth and fifth parameters to
+ *          set the opposite corner. Use `imageMode(CENTER)` to draw images
+ *          centered at the given `x` and `y` position. If no parameter is
+ *          passed the currently set mode is returned as String.
  *
- * @cat    Document
- * @subcat Image
- * @method imageMode
- * @param  {String} [mode] Either CORNER, CORNERS, or CENTER.
- * @return {String} The current mode.
+ * @cat     Document
+ * @subcat  Image
+ * @method  imageMode
+ *
+ * @param   {String} [mode] Either CORNER, CORNERS, or CENTER.
+ * @return  {String} The current mode.
  */
 pub.imageMode = function(mode) {
   if (arguments.length === 0) return currImageMode;
@@ -6328,17 +6711,32 @@ pub.imageMode = function(mode) {
 var Vector = pub.Vector = function() {
 
   /**
-   * @description A class to describe a two or three dimensional vector. This datatype stores two or three variables that are commonly used as a position, velocity, and/or acceleration. Technically, position is a point and velocity and acceleration are vectors, but this is often simplified to consider all three as vectors. For example, if you consider a rectangle moving across the screen, at any given instant it has a position (the object's location, expressed as a point.), a velocity (the rate at which the object's position changes per time unit, expressed as a vector), and acceleration (the rate at which the object's velocity changes per time unit, expressed as a vector). Since vectors represent groupings of values, we cannot simply use traditional addition/multiplication/etc. Instead, we'll need to do some "vector" math, which is made easy by the methods inside the Vector class.
-   * <br><br>
-   * Constructor of Vector, can be two- or three-dimensional.
+   * @description A class to describe a two or three dimensional vector. This
+   *          data type stores two or three variables that are commonly used as
+   *          a position, velocity, and/or acceleration. Technically, position
+   *          is a point and velocity and acceleration are vectors, but this is
+   *          often simplified to consider all three as vectors. For example, if
+   *          you consider a rectangle moving across the screen, at any given
+   *          instant it has a position (the object's location, expressed as a
+   *          point.), a velocity (the rate at which the object's position
+   *          changes per time unit, expressed as a vector), and acceleration
+   *          (the rate at which the object's velocity changes per time unit,
+   *          expressed as a vector). Since vectors represent groupings of
+   *          values, we cannot simply use traditional
+   *          addition/multiplication/etc. Instead, we'll need to do some
+   *          "vector" math, which is made easy by the methods inside the Vector
+   *          class.
+   *          <br><br>
+   *          Constructor of Vector, can be two- or three-dimensional.
    *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector
-   * @param  {Number} x The first vector.
-   * @param  {Number} y The second vector.
-   * @param  {Number} [z] The third vector.
-   * @constructor
+   * @cat     Math
+   * @subcat  Vector
+   * @method  Vector
+   *
+   * @param   {Number} x The first vector.
+   * @param   {Number} y The second vector.
+   * @param   {Number} [z] The third vector.
+   * @class
    */
   function Vector(x, y, z) {
     this.x = x || 0;
@@ -6346,15 +6744,17 @@ var Vector = pub.Vector = function() {
     this.z = z || 0;
   }
   /**
-   * @description Static function. Calculates the Euclidean distance between two points (considering a point as a vector object).
-   * Is meant to be called "static" i.e. Vector.dist(v1, v2);
+   * @description Static function. Calculates the Euclidean distance between two
+   *          points (considering a point as a vector object). Is meant to be
+   *          called "static" i.e. `Vector.dist(v1, v2);`
    *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.dist
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The distance.
+   * @cat     Math
+   * @subcat  Vector
+   * @method  Vector.dist
+   *
+   * @param   {Vector} v1 The first vector.
+   * @param   {Vector} v2 The second vector.
+   * @return  {Number} The distance.
    * @static
    */
   Vector.dist = function(v1, v2) {
@@ -6362,15 +6762,16 @@ var Vector = pub.Vector = function() {
   };
 
   /**
-   * @description Static function. Calculates the dot product of two vectors.
-   * Is meant to be called "static" i.e. Vector.dot(v1, v2);
+   * @description Static function. Calculates the dot product of two vectors. Is
+   *          meant to be called "static" i.e. `Vector.dot(v1, v2);`
    *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.dot
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The dot product.
+   * @cat     Math
+   * @subcat  Vector
+   * @method  Vector.dot
+   *
+   * @param   {Vector} v1 The first vector.
+   * @param   {Vector} v2 The second vector.
+   * @return  {Number} The dot product.
    * @static
    */
   Vector.dot = function(v1, v2) {
@@ -6379,14 +6780,15 @@ var Vector = pub.Vector = function() {
 
   /**
    * @description Static function. Calculates the cross product of two vectors.
-   * Is meant to be called "static" i.e. Vector.cross(v1, v2);
+   *          Is meant to be called "static" i.e. `Vector.cross(v1, v2);`
    *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.cross
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The cross product.
+   * @cat     Math
+   * @subcat  Vector
+   * @method  Vector.cross
+   *
+   * @param   {Vector} v1 The first vector.
+   * @param   {Vector} v2 The second vector.
+   * @return  {Number} The cross product.
    * @static
    */
   Vector.cross = function(v1, v2) {
@@ -6394,15 +6796,16 @@ var Vector = pub.Vector = function() {
   };
 
   /**
-   * @description Static function. Calculates the angle between two vectors.
-   * Is meant to be called "static" i.e. Vector.angleBetween(v1, v2);
+   * @description Static function. Calculates the angle between two vectors. Is
+   *          meant to be called "static" i.e. `Vector.angleBetween(v1, v2);`
    *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.angleBetween
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The angle.
+   * @cat     Math
+   * @subcat  Vector
+   * @method  Vector.angleBetween
+   *
+   * @param   {Vector} v1 The first vector.
+   * @param   {Vector} v2 The second vector.
+   * @return  {Number} The angle.
    * @static
    */
   Vector.angleBetween = function(v1, v2) {
@@ -6412,14 +6815,17 @@ var Vector = pub.Vector = function() {
   Vector.prototype = {
 
     /**
-     * @description Sets the x, y, and z component of the vector using three separate variables, the data from a Vector, or the values from a float array.
+     * @description Sets the `x`, `y`, and `z` component of the vector using
+     *          three separate variables, the data from a Vector, or the values
+     *          from a float array.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.set
-     * @param  {Number|Array|Vector} v Either a vector, array or x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.set
+     *
+     * @param   {Number|Array|Vector} v Either a vector, array or `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
      */
     set: function(v, y, z) {
       if (arguments.length === 1) this.set(v.x || v[0] || 0, v.y || v[1] || 0, v.z || v[2] || 0);
@@ -6432,21 +6838,24 @@ var Vector = pub.Vector = function() {
     /**
      * @description Gets a copy of the vector, returns a Vector object.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.get
-     * @return {Vector} A copy of the vector.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.get
+     *
+     * @return  {Vector} A copy of the vector.
      */
     get: function() {
       return new Vector(this.x, this.y, this.z);
     },
     /**
-     * @description Calculates the magnitude (length) of the vector and returns the result as a float
+     * @description Calculates the magnitude (length) of the vector and returns
+     *          the result as a float
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.mag
-     * @return {Number} The length.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.mag
+     *
+     * @return  {Number} The length.
      */
     mag: function() {
       var x = this.x,
@@ -6455,14 +6864,16 @@ var Vector = pub.Vector = function() {
       return Math.sqrt(x * x + y * y + z * z);
     },
     /**
-     * @description Adds x, y, and z components to a vector, adds one vector to another.
+     * @description Adds `x`, `y`, and `z` components to a vector, adds one
+     *          vector to another.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.add
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.add
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
      */
     add: function(v, y, z) {
       if (arguments.length === 1) {
@@ -6476,14 +6887,16 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * @description Substract x, y, and z components or a full vector from this vector
+     * @description Substract `x`, `y`, and `z` components or a full vector from
+     *          this vector
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.sub
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.sub
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
      */
     sub: function(v, y, z) {
       if (arguments.length === 1) {
@@ -6497,14 +6910,16 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * @description Multiplies this vector with x, y, and z components or another vector.
+     * @description Multiplies this vector with `x`, `y`, and `z` components or
+     *          another vector.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.mult
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.mult
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
      */
     mult: function(v) {
       if (typeof v === "number") {
@@ -6518,14 +6933,16 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * @description Divides this vector through x, y, and z components or another vector.
+     * @description Divides this vector through `x`, `y`, and `z` components or
+     *          another vector.`
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.div
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.div
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
      */
     div: function(v) {
       if (typeof v === "number") {
@@ -6539,15 +6956,17 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * @description Calculates the distance from this vector to another as x, y, and z components or full vector.
+     * @description Calculates the distance from this vector to another as `x`,
+     *          `y`, and `z` components or full vector.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.dist
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     * @return {Number} The distance.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.dist
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
+     * @return  {Number} The distance.
      */
     dist: function(v) {
       var dx = this.x - v.x,
@@ -6556,30 +6975,34 @@ var Vector = pub.Vector = function() {
       return Math.sqrt(dx * dx + dy * dy + dz * dz);
     },
     /**
-     * @description Calculates the dot product from this vector to another as x, y, and z components or full vector.
+     * @description Calculates the dot product from this vector to another as
+     *          `x`, `y`, and `z` components or full vector.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.dot
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     * @return {Number} The dot product.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.dot
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
+     * @return  {Number} The dot product.
      */
     dot: function(v, y, z) {
       if (arguments.length === 1) return this.x * v.x + this.y * v.y + this.z * v.z;
       return this.x * v + this.y * y + this.z * z;
     },
     /**
-     * @description Calculates the cross product from this vector to another as x, y, and z components or full vector.
+     * @description Calculates the cross product from this vector to another as
+     *          `x`, `y`, and `z` components or full vector.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.cross
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     * @return {Number} The cross product.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.cross
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
+     * @return  {Number} The cross product.
      */
     cross: function(v) {
       var x = this.x,
@@ -6590,9 +7013,9 @@ var Vector = pub.Vector = function() {
     /**
      * @description Normalizes the length of this vector to 1.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.normalize
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.normalize
      */
     normalize: function() {
       var m = this.mag();
@@ -6601,10 +7024,11 @@ var Vector = pub.Vector = function() {
     /**
      * @description Normalizes the length of this vector to the given parameter.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.limit
-     * @param  {Number} high The value to scale to.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.limit
+     *
+     * @param   {Number} high The value to scale to.
      */
     limit: function(high) {
       if (this.mag() > high) {
@@ -6615,10 +7039,11 @@ var Vector = pub.Vector = function() {
     /**
      * @description The 2D orientation (heading) of this vector in radian.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.heading
-     * @return {Number} A radian angle value.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.heading
+     *
+     * @return  {Number} A radian angle value.
      */
     heading: function() {
       return -Math.atan2(-this.y, this.x);
@@ -6626,21 +7051,24 @@ var Vector = pub.Vector = function() {
     /**
      * @description Returns data about this vector as a string.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.toString
-     * @return {String} The x, y and z components as a string.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.toString
+     *
+     * @return  {String} The `x`, `y` and `z` components as a string.
      */
     toString: function() {
       return "[" + this.x + ", " + this.y + ", " + this.z + "]";
     },
     /**
-     * @description Returns this vector as an array [x,y,z].
+     * @description Returns this vector as an array `[x,y,z]`.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.array
-     * @return {Array} The x, y and z components as  an Array of [x,y,z].
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.array
+     *
+     * @return  {Array} The `x`, `y` and `z` components as an array of
+     *          `[x,y,z]`.
      */
     array: function() {
       return [this.x, this.y, this.z];
@@ -6662,37 +7090,43 @@ var Vector = pub.Vector = function() {
 // -- Calculation --
 
 /**
- * @description Calculates the absolute value (magnitude) of a number. The absolute value of a number is always positive.
+ * @description Calculates the absolute value (magnitude) of a number. The
+ *          absolute value of a number is always positive.
  *
- * @cat    Math
- * @subcat Calculation
- * @method abs
- * @param  {Number} val A number.
- * @return {Number} The absolute value of that number.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  abs
+ *
+ * @param   {Number} val A number.
+ * @return  {Number} The absolute value of that number.
  */
 pub.abs = Math.abs;
 
 /**
- * @description Calculates the closest int value that is greater than or equal to the value of the parameter. For example, ceil(9.03) returns the value 10.
+ * @description Calculates the closest integer value that is greater than or
+ *          equal to the value of the parameter. For example, `ceil(9.03)`
+ *          returns the value `10`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method ceil
- * @param  {Number} val An arbitrary number.
- * @return {Number} The next highest integer value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  ceil
+ *
+ * @param   {Number} val An arbitrary number.
+ * @return  {Number} The next highest integer value.
  */
 pub.ceil = Math.ceil;
 
 /**
  * @description Constrains a value to not exceed a maximum and minimum value.
  *
- * @cat    Math
- * @subcat Calculation
- * @method constrain
- * @param  {Number} aNumber The value to constrain.
- * @param  {Number} aMin Minimum limit.
- * @param  {Number} aMax Maximum limit.
- * @return {Number} The constrained value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  constrain
+ *
+ * @param   {Number} aNumber The value to constrain.
+ * @param   {Number} aMin Minimum limit.
+ * @param   {Number} aMax Maximum limit.
+ * @return  {Number} The constrained value.
  */
 pub.constrain = function(aNumber, aMin, aMax) {
   if(arguments.length !== 3) error("constrain(), wrong argument count.");
@@ -6704,14 +7138,15 @@ pub.constrain = function(aNumber, aMin, aMax) {
 /**
  * @description Calculates the distance between two points.
  *
- * @cat    Math
- * @subcat Calculation
- * @method dist
- * @param  {Number} x1 The x-coordinate of the first point.
- * @param  {Number} y1 The y-coordinate of the first point.
- * @param  {Number} x2 The x-coordinate of the second point.
- * @param  {Number} y2 The y-coordinate of the second point.
- * @return {Number} The distance.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  dist
+ *
+ * @param   {Number} x1 The x-coordinate of the first point.
+ * @param   {Number} y1 The y-coordinate of the first point.
+ * @param   {Number} x2 The x-coordinate of the second point.
+ * @param   {Number} y2 The y-coordinate of the second point.
+ * @return  {Number} The distance.
  */
 pub.dist = function() {
   var dx, dy, dz;
@@ -6725,37 +7160,48 @@ pub.dist = function() {
 };
 
 /**
- * @description The Math.exp() function returns ex, where x is the argument, and e is Euler's number (also known as Napier's constant), the base of the natural logarithms.
+ * @description The `exp()` function returns `ex`, where `x` is the argument,
+ *          and `e` is Euler's number (also known as Napier's constant), the
+ *          base of the natural logarithms.
  *
- * @cat    Math
- * @subcat Calculation
- * @method exp
- * @param  {Number} x A number.
- * @return {Number} A number representing ex.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  exp
+ *
+ * @param   {Number} x A number.
+ * @return  {Number} A number representing `ex`.
  */
 pub.exp = Math.exp;
 
 /**
- * @description Calculates the closest int value that is less than or equal to the value of the parameter.
+ * @description Calculates the closest integer value that is less than or equal
+ *          to the value of the parameter.
  *
- * @cat    Math
- * @subcat Calculation
- * @method floor
- * @param  {Number} a A number.
- * @return {Number} Integer number.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  floor
+ *
+ * @param   {Number} a A number.
+ * @return  {Number} Integer number.
  */
 pub.floor = Math.floor;
 
 /**
- * @description Calculates a number between two numbers at a specific increment. The amt parameter is the amount to interpolate between the two values where 0.0 equal to the first point, 0.1 is very near the first point, 0.5 is half-way in between, etc. The lerp function is convenient for creating motion along a straight path and for drawing dotted lines.
+ * @description Calculates a number between two numbers at a specific increment.
+ *          The `amt` parameter is the amount to interpolate between the two
+ *          values where `0.0` is equal to the first point, `0.1` is very near
+ *          the first point, `0.5` is half-way in between, etc. The lerp
+ *          function is convenient for creating motion along a straight path and
+ *          for drawing dotted lines.
  *
- * @cat    Math
- * @subcat Calculation
- * @method lerp
- * @param  {Number} value1 First value.
- * @param  {Number} value2 Second value.
- * @param  {Number} amt Amount between 0.0 and 1.0.
- * @return {Number} The mapped value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  lerp
+ *
+ * @param   {Number} value1 First value.
+ * @param   {Number} value2 Second value.
+ * @param   {Number} amt Amount between 0.0 and 1.0.
+ * @return  {Number} The mapped value.
  */
 pub.lerp = function(value1, value2, amt) {
   if(arguments.length !== 3) error("lerp(), wrong argument count.");
@@ -6763,26 +7209,34 @@ pub.lerp = function(value1, value2, amt) {
 };
 
 /**
- * @description Calculates the natural logarithm (the base-e logarithm) of a number. This function expects the values greater than 0.0.
+ * @description Calculates the natural logarithm (the base-e logarithm) of a
+ *          number. This function expects the values greater than `0`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method log
- * @param  {Number} x A number, must be greater then 0.0.
- * @return {Number} The natural logarithm.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  log
+ *
+ * @param   {Number} x A number, must be greater than `0`.
+ * @return  {Number} The natural logarithm.
  */
 pub.log = Math.log;
 
 /**
- * @description Calculates the magnitude (or length) of a vector. A vector is a direction in space commonly used in computer graphics and linear algebra. Because it has no "start" position, the magnitude of a vector can be thought of as the distance from coordinate (0,0) to its (x,y) value. Therefore, mag() is a shortcut for writing "dist(0, 0, x, y)".
+ * @description Calculates the magnitude (or length) of a vector. A vector is a
+ *          direction in space commonly used in computer graphics and linear
+ *          algebra. Because it has no "start" position, the magnitude of a
+ *          vector can be thought of as the distance from coordinate `(0,0)` to
+ *          its `(x,y)` value. Therefore, `mag()` is a shortcut for writing
+ *          `dist(0, 0, x, y)`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method mag
- * @param  {Number} x Coordinate.
- * @param  {Number} y Coordinate.
- * @param  {Number} [z] Coordinate, optional.
- * @return {Number} The magnitude.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  mag
+ *
+ * @param   {Number} x Coordinate.
+ * @param   {Number} y Coordinate.
+ * @param   {Number} [z] Coordinate, optional.
+ * @return  {Number} The magnitude.
  */
 pub.mag = function(a, b, c) {
   if(!(arguments.length === 2 || arguments.length === 3)) error("mag(), wrong argument count.");
@@ -6792,17 +7246,19 @@ pub.mag = function(a, b, c) {
 
 /**
  * @description Re-maps a number from one range to another.<br>
- * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
+ *          Numbers outside the range are not clamped to `0` and `1`, because
+ *          out-of-range values are often intentional and useful.
  *
- * @cat    Math
- * @subcat Calculation
- * @method map
- * @param  {Number} value The value to be mapped.
- * @param  {Number} istart The start of the input range.
- * @param  {Number} istop The end of the input range.
- * @param  {Number} ostart The start of the output range.
- * @param  {Number} ostop The end of the output range.
- * @return {Number} The mapped value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  map
+ *
+ * @param   {Number} value The value to be mapped.
+ * @param   {Number} istart The start of the input range.
+ * @param   {Number} istop The end of the input range.
+ * @param   {Number} ostart The start of the output range.
+ * @param   {Number} ostop The end of the output range.
+ * @return  {Number} The mapped value.
  */
 pub.map = function(value, istart, istop, ostart, ostop) {
   if(arguments.length !== 5) error("map(), wrong argument count. Use: map(value, istart, istop, ostart, ostop)");
@@ -6812,13 +7268,14 @@ pub.map = function(value, istart, istop, ostart, ostop) {
 /**
  * @description Determines the largest value in a sequence of numbers.
  *
- * @cat    Math
- * @subcat Calculation
- * @method max
- * @param  {Number|Array} a A value or an array of Numbers.
- * @param  {Number} [b] Another value to be compared.
- * @param  {Number} [c] Another value to be compared.
- * @return {Number} The highest value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  max
+ *
+ * @param   {Number|Array} a A value or an array of Numbers.
+ * @param   {Number} [b] Another value to be compared.
+ * @param   {Number} [c] Another value to be compared.
+ * @return  {Number} The highest value.
  */
 pub.max = function() {
   if (arguments.length === 2) return arguments[0] < arguments[1] ? arguments[1] : arguments[0];
@@ -6833,13 +7290,14 @@ pub.max = function() {
 /**
  * @description Determines the smallest value in a sequence of numbers.
  *
- * @cat    Math
- * @subcat Calculation
- * @method min
- * @param  {Number|Array} a A value or an array of Numbers.
- * @param  {Number} [b] Another value to be compared.
- * @param  {Number} [c] Another value to be compared.
- * @return {Number} The lowest value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  min
+ *
+ * @param   {Number|Array} a A value or an array of Numbers.
+ * @param   {Number} [b] Another value to be compared.
+ * @param   {Number} [c] Another value to be compared.
+ * @return  {Number} The lowest value.
  */
 pub.min = function() {
   if (arguments.length === 2) return arguments[0] < arguments[1] ? arguments[0] : arguments[1];
@@ -6852,17 +7310,20 @@ pub.min = function() {
 };
 
 /**
- * @description Normalizes a number from another range into a value between 0 and 1.<br>
- * Identical to map(value, low, high, 0, 1);<br>
- * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
+ * @description Normalizes a number from another range into a value between `0`
+ *          and `1`.<br>
+ *          Identical to `map(value, low, high, 0, 1);`<br>
+ *          Numbers outside the range are not clamped to `0` and `1`, because
+ *          out-of-range values are often intentional and useful.
  *
- * @cat    Math
- * @subcat Calculation
- * @method norm
- * @param  {Number} aNumber The value to be normed.
- * @param  {Number} low The lowest value to be expected.
- * @param  {Number} high The highest value to be expected.
- * @return {Number} The normalized value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  norm
+ *
+ * @param   {Number} aNumber The value to be normed.
+ * @param   {Number} low The lowest value to be expected.
+ * @param   {Number} high The highest value to be expected.
+ * @return  {Number} The normalized value.
  */
 pub.norm = function(aNumber, low, high) {
   if(arguments.length !== 3) error("norm(), wrong argument count.");
@@ -6870,36 +7331,46 @@ pub.norm = function(aNumber, low, high) {
 };
 
 /**
- * @description Facilitates exponential expressions. The pow() function is an efficient way of multiplying numbers by themselves (or their reciprocal) in large quantities. For example, pow(3, 5) is equivalent to the expression 3*3*3*3*3 and pow(3, -5) is equivalent to 1 / 3*3*3*3*3
+ * @description Facilitates exponential expressions. The `pow()` function is an
+ *          efficient way of multiplying numbers by themselves (or their
+ *          reciprocal) in large quantities. For example, `pow(3, 5)` is
+ *          equivalent to the expression `3 * 3 * 3 * 3 * 3` and `pow(3, -5)` is
+ *          equivalent to `1 / 3 * 3 * 3 * 3 * 3`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method pow
- * @param  {Number} num Base of the exponential expression.
- * @param  {Number} exponent Power of which to raise the base.
- * @return {Number} the result
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  pow
+ *
+ * @param   {Number} num Base of the exponential expression.
+ * @param   {Number} exponent Power of which to raise the base.
+ * @return  {Number} the result
  */
 pub.pow = Math.pow;
 
 /**
- * @description Calculates the integer closest to the value parameter. For example, round(9.2) returns the value 9.
+ * @description Calculates the integer closest to the value parameter. For
+ *          example, `round(9.2)` returns the value `9`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method round
- * @param  {Number} value The value to be rounded.
- * @return {Number} The rounded value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  round
+ *
+ * @param   {Number} value The value to be rounded.
+ * @return  {Number} The rounded value.
  */
 pub.round = Math.round;
 
 /**
- * @description Squares a number (multiplies a number by itself). The result is always a positive number, as multiplying two negative numbers always yields a positive result. For example, -1 * -1 = 1.
+ * @description Squares a number (multiplies a number by itself). The result is
+ *          always a positive number, as multiplying two negative numbers always
+ *          yields a positive result. For example, `-1 * -1 = 1`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method sq
- * @param  {Number} aNumber The value to be squared.
- * @return {Number} Squared number.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  sq
+ *
+ * @param   {Number} aNumber The value to be squared.
+ * @return  {Number} Squared number.
  */
 pub.sq = function(aNumber) {
   if(arguments.length !== 1) error("sq(), wrong argument count.");
@@ -6909,117 +7380,159 @@ pub.sq = function(aNumber) {
 // -- Trigonometry --
 
 /**
- * @description Calculates the square root of a number. The square root of a number is always positive, even though there may be a valid negative root. The square root s of number a is such that s*s = a. It is the opposite of squaring.
+ * @description Calculates the square root of a number. The square root of a
+ *          number is always positive, even though there may be a valid negative
+ *          root. The square root s of number a is such that `s * s = a`. It is
+ *          the opposite of squaring.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method sqrt
- * @param  {Number} val A value.
- * @return {Number} Square root.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  sqrt
+ *
+ * @param   {Number} val A value.
+ * @return  {Number} Square root.
  */
 pub.sqrt = Math.sqrt;
 
 /**
- * @description The inverse of cos(), returns the arc cosine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of `cos()`, returns the arc cosine of a value. This
+ *          function expects the values in the range of `-1` to `1` and values
+ *          are returned in the range `0` to `PI` (`3.1415927`).
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method acos
- * @param  {Number} value The value whose arc cosine is to be returned.
- * @return {Number} The arc cosine.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  acos
+ *
+ * @param   {Number} value The value whose arc cosine is to be returned.
+ * @return  {Number} The arc cosine.
  */
 pub.acos = Math.acos;
 
 /**
- * @description The inverse of sin(), returns the arc sine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of `sin()`, returns the arc sine of a value. This
+ *          function expects the values in the range of `-1` to `1` and values
+ *          are returned in the range `0` to `PI` (`3.1415927`).
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method asin
- * @param  {Number} value The value whose arc sine is to be returned.
- * @return {Number} The arc sine.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  asin
+ *
+ * @param   {Number} value The value whose arc sine is to be returned.
+ * @return  {Number} The arc sine.
  */
 pub.asin = Math.asin;
 
 /**
- * @description The inverse of tan(), returns the arc tangent of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of `tan()`, returns the arc tangent of a value. This
+ *          function expects the values in the range of `-1` to `1` and values
+ *          are returned in the range `0` to `PI` (`3.1415927`).
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method atan
- * @param  {Number} value The value whose arc tangent is to be returned.
- * @return {Number} The arc tangent.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  atan
+ *
+ * @param   {Number} value The value whose arc tangent is to be returned.
+ * @return  {Number} The arc tangent.
  */
 pub.atan = Math.atan;
 
 /**
- * @description Calculates the angle (in radians) from a specified point to the coordinate origin as measured from the positive x-axis. Values are returned as a float in the range from PI to -PI. The atan2() function is most often used for orienting geometry to the position of the cursor. Note: The y-coordinate of the point is the first parameter and the x-coordinate is the second due the the structure of calculating the tangent.
+ * @description Calculates the angle (in radians) from a specified point to the
+ *          coordinate origin as measured from the positive x-axis. Values are
+ *          returned as a float in the range from `PI` to `-PI`. The `atan2()`
+ *          function is most often used for orienting geometry to the position
+ *          of the cursor. Note: The y-coordinate of the point is the first
+ *          parameter and the x-coordinate is the second due the the structure
+ *          of calculating the tangent.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method atan2
- * @param  {Number} y The y coordinate.
- * @param  {Number} x The x coordinate.
- * @return {Number} The atan2 value.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  atan2
+ *
+ * @param   {Number} y The y coordinate.
+ * @param   {Number} x The x coordinate.
+ * @return  {Number} The atan2 value.
  */
 pub.atan2 = Math.atan2;
 
 /**
- * @description Calculates the cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range -1 to 1.
+ * @description Calculates the cosine of an angle. This function expects the
+ *          values of the angle parameter to be provided in radians (values from
+ *          `0` to `PI * 2`). Values are returned in the range `-1` to `1`.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method cos
- * @param  {Number} rad A value in radians.
- * @return {Number} The cosine.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  cos
+ *
+ * @param   {Number} rad A value in radians.
+ * @return  {Number} The cosine.
  */
 pub.cos = Math.cos;
 
 /**
- * @description Converts a radian measurement to its corresponding value in degrees. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
+ * @description Converts a radian measurement to its corresponding value in
+ *          degrees. Radians and degrees are two ways of measuring the same
+ *          thing. There are 360 degrees in a circle and `2 * PI` radians in a
+ *          circle. For example, `90° = PI / 2 = 1.5707964`. All trigonometric
+ *          methods in basil require their parameters to be specified in
+ *          radians.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method degrees
- * @param  {Number} aAngle An angle in radians.
- * @return {Number} The given angle in degree.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  degrees
+ *
+ * @param   {Number} aAngle An angle in radians.
+ * @return  {Number} The given angle in degree.
  */
 pub.degrees = function(aAngle) {
   return aAngle * 180 / Math.PI;
 };
 
 /**
- * @description Converts a degree measurement to its corresponding value in radians. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
+ * @description Converts a degree measurement to its corresponding value in
+ *          radians. Radians and degrees are two ways of measuring the same
+ *          thing. There are 360 degrees in a circle and `2 * PI` radians in a
+ *          circle. For example, `90° = PI / 2 = 1.5707964`. All trigonometric
+ *          methods in basil require their parameters to be specified in
+ *          radians.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method radians
- * @param  {Number} aAngle An angle in degree.
- * @return {Number} The given angle in radians.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  radians
+ *
+ * @param   {Number} aAngle An angle in degree.
+ * @return  {Number} The given angle in radians.
  */
 pub.radians = function(aAngle) {
   return aAngle / 180 * Math.PI;
 };
 
 /**
- * @description Calculates the sine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to 6.28). Values are returned in the range -1 to 1.
+ * @description Calculates the sine of an angle. This function expects the
+ *          values of the angle parameter to be provided in radians (values from
+ *          `0` to `6.28`). Values are returned in the range `-1` to `1`.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method sin
- * @param  {Number} rad A value in radians.
- * @return {Number} The sine value.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  sin
+ *
+ * @param   {Number} rad A value in radians.
+ * @return  {Number} The sine value.
  */
 pub.sin = Math.sin;
 
 /**
- * @description Calculates the ratio of the sine and cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range infinity to -infinity.
+ * @description Calculates the ratio of the sine and cosine of an angle. This
+ *          function expects the values of the angle parameter to be provided in
+ *          radians (values from `0` to `PI * 2`). Values are returned in the
+ *          range `infinity` to `-infinity`.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method tan
- * @param  {Number} rad A value in radians.
- * @return {Number} The tangent value.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  tan
+ *
+ * @param   {Number} rad A value in radians.
+ * @return  {Number} The tangent value.
  */
 pub.tan = Math.tan;
 
@@ -7028,15 +7541,25 @@ pub.tan = Math.tan;
 var currentRandom = Math.random;
 
 /**
- * @description Generates random numbers. Each time the random() function is called, it returns an unexpected value within the specified range. If one parameter is passed to the function it will return a float between zero and the value of the high parameter. The function call random(5) returns values between 0 and 5. If two parameters are passed, it will return a float with a value between the the parameters. The function call random(-5, 10.2) returns values between -5 and 10.2.<br>
- * One parameter sets the range from 0 to the given parameter, while with two parameters present you set the range from val1 - val2.
+ * @description Generates random numbers. Each time the `random()` function is
+ *          called, it returns an unexpected value within the specified range.
+ *          If one parameter is passed to the function it will return a float
+ *          between zero and the value of the high parameter. The function call
+ *          `random(5)` returns values between `0` and `5`. If two parameters
+ *          are passed, it will return a float with a value between the the
+ *          parameters. The function call `random(-5, 10.2)` returns values
+ *          between `-5` and `10.2`.<br>
+ *          One parameter sets the range from `0`
+ *          to the given parameter, while with two parameters present you set
+ *          the range from `val1` to `val2`.
  *
- * @cat    Math
- * @subcat Random
- * @method random
- * @param  {Number} [low] The low border of the range.
- * @param  {Number} [high] The high border of the range.
- * @return {Number} A random number.
+ * @cat     Math
+ * @subcat  Random
+ * @method  random
+ *
+ * @param   {Number} [low] The low border of the range.
+ * @param   {Number} [high] The high border of the range.
+ * @return  {Number} A random number.
  */
 pub.random = function() {
   if (arguments.length === 0) return currentRandom();
@@ -7065,13 +7588,16 @@ Marsaglia.createRandomized = function() {
   return new Marsaglia(now / 6E4 & 4294967295, now & 4294967295);
 };
 /**
- * @description Sets the seed value for random().<br>
- * By default, random() produces different results each time the program is run. Set the seed parameter to a constant to return the same pseudo-random numbers each time the software is run.
+ * @description Sets the seed value for `random()`.<br> By default, `random()`
+ *          produces different results each time the program is run. Set the
+ *          seed parameter to a constant to return the same pseudo-random
+ *          numbers each time the software is run.
  *
- * @cat    Math
- * @subcat Random
- * @method randomSeed
- * @param  {Number} seed The seed value.
+ * @cat     Math
+ * @subcat  Random
+ * @method  randomSeed
+ *
+ * @param   {Number} seed The seed value.
  */
 pub.randomSeed = function(seed) {
   currentRandom = (new Marsaglia(seed)).nextDouble;
@@ -7079,18 +7605,20 @@ pub.randomSeed = function(seed) {
 /**
  * @description Random Generator with Gaussian distribution.
  *
- * @cat    Math
- * @subcat Random
- * @method Random
- * @param  {Number} seed The seed value.
- * @constructor
+ * @cat     Math
+ * @subcat  Random
+ * @method  Random
+ *
+ * @param   {Number} seed The seed value.
+ * @class
  */
 pub.Random = function(seed) {
   var haveNextNextGaussian = false,
     nextNextGaussian, random;
   /**
-   * @method Random.nextGaussian
-   * @return {Number} The next Gaussian random value.
+   * @method  Random.nextGaussian
+   *
+   * @return  {Number} The next Gaussian random value.
    */
   this.nextGaussian = function() {
     if (haveNextNextGaussian) {
@@ -7188,21 +7716,47 @@ var noiseProfile = {
 };
 
 /**
- * @description Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural ordered, harmonic succession of numbers compared to the standard random() function. It was invented by Ken Perlin in the 1980s and been used since in graphical applications to produce procedural textures, natural motion, shapes, terrains etc.
- * <br><br>
- * The main difference to the random() function is that Perlin noise is defined in an infinite n-dimensional space where each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. basil.js can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space. The 2nd and 3rd dimension can also be interpreted as time.
- * <br><br>
- * The actual noise is structured similar to an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, perlin noise is computed over several octaves which are added together for the final result.
- * <br><br>
- * Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space the value of the coordinates doesn't matter as such, only the distance between successive coordinates does (eg. when using noise() within a loop). As a general rule the smaller the difference between coordinates, the smoother the resulting noise sequence will be. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
+ * @description Returns the Perlin noise value at specified coordinates. Perlin
+ *          noise is a random sequence generator producing a more natural
+ *          ordered, harmonic succession of numbers compared to the standard
+ *          `random()` function. It was invented by Ken Perlin in the 1980s and
+ *          been used since in graphical applications to produce procedural
+ *          textures, natural motion, shapes, terrains etc.
+ *          <br><br>
+ *          The main
+ *          difference to the `random()` function is that Perlin noise is
+ *          defined in an infinite n-dimensional space where each pair of
+ *          coordinates corresponds to a fixed semi-random value (fixed only for
+ *          the lifespan of the program). The resulting value will always be
+ *          between `0` and `1`. basil.js can compute 1D, 2D and 3D noise,
+ *          depending on the number of coordinates given. The noise value can be
+ *          animated by moving through the noise space. The 2nd and 3rd
+ *          dimension can also be interpreted as time.
+ *          <br><br>
+ *          The actual noise
+ *          is structured similar to an audio signal, in respect to the
+ *          function's use of frequencies. Similar to the concept of harmonics
+ *          in physics, perlin noise is computed over several octaves which are
+ *          added together for the final result.
+ *          <br><br>
+ *          Another way to adjust
+ *          the character of the resulting sequence is the scale of the input
+ *          coordinates. As the function works within an infinite space the
+ *          value of the coordinates doesn't matter as such, only the distance
+ *          between successive coordinates does (eg. when using `noise()` within
+ *          a loop). As a general rule the smaller the difference between
+ *          coordinates, the smoother the resulting noise sequence will be.
+ *          Steps of `0.005`- `0.03` work best for most applications, but this
+ *          will differ depending on use.
  *
- * @cat    Math
- * @subcat Random
- * @method noise
- * @param  {Number} x Coordinate in x space.
- * @param  {Number} [y] Coordinate in y space.
- * @param  {Number} [z] Coordinate in z space.
- * @return {Number} The noise value.
+ * @cat     Math
+ * @subcat  Random
+ * @method  noise
+ *
+ * @param   {Number} x Coordinate in x space.
+ * @param   {Number} [y] Coordinate in y space.
+ * @param   {Number} [z] Coordinate in z space.
+ * @return  {Number} The noise value.
  */
 pub.noise = function(x, y, z) {
   if (noiseProfile.generator === undefined) noiseProfile.generator = new PerlinNoise(noiseProfile.seed);
@@ -7229,15 +7783,31 @@ pub.noise = function(x, y, z) {
 };
 
 /**
- * @description Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overal intensity of the noise, whereas higher octaves create finer grained details in the noise sequence. By default, noise is computed over 4 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the 1st octave. This falloff amount can be changed by adding an additional function parameter. Eg. a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. Any value between 0.0 and 1.0 is valid, however note that values greater than 0.5 might result in greater than 1.0 values returned by noise().
- * <br><br>
- * By changing these parameters, the signal created by the noise() function can be adapted to fit very specific needs and characteristics.
+ * @description Adjusts the character and level of detail produced by the Perlin
+ *          noise function. Similar to harmonics in physics, noise is computed
+ *          over several octaves. Lower octaves contribute more to the output
+ *          signal and as such define the overal intensity of the noise, whereas
+ *          higher octaves create finer grained details in the noise sequence.
+ *          By default, noise is computed over 4 octaves with each octave
+ *          contributing exactly half than its predecessor, starting at 50%
+ *          strength for the 1st octave. This falloff amount can be changed by
+ *          adding an additional function parameter. Eg. a falloff factor of
+ *          `0.75` means each octave will now have 75% impact (25% less) of the
+ *          previous lower octave. Any value between `0` and `1` is valid,
+ *          however note that values greater than `0.5` might result in greater
+ *          than `1` values returned by `noise()`.
+ *          <br><br>
+ *          By changing these
+ *          parameters, the signal created by the `noise()` function can be
+ *          adapted to fit very specific needs and characteristics.
  *
- * @cat    Math
- * @subcat Random
- * @method noiseDetail
- * @param  {Number} octaves Number of octaves to be used by the noise() function.
- * @param  {Number} fallout Falloff factor for each octave.
+ * @cat     Math
+ * @subcat  Random
+ * @method  noiseDetail
+ *
+ * @param   {Number} octaves Number of octaves to be used by the noise()
+ *          function.
+ * @param   {Number} fallout Falloff factor for each octave.
  */
 pub.noiseDetail = function(octaves, fallout) {
   noiseProfile.octaves = octaves;
@@ -7245,12 +7815,16 @@ pub.noiseDetail = function(octaves, fallout) {
 };
 
 /**
- * @description Sets the seed value for noise(). By default, noise() produces different results each time the program is run. Set the value parameter to a constant to return the same pseudo-random numbers each time the software is run.
+ * @description Sets the seed value for `noise()`. By default, `noise()`
+ *          produces different results each time the program is run. Set the
+ *          value parameter to a constant to return the same pseudo-random
+ *          numbers each time the software is run.
  *
- * @cat    Math
- * @subcat Random
- * @method noiseSeed
- * @param  {Number} seed Noise seed value.
+ * @cat     Math
+ * @subcat  Random
+ * @method  noiseSeed
+ *
+ * @param   {Number} seed Noise seed value.
  */
 pub.noiseSeed = function(seed) {
   noiseProfile.seed = seed;
@@ -7267,14 +7841,20 @@ var precision = function(num, dec) {
 };
 
 /**
- * @description The function calculates the geometric bounds of any given page item or text. Use the `transforms()` function to modify page items.
- * In case the object is any kind of text, additional typographic information baseline and xHeight are calculated.
+ * @description The function calculates the geometric bounds of any given page
+ *          item or text. Use the `transforms()` function to modify page items.
+ *          In case the object is any kind of text, additional typographic
+ *          information `baseline` and `xHeight` are calculated.
  *
- * @cat    Document
- * @subcat Transformation
- * @method bounds
- * @param  {PageItem|Text} obj The page item or text to calculate the geometric bounds.
- * @return {Object} Geometric bounds object with these properties: width, height, left, right, top, bottom and for text: baseline, xHeight.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  bounds
+ *
+ * @param   {PageItem|Text} obj The page item or text to calculate the geometric
+ *          bounds.
+ * @return  {Object} Geometric bounds object with these properties: `width`,
+ *          `height`, `left`, `right`, `top`, `bottom` and for text: `baseline`,
+ *          `xHeight`.
  */
 pub.bounds = function (obj) {
   var x1, y1, x2, y2, w, h;
@@ -7343,15 +7923,27 @@ pub.bounds = function (obj) {
 /* global precision */
 
 /**
- * @description Sets the reference point for transformations using the `transform()` function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.<br>
- * Arguments can be the basil constants `TOP_LEFT`, `TOP_CENTER`, `TOP_RIGHT`, `CENTER_LEFT`, `CENTER`, `CENTER_RIGHT`, `BOTTOM_LEFT`, `BOTTOM_CENTER` or `BOTTOM_RIGHT`. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.<br>
- * If the function is used without any arguments the currently set reference point will be returned.
+ * @description Sets the reference point for transformations using the
+ *          `transform()` function. The reference point will be used for all
+ *          following transformations, until it is changed again. By default,
+ *          the reference point is set to the top left.<br>
+ *          Arguments can be the
+ *          basil constants `TOP_LEFT`, `TOP_CENTER`, `TOP_RIGHT`,
+ *          `CENTER_LEFT`, `CENTER`, `CENTER_RIGHT`, `BOTTOM_LEFT`,
+ *          `BOTTOM_CENTER` or `BOTTOM_RIGHT`. Alternatively the digits `1`
+ *          through `9` (as they are arranged on a num pad) can be used to set
+ *          the anchor point. Lastly the function can also use an InDesign
+ *          anchor point enumerator to set the reference point.<br>
+ *          If the
+ *          function is used without any arguments the currently set reference
+ *          point will be returned.
  *
- * @cat    Document
- * @subcat Transformation
- * @method referencePoint
- * @param  {String} [referencePoint] The reference point to set.
- * @return {String} Current reference point setting.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  referencePoint
+ *
+ * @param   {String} [referencePoint] The reference point to set.
+ * @return  {String} Current reference point setting.
  */
 pub.referencePoint = function(rp) {
   if(!arguments.length) {
@@ -7399,26 +7991,46 @@ pub.referencePoint = function(rp) {
 };
 
 /**
- * @description Transforms a given page item. The type of transformation is determinded with the second parameter. The third parameter is the transformation value, either a number or an array of x and y values. The transformation's reference point (top left, bottom center etc.) can be set beforehand by using the `referencePoint()` function. If the third parameter is ommited, the function can be used to measure the value of the page item.
- * There are 10 different transformation types:
- *    - `"translate"`: Translates the page item by the given `[x, y]` values. Returns the coordinates of the page item's anchor point as an array.
- *    - `"rotate"`: Rotates the page item to the given degree value. Returns the page item's rotation value in degrees.
- *    - `"scale"`: Scales the page item to the given `[x, y]` scale factor values. Alternatively, a single scale factor value can be used to scale the page item uniformely. Returns the scale factor values of the page item's current scale as an array.
- *    - `"shear"`: Shears the page item to the given degree value. Returns the page item's shear value in degrees.
- *    - `"size"`: Sets the page item's size to the given `[x, y]` dimensions. Returns the size of the page item as an array.
- *    - `"width"`: Sets the page item's width to the given value. Returns the width of the page item.
- *    - `"height"`: Sets the page item's height to the given value. Returns the height of the page item.
- *    - `"position"`: Sets the position of the page item's anchor point to the given `[x, y]` coordinates. Returns the coordinates of the page item's anchor point as an array.
- *    - `"x"`: Sets the x-position of the page item's anchor point to the given value. Returns the x-coordinate of the page item's anchor point.
- *    - `"y"`: Sets the y-position of the page item's anchor point to the given value. Returns the y-coordinate of the page item's anchor point.
+ * @description Transforms a given page item. The type of transformation is
+ *          determinded with the second parameter. The third parameter is the
+ *          transformation value, either a number or an array of x and y values.
+ *          The transformation's reference point (top left, bottom center etc.)
+ *          can be set beforehand by using the `referencePoint()` function. If
+ *          the third parameter is ommited, the function can be used to measure
+ *          the value of the page item. There are 10 different transformation
+ *          types:
+ *    - `"translate"`: Translates the page item by the given `[x, y]` values.
+ *      Returns the coordinates of the page item's anchor point as an array.
+ *    - `"rotate"`: Rotates the page item to the given degree value. Returns the
+ *      page item's rotation value in degrees.
+ *    - `"scale"`: Scales the page item to the given `[x, y]` scale factor
+ *      values. Alternatively, a single scale factor value can be used to scale
+ *      the page item uniformely. Returns the scale factor values of the page
+ *      item's current scale as an array.
+ *    - `"shear"`: Shears the page item to the given degree value. Returns the
+ *      page item's shear value in degrees.
+ *    - `"size"`: Sets the page item's size to the given `[x, y]` dimensions.
+ *      Returns the size of the page item as an array.
+ *    - `"width"`: Sets the page item's width to the given value. Returns the
+ *      width of the page item.
+ *    - `"height"`: Sets the page item's height to the given value. Returns the
+ *      height of the page item.
+ *    - `"position"`: Sets the position of the page item's anchor point to the
+ *      given `[x, y]` coordinates. Returns the coordinates of the page item's
+ *      anchor point as an array.
+ *    - `"x"`: Sets the x-position of the page item's anchor point to the given
+ *      value. Returns the x-coordinate of the page item's anchor point.
+ *    - `"y"`: Sets the y-position of the page item's anchor point to the given
+ *      value. Returns the y-coordinate of the page item's anchor point.
  *
- * @cat    Document
- * @subcat Transformation
- * @method transform
- * @param  {PageItem} pItem The page item to transform.
- * @param  {String} type The type of transformation.
- * @param  {Number|Array} [value] The value(s) of the transformation.
- * @return {Number|Array} The current value(s) of the specified transformation.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  transform
+ *
+ * @param   {PageItem} pItem The page item to transform.
+ * @param   {String} type The type of transformation.
+ * @param   {Number|Array} [value] The value(s) of the transformation.
+ * @return  {Number|Array} The current value(s) of the specified transformation.
  *
  * @example <caption>Rotating a rectangle to a 25 degrees angle</caption>
  * var r = rect(20, 40, 200, 100);
@@ -7429,7 +8041,8 @@ pub.referencePoint = function(rp) {
  * var w = transform(r, "width");
  * println(w); // prints the rectangle's random width between 100 and 300
  *
- * @example <caption>Position a rectangle's lower right corner at a certain position</caption>
+ * @example <caption>Position a rectangle's lower right corner at a certain
+ *          position</caption>
  * var r = rect(20, 40, random(100, 300), random(50, 150));
  * referencePoint(BOTTOM_RIGHT);
  * transform(r, "position", [40, 40]);
@@ -7758,23 +8371,31 @@ Matrix2D.prototype = {
 };
 
 /**
- * @description Multiplies the current matrix by the one specified through the parameters.
+ * @description Multiplies the current matrix by the one specified through the
+ *          parameters.
  *
- * @cat    Document
- * @subcat Transformation
- * @method applyMatrix
- * @param  {Matrix2D} matrix The matrix to be applied.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  applyMatrix
+ *
+ * @param   {Matrix2D} matrix The matrix to be applied.
  */
 pub.applyMatrix = function (matrix) {
   currMatrix.apply(matrix);
 };
 
 /**
- * @description Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
+ * @description Pops the current transformation matrix off the matrix stack.
+ *          Understanding pushing and popping requires understanding the concept
+ *          of a matrix stack. The `pushMatrix()` function saves the current
+ *          coordinate system to the stack and `popMatrix()` restores the prior
+ *          coordinate system. `pushMatrix()` and `popMatrix()` are used in
+ *          conjuction with the other transformation methods and may be embedded
+ *          to control the scope of the transformations.
  *
- * @cat    Document
- * @subcat Transformation
- * @method popMatrix
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  popMatrix
  */
 pub.popMatrix = function () {
   if (matrixStack.length > 0) {
@@ -7787,20 +8408,27 @@ pub.popMatrix = function () {
 /**
  * @description Prints the current matrix to the console window.
  *
- * @cat    Document
- * @subcat Transformation
- * @method printMatrix
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  printMatrix
  */
 pub.printMatrix = function () {
   currMatrix.print();
 };
 
 /**
- * @description Pushes the current transformation matrix onto the matrix stack. Understanding `pushMatrix()` and `popMatrix()` requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
+ * @description Pushes the current transformation matrix onto the matrix stack.
+ *          Understanding `pushMatrix()` and `popMatrix()` requires
+ *          understanding the concept of a matrix stack. The `pushMatrix()`
+ *          function saves the current coordinate system to the stack and
+ *          `popMatrix()` restores the prior coordinate system. `pushMatrix()`
+ *          and `popMatrix()` are used in conjuction with the other
+ *          transformation methods and may be embedded to control the scope of
+ *          the transformations.
  *
- * @cat    Document
- * @subcat Transformation
- * @method pushMatrix
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  pushMatrix
  */
 pub.pushMatrix = function () {
   matrixStack.push(currMatrix.array());
@@ -7809,9 +8437,9 @@ pub.pushMatrix = function () {
 /**
  * @description Replaces the current matrix with the identity matrix.
  *
- * @cat    Document
- * @subcat Transformation
- * @method resetMatrix
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  resetMatrix
  */
 pub.resetMatrix = function () {
   matrixStack = [];
@@ -7821,12 +8449,26 @@ pub.resetMatrix = function () {
 };
 
 /**
- * @description Rotates an object the amount specified by the angle parameter. Angles should be specified in radians (values from 0 to `PI`*2) or converted to radians with the `radians()` function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a clockwise direction with 0 radians or degrees being up and `HALF_PI` being to the right etc. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `rotate(PI/2)` and then `rotate(PI/2)` is the same as `rotate(PI)`. If `rotate()` is called within the `draw()`, the transformation is reset when the loop begins again. Technically, `rotate()` multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
+ * @description Rotates an object the amount specified by the angle parameter.
+ *          Angles should be specified in radians (values from 0 to `PI`*2) or
+ *          converted to radians with the `radians()` function. Objects are
+ *          always rotated around their relative position to the origin and
+ *          positive numbers rotate objects in a clockwise direction with 0
+ *          radians or degrees being up and `HALF_PI` being to the right etc.
+ *          Transformations apply to everything that happens after and
+ *          subsequent calls to the function accumulates the effect. For
+ *          example, calling `rotate(PI/2)` and then `rotate(PI/2)` is the same
+ *          as `rotate(PI)`. If `rotate()` is called within the `draw()`, the
+ *          transformation is reset when the loop begins again. Technically,
+ *          `rotate()` multiplies the current transformation matrix by a
+ *          rotation matrix. This function can be further controlled by the
+ *          `pushMatrix()` and `popMatrix()`.
  *
- * @cat    Document
- * @subcat Transformation
- * @method rotate
- * @param  {Number} angle The angle specified in radians
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  rotate
+ *
+ * @param   {Number} angle The angle specified in radians
  */
 pub.rotate = function (angle) {
   if(typeof arguments[0] === "undefined") {
@@ -7836,14 +8478,25 @@ pub.rotate = function (angle) {
 };
 
 /**
- * @description Increasing and decreasing the size of an object by expanding and contracting vertices. Scale values are specified as decimal percentages. The function call `scale(2.0)` increases the dimension of a shape by 200%. Objects always scale from their relative origin to the coordinate system. Transformations apply to everything that happens after and subsequent calls to the function multiply the effect. For example, calling `scale(2.0)` and then `scale(1.5)` is the same as `scale(3.0)`. If `scale()` is called within `draw()`, the transformation is reset when the loop begins again. This function can be further controlled by `pushMatrix()` and `popMatrix()`.
- * If only one parameter is given, it is applied on X and Y axis.
+ * @description Increasing and decreasing the size of an object by expanding and
+ *          contracting vertices. Scale values are specified as decimal
+ *          percentages. The function call `scale(2.0)` increases the dimension
+ *          of a shape by 200%. Objects always scale from their relative origin
+ *          to the coordinate system. Transformations apply to everything that
+ *          happens after and subsequent calls to the function multiply the
+ *          effect. For example, calling `scale(2.0)` and then `scale(1.5)` is
+ *          the same as `scale(3.0)`. If `scale()` is called within `draw()`,
+ *          the transformation is reset when the loop begins again. This
+ *          function can be further controlled by `pushMatrix()` and
+ *          `popMatrix()`. If only one parameter is given, it is applied on X
+ *          and Y axis.
  *
- * @cat    Document
- * @subcat Transformation
- * @method scale
- * @param  {Number} scaleX The amount to scale the X axis.
- * @param  {Number} scaleY The amount to scale the Y axis.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  scale
+ *
+ * @param   {Number} scaleX The amount to scale the X axis.
+ * @param   {Number} scaleY The amount to scale the Y axis.
  */
 pub.scale = function (scaleX, scaleY) {
   if(typeof arguments[0] != "number" || (arguments.length === 2 && typeof arguments[1] != "number")) {
@@ -7853,13 +8506,20 @@ pub.scale = function (scaleX, scaleY) {
 };
 
 /**
- * @description Specifies an amount to displace objects within the page. The x parameter specifies left/right translation, the y parameter specifies up/down translation. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `translate(50, 0)` and then `translate(20, 0)` is the same as `translate(70, 0)`. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
+ * @description Specifies an amount to displace objects within the page. The `x`
+ *          parameter specifies left/right translation, the `y` parameter
+ *          specifies up/down translation. Transformations apply to everything
+ *          that happens after and subsequent calls to the function accumulates
+ *          the effect. For example, calling `translate(50, 0)` and then
+ *          `translate(20, 0)` is the same as `translate(70, 0)`. This function
+ *          can be further controlled by the `pushMatrix()` and `popMatrix()`.
  *
- * @cat    Document
- * @subcat Transformation
- * @method translate
- * @param  {Number} tx The amount of offset on the X axis.
- * @param  {Number} ty The amount of offset on the Y axis.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  translate
+ *
+ * @param   {Number} tx The amount of offset on the X axis.
+ * @param   {Number} ty The amount of offset on the Y axis.
  */
 pub.translate = function (tx, ty) {
   if(typeof arguments[0] === "undefined" || typeof arguments[1] === "undefined") {

--- a/basil.js
+++ b/basil.js
@@ -7199,8 +7199,8 @@ pub.bounds = function (obj) {
 /* global precision */
 
 /**
- * @description Sets the reference point for transformations using the <code>transform()</code> function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.<br>
- * Arguments can be the basil constants <code>TOP_LEFT</code>, <code>TOP_CENTER</code>, <code>TOP_RIGHT</code>, <code>CENTER_LEFT</code>, <code>CENTER</code>, <code>CENTER_RIGHT</code>, <code>BOTTOM_LEFT</code>, <code>BOTTOM_CENTER</code> or <code>BOTTOM_RIGHT</code>. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.<br>
+ * @description Sets the reference point for transformations using the `transform()` function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.<br>
+ * Arguments can be the basil constants `TOP_LEFT`, `TOP_CENTER`, `TOP_RIGHT`, `CENTER_LEFT`, `CENTER`, `CENTER_RIGHT`, `BOTTOM_LEFT`, `BOTTOM_CENTER` or `BOTTOM_RIGHT`. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.<br>
  * If the function is used without any arguments the currently set reference point will be returned.
  *
  * @cat    Document
@@ -7255,20 +7255,18 @@ pub.referencePoint = function(rp) {
 };
 
 /**
- * @description Transforms a given page item. The type of transformation is determinded with the second parameter. The third parameter is the transformation value, either a number or an array of x and y values. The transformation's reference point (top left, bottom center etc.) can be set beforehand by using the <code>referencePoint()</code> function. If the third parameter is ommited, the function can be used to measure the value of the page item.
+ * @description Transforms a given page item. The type of transformation is determinded with the second parameter. The third parameter is the transformation value, either a number or an array of x and y values. The transformation's reference point (top left, bottom center etc.) can be set beforehand by using the `referencePoint()` function. If the third parameter is ommited, the function can be used to measure the value of the page item.
  * There are 10 different transformation types:
- * <ul>
- * <li> <code>"translate"</code>: Translates the page item by the given <code>[x, y]</code> values. Returns the coordinates of the page item's anchor point as an array.</li>
- * <li> <code>"rotate"</code>: Rotates the page item to the given degree value. Returns the page item's rotation value in degrees.</li>
- * <li> <code>"scale"</code>: Scales the page item to the given <code>[x, y]</code> scale factor values. Alternatively, a single scale factor value can be used to scale the page item uniformely. Returns the scale factor values of the page item's current scale as an array.</li>
- * <li> <code>"shear"</code>: Shears the page item to the given degree value. Returns the page item's shear value in degrees.</li>
- * <li> <code>"size"</code>: Sets the page item's size to the given <code>[x, y]</code> dimensions. Returns the size of the page item as an array.</li>
- * <li> <code>"width"</code>: Sets the page item's width to the given value. Returns the width of the page item.</li>
- * <li> <code>"height"</code>: Sets the page item's height to the given value. Returns the height of the page item.</li>
- * <li> <code>"position"</code>: Sets the position of the page item's anchor point to the given <code>[x, y]</code> coordinates. Returns the coordinates of the page item's anchor point as an array.</li>
- * <li> <code>"x"</code>: Sets the x-position of the page item's anchor point to the given value. Returns the x-coordinate of the page item's anchor point.</li>
- * <li> <code>"y"</code>: Sets the y-position of the page item's anchor point to the given value. Returns the y-coordinate of the page item's anchor point.</li>
- * </ul>
+ *    - `"translate"`: Translates the page item by the given `[x, y]` values. Returns the coordinates of the page item's anchor point as an array.
+ *    - `"rotate"`: Rotates the page item to the given degree value. Returns the page item's rotation value in degrees.
+ *    - `"scale"`: Scales the page item to the given `[x, y]` scale factor values. Alternatively, a single scale factor value can be used to scale the page item uniformely. Returns the scale factor values of the page item's current scale as an array.
+ *    - `"shear"`: Shears the page item to the given degree value. Returns the page item's shear value in degrees.
+ *    - `"size"`: Sets the page item's size to the given `[x, y]` dimensions. Returns the size of the page item as an array.
+ *    - `"width"`: Sets the page item's width to the given value. Returns the width of the page item.
+ *    - `"height"`: Sets the page item's height to the given value. Returns the height of the page item.
+ *    - `"position"`: Sets the position of the page item's anchor point to the given `[x, y]` coordinates. Returns the coordinates of the page item's anchor point as an array.
+ *    - `"x"`: Sets the x-position of the page item's anchor point to the given value. Returns the x-coordinate of the page item's anchor point.
+ *    - `"y"`: Sets the y-position of the page item's anchor point to the given value. Returns the y-coordinate of the page item's anchor point.
  *
  * @cat    Document
  * @subcat Transformation
@@ -7628,7 +7626,7 @@ pub.applyMatrix = function (matrix) {
 };
 
 /**
- * @description Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires understanding the concept of a matrix stack. The <code>pushMatrix()</code> function saves the current coordinate system to the stack and <code>popMatrix()</code> restores the prior coordinate system. <code>pushMatrix()</code> and <code>popMatrix()</code> are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
+ * @description Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
  *
  * @cat    Document
  * @subcat Transformation
@@ -7654,7 +7652,7 @@ pub.printMatrix = function () {
 };
 
 /**
- * @description Pushes the current transformation matrix onto the matrix stack. Understanding <code>pushMatrix()</code> and <code>popMatrix()</code> requires understanding the concept of a matrix stack. The <code>pushMatrix()</code> function saves the current coordinate system to the stack and <code>popMatrix()</code> restores the prior coordinate system. <code>pushMatrix()</code> and <code>popMatrix()</code> are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
+ * @description Pushes the current transformation matrix onto the matrix stack. Understanding `pushMatrix()` and `popMatrix()` requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
  *
  * @cat    Document
  * @subcat Transformation
@@ -7679,7 +7677,7 @@ pub.resetMatrix = function () {
 };
 
 /**
- * @description Rotates an object the amount specified by the angle parameter. Angles should be specified in radians (values from 0 to <code>PI</code>*2) or converted to radians with the <code>radians()</code> function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a clockwise direction with 0 radians or degrees being up and <code>HALF_PI</code> being to the right etc. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <code>rotate(PI/2)</code> and then <code>rotate(PI/2)</code> is the same as <code>rotate(PI)</code>. If <code>rotate()</code> is called within the <code>draw()</code>, the transformation is reset when the loop begins again. Technically, <code>rotate()</code> multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by the <code>pushMatrix()</code> and <code>popMatrix()</code>.
+ * @description Rotates an object the amount specified by the angle parameter. Angles should be specified in radians (values from 0 to `PI`*2) or converted to radians with the `radians()` function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a clockwise direction with 0 radians or degrees being up and `HALF_PI` being to the right etc. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `rotate(PI/2)` and then `rotate(PI/2)` is the same as `rotate(PI)`. If `rotate()` is called within the `draw()`, the transformation is reset when the loop begins again. Technically, `rotate()` multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
  *
  * @cat    Document
  * @subcat Transformation
@@ -7694,7 +7692,7 @@ pub.rotate = function (angle) {
 };
 
 /**
- * @description Increasing and decreasing the size of an object by expanding and contracting vertices. Scale values are specified as decimal percentages. The function call <code>scale(2.0)</code> increases the dimension of a shape by 200%. Objects always scale from their relative origin to the coordinate system. Transformations apply to everything that happens after and subsequent calls to the function multiply the effect. For example, calling <code>scale(2.0)</code> and then <code>scale(1.5)</code> is the same as <code>scale(3.0)</code>. If <code>scale()</code> is called within <code>draw()</code>, the transformation is reset when the loop begins again. This function can be further controlled by <code>pushMatrix()</code> and <code>popMatrix()</code>.
+ * @description Increasing and decreasing the size of an object by expanding and contracting vertices. Scale values are specified as decimal percentages. The function call `scale(2.0)` increases the dimension of a shape by 200%. Objects always scale from their relative origin to the coordinate system. Transformations apply to everything that happens after and subsequent calls to the function multiply the effect. For example, calling `scale(2.0)` and then `scale(1.5)` is the same as `scale(3.0)`. If `scale()` is called within `draw()`, the transformation is reset when the loop begins again. This function can be further controlled by `pushMatrix()` and `popMatrix()`.
  * If only one parameter is given, it is applied on X and Y axis.
  *
  * @cat    Document
@@ -7711,7 +7709,7 @@ pub.scale = function (scaleX, scaleY) {
 };
 
 /**
- * @description Specifies an amount to displace objects within the page. The x parameter specifies left/right translation, the y parameter specifies up/down translation. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <code>translate(50, 0)</code> and then <code>translate(20, 0)</code> is the same as <code>translate(70, 0)</code>. This function can be further controlled by the <code>pushMatrix()</code> and <code>popMatrix()</code>.
+ * @description Specifies an amount to displace objects within the page. The x parameter specifies left/right translation, the y parameter specifies up/down translation. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `translate(50, 0)` and then `translate(20, 0)` is the same as `translate(70, 0)`. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
  *
  * @cat    Document
  * @subcat Transformation

--- a/basil.js
+++ b/basil.js
@@ -85,6 +85,8 @@ var pub = {};
  */
 pub.VERSION = "1.1.0";
 
+/*
+  ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 // ----------------------------------------
 // src/includes/constants.js
 // ----------------------------------------
@@ -491,7 +493,7 @@ var stackArray = $.stack.
 pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1] : stackArray[0];
 
 /**
-* Used with <code>mode()</code> to set performance mode. Disables screen redraw during processing.
+* Used with `mode()` to set performance mode. Disables screen redraw during processing.
 * @property SILENT {String}
 * @cat Environment
 * @subcat modes
@@ -499,7 +501,7 @@ pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1] : stackArray[0
 pub.SILENT = "silent";
 
 /**
- * Used with <code>mode()</code> to set performance mode. Processes the document in background mode. The document will not be visible until the script is done or until the mode is changed back to <code>VISIBLE</code>. The document will be removed from the display list and added again after the script is done. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use <code>println("yourMessage")</code> in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.
+ * Used with `mode()` to set performance mode. Processes the document in background mode. The document will not be visible until the script is done or until the mode is changed back to `VISIBLE`. The document will be removed from the display list and added again after the script is done. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use `println("yourMessage")` in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.
  * @property HIDDEN {String}
  * @cat Environment
  * @subcat modes
@@ -507,7 +509,7739 @@ pub.SILENT = "silent";
 pub.HIDDEN = "hidden";
 
 /**
- * Default mode. Used with <code>mode()</code> to set performance mode. Processes the document with screen redraw, use this option to see direct results during the process. This will slow down the process in terms of processing time.
+ * Default mode. Used with `mode()` to set performance mode. Processes the document with screen redraw, use this option to see direct results during the process. This will slow down the process in terms of processing time.
+ * @property VISIBLE {String}
+ * @cat Environment
+ * @subcat modes
+ */
+pub.VISIBLE = "visible";
+
+
+var ERROR_PREFIX = "\nBasil.js Error -> ",
+  WARNING_PREFIX = "### Basil Warning -> ";
+
+
+// ----------------------------------------
+// src/includes/public-vars.js
+// ----------------------------------------
+
+/**
+ * @description System variable which stores the width of the current page.
+ *
+ * @cat Environment
+ * @property {Number} width Width of the current page.
+ */
+pub.width = null;
+
+/**
+ * @description System variable which stores the height of the current page.
+ *
+ * @cat Environment
+ * @property {Number} height Height of the current page.
+ */
+pub.height = null;
+
+  B A S I L . J S
+// ----------------------------------------
+// src/includes/private-vars.js
+// ----------------------------------------
+
+var addToStoryCache = null, /* tmp cache, see addToStroy(), via InDesign external library file*/
+  appSettings = null,
+  currAlign = null,
+  currCanvasMode = null,
+  currColorMode = null,
+  currDialogFolder = null,
+  currDoc = null,
+  currDocSettings = null,
+  currEllipseMode = null,
+  currFillColor = null,
+  currFillTint = null,
+  currFont = null,
+  currFontSize = null,
+  currGradientMode = null,
+  currImageMode = null,
+  currKerning = null,
+  currLayer = null,
+  currLeading = null,
+  currMatrix = null,
+  currMode = null,
+  currOriginX = null,
+  currOriginY = null,
+  currPage = null,
+  currPathPointer = null,
+  currPolygon = null,
+  currRefPoint = null,
+  currRectMode = null,
+  currShapeMode = null,
+  currStrokeColor = null,
+  currStrokeTint = null,
+  currStrokeWeight = null,
+  currTracking = null,
+  currUnits = null,
+  currVertexPoints = null,
+  currYAlign = null,
+  currFrameRate = null,
+  currIdleTask = null,
+  matrixStack = null,
+  noneSwatchColor = null,
+  progressPanel = null,
+  startTime = null;
+
+  Bringing the spirit of the Processing visualization language to Adobe InDesign.
+
+// ----------------------------------------
+// src/includes/global-functions.js
+// ----------------------------------------
+
+/**
+ * @description The <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/filter">filter()</a> method creates a new array with all elements that pass the test implemented by the provided function.
+ *
+ * @cat    Data
+ * @subcat Array
+ * @method Array.filter
+ * @param  {Function} callback The Function is a predicate, to test each element of the array. Return true to keep the element, false otherwise.
+ * @return {Array} The new array with the elements that pass the test.
+ */
+if (!Array.prototype.filter) {
+  Array.prototype.filter = function(fun) {
+    if (this === null) throw new TypeError();
+    var t = Object(this);
+    var len = t.length >>> 0;
+    if (typeof fun != "function") throw new TypeError();
+    var res = [];
+    var thisp = arguments[1];
+    for (var i = 0; i < len; i++) {
+      if (i in t) {
+        var val = t[i]; // in case fun mutates this
+        if (fun.call(thisp, val, i, t)) res.push(val);
+      }
+    }
+    return res;
+  };
+}
+
+/**
+ * @description The <a href="https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array/map">map()</a> method creates a new array with the results of calling a provided function on every element in this array.
+ *
+ * @cat    Data
+ * @subcat Array
+ * @method Array.map
+ * @param  {Function} callback Function that produces an element of the new Array.
+ * @return {Array} The new array with each element being the result of the callback function.
+ */
+if (!Array.prototype.map) {
+  Array.prototype.map = function(callback, thisArg) {
+    var T, A, k;
+    if (this == null) {
+      throw new TypeError(" this is null or not defined");
+    }
+    var O = Object(this);
+    var len = O.length >>> 0;
+    if (typeof callback !== "function") {
+      throw new TypeError(callback + " is not a function");
+    }
+    if (thisArg) {
+      T = thisArg;
+    }
+    A = new Array(len);
+    k = 0;
+    while(k < len) {
+      var kValue, mappedValue;
+      if (k in O) {
+        kValue = O[ k ];
+        mappedValue = callback.call(T, kValue, k, O);
+        A[ k ] = mappedValue;
+      }
+      k++;
+    }
+    return A;
+  };
+}
+
+/**
+* @description Used to run a function on all elements of an array. Please note the existance of the convenience methods `stories()`, `paragraphs()`, `lines()`, `words()` and `characters()` that are used to iterate through all instances of the given type in the given document.
+*
+* @cat    Data
+* @subcat Array
+* @method Array.forEach
+* @param  {Array} collection The array to be processed.
+* @param  {Function} cb The function that will be called on each element. The call will be like function(item,i) where i is the current index of the item within the array.
+*/
+forEach = function(collection, cb) {
+  for (var i = 0, len = collection.length; i < len; i++) {
+
+    if(!isValid(collection[i])) {
+      warning("forEach(), invalid object processed.");
+      continue;
+    }
+
+    if(cb(collection[i], i) === false) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * @description HashList is a data container that allows you to store information as key - value pairs. As usual in JavaScript mixed types of keys and values are accepted in one HashList instance.
+ *
+ * @cat    Data
+ * @subcat HashList
+ * @method HashList
+ * @constructor
+ */
+// taken from http://pbrajkumar.wordpress.com/2011/01/17/hashmap-in-javascript/
+HashList = function () {
+  var that = {};
+  that.length = 0;
+  that.items = {};
+
+  for (var key in that.items) {
+    pub.println(key);
+  }
+
+  // Please note: this is removing Object fields, but has to be done to have an empty "bucket"
+  function checkKey(key) {
+    if(that.items[key] instanceof Function) {
+      that.items[key] = undefined;
+    }
+  }
+
+  /**
+   *
+   * @description This removes a key - value pair by its key.
+   *
+   * @cat    Data
+   * @subcat HashList
+   * @method HashList.remove
+   * @param  {String} key The key to delete.
+   * @return {Object} The value before deletion.
+   */
+  that.remove = function(key) {
+    var tmp_previous;
+    if (typeof that.items[key] != "undefined") {
+      var tmp_previous = that.items[key];
+      delete that.items[key];
+      that.length--;
+    }
+    return tmp_previous;
+  };
+
+  /**
+   * @description This gets a value by its key.
+   *
+   * @cat    Data
+   * @subcat HashList
+   * @method HashList.get
+   * @param  {String} key The key to look for.
+   * @return {Object} The value.
+   */
+  that.get = function(key) {
+    return that.items[key];
+  };
+
+  /**
+   * @description This sets a key - value pair. If a key is already existing, the value will be updated. Please note that Functions are currently not supported as values.
+   *
+   * @cat    Data
+   * @subcat HashList
+   * @method HashList.set
+   * @param  {String} key The key to use.
+   * @param  {Object|String|Number|Boolean} value The value to set.
+   * @return {Object} The value after setting.
+   */
+  that.set = function(key, value) {
+
+    if(value instanceof Function) error("HashList does not support storing Functions as values.");
+    checkKey(key);
+    if (typeof value != "undefined") {
+      if (typeof that.items[key] === "undefined") {
+        that.length++;
+      }
+      that.items[key] = value;
+    }
+    return that.items[key];
+  };
+
+  /**
+   * @description Checks for the existence of a given key.
+   *
+   * @cat    Data
+   * @subcat HashList
+   * @method HashList.hasKey
+   * @param  {String} key The key to check.
+   * @return {Boolean} Returns true or false.
+   */
+  that.hasKey = function(key) {
+    checkKey(key);
+    return typeof that.items[key] != "undefined";
+  };
+
+  /**
+   * @description Checks if a certain value exists at least once in all of the key - value pairs.
+   *
+   * @cat    Data
+   * @subcat HashList
+   * @method HashList.hasValue
+   * @param  {Object|String|Number|Boolean} value The value to check.
+   * @return {Boolean} Returns true or false.
+   */
+  that.hasValue = function(value) {
+    var obj = that.items;
+    var found = false;
+    for(var key in obj) {
+      if (obj[key] === value) {
+        found = true;
+        break;
+      }
+    }
+    return found;
+  };
+
+  /**
+   * @description Returns an array of all keys that are sorted by their values from highest to lowest. Please note that this only works if you have conistently used Numbers for values.
+   *
+   * @cat    Data
+   * @subcat HashList
+   * @method HashList.getKeysByValues
+   * @return {Array} An array with all the keys.
+   */
+  that.getKeysByValues = function() {
+    var obj = that.items;
+    var keys = [];
+    for(var key in obj)
+        {
+      if(typeof obj[key] != "number") error("HashList.getKeysByValues(), only works with Numbers as values. ");
+      keys.push(key);
+    }
+    return keys.sort(function(a, b) {return obj[b] - obj[a];});
+  };
+
+  /**
+   * @description Returns an array with all keys in a sorted order from higher to lower magnitude.
+   *
+   * @cat    Data
+   * @subcat HashList
+   * @method HashList.getSortedKeys
+   * @return {Array} An array with all the keys sorted.
+   */
+  that.getSortedKeys = function () {
+    return that.getKeys().sort(); // ["a", "b", "z"]
+  };
+
+  /**
+   * @description Returns an array with all keys.
+   *
+   * @cat    Data
+   * @subcat HashList
+   * @method HashList.getKeys
+   * @return {Array} An array with all the keys.
+   */
+  that.getKeys = function () {
+    var keys = [];
+
+    for(var key in that.items)
+      {
+      if(that.items.hasOwnProperty(key))
+          {
+        keys.push(key);
+      }
+    }
+    return keys;
+  };
+
+  /**
+   * @description Returns an array with all values.
+   *
+   * @cat    Data
+   * @subcat HashList
+   * @method HashList.getValues
+   * @return {Array} An array with all the values.
+   */
+  that.getValues = function () {
+
+    var obj = that.items;
+    var values = [];
+
+    for(var key in obj) {
+      values.push(obj[key]);
+    }
+    return values;
+
+  };
+
+  /**
+   * @description Deletes all the key - value pairs in this HashList.
+   *
+   * @cat    Data
+   * @subcat HashList
+   * @method HashList.clear
+   */
+  that.clear = function() {
+    for (var i in that.items) {
+      delete that.items[i];
+    }
+    that.length = 0;
+  };
+  return that;
+};
+
+  License        - MIT
+
+
+  Core
+                 - Ted Davis http://teddavis.org
+                 - Benedikt Groß http://benedikt-gross.de
+                 - Ludwig Zeller http://ludwigzeller.de
+  Members
+                 - Philipp Adrian http://www.philippadrian.com/
+                 - be:screen GmbH http://bescreen.de
+                 - Stefan Landsbek http://47nord.de
+// ----------------------------------------
+// src/includes/core.js
+// ----------------------------------------
+
+// all initialisations should go here
+var init = function() {
+
+  welcome();
+  populateGlobal();
+
+  // -- init internal state vars --
+  startTime = Date.now();
+  currStrokeWeight = 1;
+  currStrokeTint = 100;
+  currFillTint = 100;
+  currOriginX = 0;
+  currOriginY = 0;
+  currCanvasMode = pub.PAGE;
+  currColorMode = pub.RGB;
+  currGradientMode = pub.LINEAR;
+  currDocSettings = {};
+  currDialogFolder = Folder("~");
+  currMode = pub.VISIBLE;
+
+  appSettings = {
+    enableRedraw: app.scriptPreferences.enableRedraw,
+    preflightOff: app.preflightOptions.preflightOff,
+    adjustStrokeWeight: app.transformPreferences.adjustStrokeWeightWhenScaling,
+    whenScaling: app.transformPreferences.whenScaling
+  };
+
+  app.doScript(runScript, ScriptLanguage.JAVASCRIPT, undefined, UndoModes.ENTIRE_SCRIPT, pub.SCRIPTNAME);
+
+  if($.global.hasOwnProperty("basilTest")) {
+    return;
+  }
+
+  exit(); // quit program execution
+};
+
+
+// ----------------------------------------
+// execution
+
+var runScript = function() {
+
+  var execTime;
+
+  try {
+
+    if($.global.loop instanceof Function) {
+      if ($.engineName !== "loop") {
+        error("function loop(), no target engine! To use basil's loop function, add the code line\n\n #targetengine \"loop\";\n\n at the very top of your script.");
+      } else {
+        prepareLoop();
+      }
+    }
+
+    // app settings
+    app.scriptPreferences.enableRedraw = true;
+    app.preflightOptions.preflightOff = true;
+    app.transformPreferences.adjustStrokeWeightWhenScaling = true;
+    app.transformPreferences.whenScaling = WhenScalingOptions.APPLY_TO_CONTENT;
+
+    currentDoc();
+
+    appSettings.refPoint = app.activeWindow.transformReferencePoint;
+    currRefPoint = pub.referencePoint(app.activeWindow.transformReferencePoint);
+
+    if ($.global.setup instanceof Function) {
+      setup();
+    }
+
+    if ($.global.draw instanceof Function) {
+      draw();
+    } else if ($.global.loop instanceof Function) {
+      var sleep = null;
+      if (arguments.length === 0) sleep = Math.round(1000 / currFrameRate);
+      else sleep = Math.round(1000 / framerate);
+
+      currIdleTask = app.idleTasks.add({name: "basil_idle_task", sleep: sleep});
+      currIdleTask.addEventListener(IdleEvent.ON_IDLE, function() {
+        loop();
+      }, false);
+      println("Run the script lib/stop.jsx to end the loop, clean up and quit the script!");
+    }
+
+  } catch (e) {
+    execTime = executionDuration();
+
+    if(e.userCancel) {
+      println("[Cancelled by user after " + execTime + "]");
+    } else {
+      println("[Cancelled after " + execTime + "]");
+      alert(e);
+    }
+
+  } finally {
+
+    if((!execTime) && !($.global.loop instanceof Function)) {
+      println("[Finished in " + executionDuration() + "]");
+    }
+
+    if(currDoc && !currDoc.windows.length) {
+      currDoc.windows.add(); // open the hidden doc
+    }
+    closeHiddenDocs();
+    if (progressPanel) {
+      progressPanel.closePanel();
+    }
+    if (addToStoryCache) {
+      addToStoryCache.close();
+    }
+
+    if (!($.global.loop instanceof Function) || $.global.draw instanceof Function) {
+      resetUserSettings();
+    }
+  }
+
+}
+
+var prepareLoop = function() {
+  // before running the loop we need to check if the stop script exists
+  // the script looks for the lib folder next to itself
+  var currentBasilFolderPath = File($.fileName).parent.fsName;
+  var scriptPath = currentBasilFolderPath + "/lib/stop.jsx";
+
+  var stopScriptFile = pub.file(scriptPath);
+  if(stopScriptFile.exists !== true) {
+    // the script is not there, let's create it
+    var scriptContent = [
+      "#targetengine \"loop\"",
+      "noLoop(true);",
+      "if (typeof cleanUp === \"function\") {",
+      "  cleanUp();",
+      "  cleanUp = null;",
+      "}"
+    ];
+    pub.saveStrings(stopScriptFile, scriptContent);
+  }
+  currFrameRate = 25;
+}
+
+/**
+ * @description Sets the framerate per second to determine how often loop() is called per second. If the processor is not fast enough to maintain the specified rate, the frame rate will not be achieved. Setting the frame rate within setup() is recommended. The default rate is 25 frames per second. Calling frameRate() with no arguments returns the currently set framerate.
+ *
+ * @cat    Environment
+ * @method frameRate
+ * @param  {Number} [fps] Frames per second.
+ * @return {Number} Currently set frame rate.
+ */
+pub.frameRate = function(fps) {
+  if(arguments.length) {
+    if(!isNumber(fps) || fps <= 0) {
+      error("frameRate(), invalid argument. Use a number greater than 0.")
+    }
+
+    currFrameRate = fps;
+    if(currIdleTask) {
+      currIdleTask.sleep = Math.ceil(1000 / fps);
+    }
+  }
+  return currFrameRate;
+};
+
+/**
+ * @description Stops basil from continuously executing the code within loop() and quits the script.
+ *
+ * @cat    Environment
+ * @method noLoop
+ */
+pub.noLoop = function(printFinished) {
+  var allIdleTasks = app.idleTasks;
+  for (var i = app.idleTasks.length - 1; i >= 0; i--) {
+    allIdleTasks[i].remove();
+  }
+  if(printFinished) {
+    println("Basil.js -> Stopped looping.");
+    println("[Finished in " + executionDuration() + "]");
+  };
+  resetUserSettings();
+};
+
+/**
+ * @description Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, `mode()` should be placed in the beginning of the script. In basil there are three different performance modes:<br>
+ * `VISIBLE` is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.<br>
+ * `HIDDEN` allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use `println("yourMessage")` in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.<br>
+ * `SILENT` processes the document without redrawing the screen. The document will stay visible and only update once the script is finished or once the mode is changed back to `VISIBLE`.
+ *
+ * @cat    Environment
+ * @method mode
+ * @param  {String} mode The performance mode to switch to.
+ */
+pub.mode = function(mode) {
+
+  if(!(mode === pub.VISIBLE || mode === pub.HIDDEN || mode === pub.SILENT)) {
+    error("mode(), invalid argument. Use VISIBLE, HIDDEN or SILENT.");
+  }
+
+  app.scriptPreferences.enableRedraw = (mode === pub.VISIBLE || mode === pub.HIDDEN);
+
+  if(!currDoc) {
+    // initiate new document in given mode
+    currentDoc(mode);
+  } else {
+
+    if (!currDoc.saved && !currDoc.modified && pub.HIDDEN) {
+      // unsaved, unmodified doc at the beginning of the script that needs to be hidden
+      // -> will be closed without saving, fresh hidden document will be opened
+      currDoc.close(SaveOptions.NO);
+      currDoc = app.documents.add(false);
+      setCurrDoc(currDoc);
+    } else if (mode === pub.HIDDEN && currMode !== pub.HIDDEN) {
+      // existing document needs to be hidden
+      if (!currDoc.saved && currDoc.modified) {
+        try {
+          currDoc.save();
+        } catch(e) {
+          throw {userCancel: true};
+        }
+        warning("Document was not saved and has now been saved to your hard drive in order to enter HIDDEN.");
+      } else if (currDoc.modified) {
+        currDoc.save(File(currDoc.fullName));
+        warning("Document was modified and has now been saved to your hard drive in order to enter HIDDEN.");
+      }
+      var docPath = currDoc.fullName;
+      currDoc.close(); // close the doc and reopen it without adding to the display list
+      currDoc = app.open(File(docPath), false);
+
+      setCurrDoc(currDoc);
+    } else if (mode !== pub.HIDDEN && currMode === pub.HIDDEN) {
+      // existing document needs to be unhidden
+      currDoc.windows.add();
+    }
+  }
+
+  if (!progressPanel && (mode === pub.HIDDEN || mode === pub.SILENT)) {
+    // turn on progress panel
+    progressPanel = new Progress();
+  } else if (progressPanel && mode === pub.VISIBLE) {
+    // turn off progress panel
+    progressPanel.closePanel();
+    progressPanel = null;
+  }
+
+  currMode = mode;
+};
+
+
+// ----------------------------------------
+// all private from here
+
+var welcome = function() {
+  clearConsole();
+  println("Running "
+      + pub.SCRIPTNAME
+      + " using basil.js "
+      + pub.VERSION
+      + " ...");
+};
+
+var populateGlobal = function() {
+  // inject all functions of pub into global space
+  // to make them available to the user
+
+  $.global.basilGlobal = [];
+  for(var key in pub) {
+    if(pub.hasOwnProperty(key)) {
+      if($.global.hasOwnProperty(key)) {
+        // the user created a function or variable
+        // with the same name as a basil has
+        var pubFuncVar = pub[key] instanceof Function ? "function \"" : "variable \"";
+        var globFuncVar = $.global[key] instanceof Function ? "function" : "variable";
+        error("basil had problems creating the global " + pubFuncVar + key + "\", possibly because your code is already using that name as a " + globFuncVar + ". You may want to rename your " + globFuncVar + " to something else.");
+      } else {
+        $.global[key] = pub[key];
+        $.global.basilGlobal.push(key);
+      }
+    }
+  }
+}
+
+var currentDoc = function(mode) {
+  if (!currDoc) {
+    var doc = null;
+    if (app.documents.length && app.windows.length) {
+      doc = app.activeDocument;
+      if (mode === pub.HIDDEN) {
+        if (!doc.saved) {
+          try {
+            doc.save();
+          } catch(e) {
+            throw {userCancel: true};
+          }
+          warning("Document was not saved and has now been saved to your hard drive in order to enter HIDDEN.");
+        } else if (doc.modified) {
+          doc.save(File(doc.fullName));
+          warning("Document was modified and has now been saved to your hard drive in order to enter HIDDEN.");
+        }
+        var docPath = doc.fullName;
+        doc.close(); // Close the doc and reopen it without adding to the display list
+        doc = app.open(File(docPath), false);
+      }
+    } else {
+      doc = app.documents.add(mode !== pub.HIDDEN);
+    }
+    if(!doc.saved && !doc.modified) {
+      setCurrDoc(doc, true);
+    } else {
+      setCurrDoc(doc);
+    }
+  }
+  return currDoc;
+};
+
+var closeHiddenDocs = function () {
+    // in Case we break the Script during execution in HIDDEN we might have documents open that are not on the display list. Close them.
+  for (var i = app.documents.length - 1; i >= 0; i -= 1) {
+    var d = app.documents[i];
+    if (!d.windows.length) {
+      d.close(SaveOptions.NO);
+    }
+  }
+};
+
+var setCurrDoc = function(doc, skipStyles) {
+  resetCurrDoc();
+  currDoc = doc;
+  // -- setup document --
+  // save initial doc settings for later resetting
+  currDocSettings.rulerOrigin = currDoc.viewPreferences.rulerOrigin;
+  currDocSettings.hUnits = currDoc.viewPreferences.horizontalMeasurementUnits;
+  currDocSettings.vUnits = currDoc.viewPreferences.verticalMeasurementUnits;
+
+  currDocSettings.pStyle = currDoc.textDefaults.appliedParagraphStyle;
+  currDocSettings.cStyle = currDoc.textDefaults.appliedCharacterStyle;
+  currDocSettings.otxtStyle = currDoc.pageItemDefaults.appliedTextObjectStyle;
+  currDocSettings.ograStyle = currDoc.pageItemDefaults.appliedGraphicObjectStyle;
+  currDocSettings.ogriStyle = currDoc.pageItemDefaults.appliedGridObjectStyle;
+
+  // set document to default values
+  pub.units(currDoc.viewPreferences.horizontalMeasurementUnits);
+
+  if(!skipStyles) {
+    // in a fresh, unsaved document, those styles should not be set
+    // in order not to modify the doc and be able to enter mode(HIDDEN) without saving
+    currDoc.textDefaults.appliedParagraphStyle = currDoc.paragraphStyles.firstItem();
+    currDoc.textDefaults.appliedCharacterStyle = currDoc.characterStyles.firstItem();
+    currDoc.pageItemDefaults.appliedTextObjectStyle = currDoc.objectStyles.firstItem();
+    currDoc.pageItemDefaults.appliedGraphicObjectStyle = currDoc.objectStyles.firstItem();
+    currDoc.pageItemDefaults.appliedGridObjectStyle = currDoc.objectStyles.firstItem();
+  }
+
+  currAlign = currDoc.textDefaults.justification;
+  currFont = currDoc.textDefaults.appliedFont;
+  currFontSize = currDoc.textDefaults.pointSize;
+  currKerning = 0;
+  currLeading = currDoc.textDefaults.leading;
+  currTracking = currDoc.textDefaults.tracking;
+
+  updatePublicPageSizeVars();
+};
+
+var Progress = function () {
+  this.init = function () {
+    this.panel = Window.find("window", "processing...");
+    if (this.panel === null) {
+      this.panel = new Window("window", "processing...");
+      var logo = (Folder.fs == "Macintosh") ? new File("~/Documents/basiljs/bundle/lib/basil.png") : new File("%USERPROFILE%Documents/basiljs/bundle/lib/basil.png");
+      if (logo.exists) {
+        this.panel.add("image", undefined, logo);
+      }
+      this.panel.statusbar = this.panel.add("edittext", [0, 0, 400, 300], "", {multiline: true, scrolling: false, readonly: true});
+    }
+    this.panel.statusbar.text = "Using basil.js " + pub.VERSION + " ... \nEntering background render mode ...";
+    this.panel.show();
+  };
+  this.closePanel = function () {
+    if (this.panel) {
+      this.panel.hide();
+      this.panel.close();
+    }
+  };
+  this.writeMessage = function (msg) {
+    if (Folder.fs == "Macintosh") { // Indesign Bug on Mac: Need to set app.scriptPreferences.enableRedraw = true to redraw window....
+      var rd = app.scriptPreferences.enableRedraw;
+      app.scriptPreferences.enableRedraw = true;
+    }
+    var lines = this.panel.statusbar.text.split(/\n/);
+    if (lines.length > 17)
+      lines.shift();
+    lines.push(msg);
+    this.panel.statusbar.text = lines.join("\n");
+    this.panel.layout.layout();
+    if (Folder.fs == "Macintosh") {
+      app.scriptPreferences.enableRedraw = rd;
+    }
+  };
+  this.init();
+};
+
+var resetCurrDoc = function() {
+  // resets doc and doc specific vars
+  currDoc = null;
+  currPage = null;
+  currLayer = null;
+  currFillColor = "Black";
+  noneSwatchColor = "None";
+  currStrokeColor = "Black";
+  currRectMode = pub.CORNER;
+  currEllipseMode = pub.CENTER;
+  currYAlign = VerticalJustification.TOP_ALIGN;
+  currFont = null;
+  currImageMode = pub.CORNER;
+
+  pub.resetMatrix();
+};
+
+var currentLayer = function() {
+  if (currLayer === null || !currLayer) {
+    currentDoc();
+    if (currDoc.windows.length) {
+      currLayer = app.activeDocument.activeLayer;
+    } else {
+      currLayer = currDoc.layers[0];
+    }
+  }
+  return currLayer;
+};
+
+var currentPage = function() {
+  if (currPage === null || !currPage) {
+    currentDoc();
+    if (currDoc.windows.length) {
+      currPage = app.activeWindow.activePage;
+    } else {
+      currPage = currDoc.pages[0];
+    }
+  }
+  return currPage;
+};
+
+var updatePublicPageSizeVars = function () {
+  var w, h;
+  var cm = currCanvasMode;
+  var p = currentPage();
+  var spread = p.parent;
+  var docPrefs = currentDoc().documentPreferences;
+  currOriginX = 0;
+  currOriginY = 0;
+
+  if(cm === pub.PAGE || cm === pub.MARGIN || cm === pub.BLEED) {
+    currDoc.viewPreferences.rulerOrigin = RulerOrigin.PAGE_ORIGIN;
+    pub.resetMatrix();
+
+    var leftHand = (p.side === PageSideOptions.LEFT_HAND);
+    w = p.bounds[3] - p.bounds[1];
+    h = p.bounds[2] - p.bounds[0];
+
+    if (cm === pub.MARGIN) {
+      w -= (p.marginPreferences.left + p.marginPreferences.right);
+      h -= (p.marginPreferences.top + p.marginPreferences.bottom);
+      currOriginX = leftHand ? p.marginPreferences.right : p.marginPreferences.left;
+      currOriginY = p.marginPreferences.top;
+    } else if (cm === pub.BLEED) {
+      // pub.BLEED
+      var leftBleed = 0;
+      var rightBleed = 0;
+      if(p === spread.pages.firstItem()) {
+        leftBleed = leftHand ? docPrefs.documentBleedOutsideOrRightOffset : docPrefs.documentBleedInsideOrLeftOffset;
+      }
+      if(p === spread.pages.lastItem()) {
+        rightBleed = leftHand ? docPrefs.documentBleedInsideOrLeftOffset : docPrefs.documentBleedOutsideOrRightOffset;
+      }
+      w += leftBleed + rightBleed;
+      h += docPrefs.documentBleedTopOffset + docPrefs.documentBleedBottomOffset;
+      currOriginX = -leftBleed;
+      currOriginY = -docPrefs.documentBleedTopOffset;
+    }
+
+  } else {
+    // FACING_MODES
+    currDoc.viewPreferences.rulerOrigin = RulerOrigin.SPREAD_ORIGIN;
+    pub.resetMatrix();
+    var firstPage = spread.pages.firstItem();
+    var lastPage = spread.pages.lastItem();
+    var firstPageLeftHand = (firstPage.side === PageSideOptions.LEFT_HAND);
+    var lastPageLeftHand = (lastPage.side === PageSideOptions.LEFT_HAND);
+    w = lastPage.bounds[3] - firstPage.bounds[1];
+    h = p.bounds[2] - p.bounds[0];
+
+    if(cm === pub.FACING_MARGINS) {
+      var leftMargin = firstPageLeftHand ? firstPage.marginPreferences.right : firstPage.marginPreferences.left;
+      var rightMargin = lastPageLeftHand ? lastPage.marginPreferences.left : lastPage.marginPreferences.right;
+      w -= (leftMargin + rightMargin);
+      h -= (p.marginPreferences.top + p.marginPreferences.bottom);
+      currOriginX = leftMargin;
+      currOriginY = p.marginPreferences.top;
+    } else if (cm === pub.FACING_BLEEDS) {
+      var leftBleed = firstPageLeftHand ? docPrefs.documentBleedOutsideOrRightOffset : docPrefs.documentBleedInsideOrLeftOffset;
+      var rightBleed = lastPageLeftHand ? docPrefs.documentBleedInsideOrLeftOffset : docPrefs.documentBleedOutsideOrRightOffset;
+      w += leftBleed + rightBleed;
+      h += docPrefs.documentBleedTopOffset + docPrefs.documentBleedBottomOffset;
+      currOriginX = -leftBleed;
+      currOriginY = -docPrefs.documentBleedTopOffset;
+    }
+
+  }
+
+  pub.translate(currOriginX, currOriginY);
+  pub.width = $.global.width = w;
+  pub.height = $.global.height = h;
+
+};
+
+var resetUserSettings = function() {
+  // app settings
+  app.scriptPreferences.enableRedraw = appSettings.enableRedraw;
+  app.preflightOptions.preflightOff  = appSettings.preflightOff;
+  app.transformPreferences.adjustStrokeWeightWhenScaling = appSettings.adjustStrokeWeight;
+  app.transformPreferences.whenScaling = appSettings.whenScaling;
+
+  if(app.properties.activeWindow instanceof LayoutWindow ) {
+    app.activeWindow.transformReferencePoint = appSettings.refPoint;
+  }
+
+  // doc settings
+  if(currDoc && currDocSettings) {
+    resetDocSettings();
+  }
+}
+
+var resetDocSettings = function() {
+  try {
+    currDoc.viewPreferences.rulerOrigin = currDocSettings.rulerOrigin;
+    currDoc.viewPreferences.horizontalMeasurementUnits = currDocSettings.hUnits;
+    currDoc.viewPreferences.verticalMeasurementUnits = currDocSettings.vUnits;
+
+    currDoc.textDefaults.appliedParagraphStyle = currDocSettings.pStyle;
+    currDoc.textDefaults.appliedCharacterStyle = currDocSettings.cStyle;
+    currDoc.pageItemDefaults.appliedTextObjectStyle = currDocSettings.otxtStyle;
+    currDoc.pageItemDefaults.appliedGraphicObjectStyle = currDocSettings.ograStyle;
+    currDoc.pageItemDefaults.appliedGridObjectStyle = currDocSettings.ogriStyle;
+  } catch (e) {
+    // document was closed via non-basil methods
+    currDoc = null;
+  }
+}
+
+var createSelectionDialog = function(settings) {
+  var result;
+  if(!settings) {
+    settings = {};
+  }
+
+  // set settings object to given values or defaults
+  settings.prompt = settings.hasOwnProperty("prompt") ? settings.prompt : "";
+  settings.filter = settings.hasOwnProperty("filter") ? settings.filter : [""];
+  settings.folder = settings.hasOwnProperty("folder") ? settings.folder : currDialogFolder;
+  settings.multiFile = settings.hasOwnProperty("multiFile") ? true : false;
+  settings.folderSelect = settings.hasOwnProperty("folderSelect") ? true : false;
+
+  if(!isString(settings.prompt)) {
+    settings.prompt = "";
+  }
+  if(!isString(settings.filter) && !isArray(settings.filter)) {
+    settings.filter = [""];
+  }
+  if(isString(settings.filter)) {
+    settings.filter = [settings.filter];
+  }
+  if(isString(settings.folder)) {
+    settings.folder = pub.folder(settings.folder);
+  }
+  if(!(settings.folder instanceof Folder) || !settings.folder.exists) {
+    settings.folder = currDialogFolder;
+  }
+
+  if(settings.folderSelect) {
+    result = Folder(settings.folder).selectDlg(settings.prompt);
+  } else {
+    function filterFiles(file){
+      if (file instanceof Folder) { return true }
+      for (var i = settings.filter.length - 1; i >= 0; i--) {
+        if (isString(settings.filter[i]) && endsWith(file.name.toLowerCase(), settings.filter[i].toLowerCase())) { return true }
+      }
+      return false;
+    }
+
+    result = File(settings.folder).openDlg(settings.prompt, filterFiles, settings.multiFile);
+  }
+
+  if(result instanceof File) {
+    currDialogFolder = result.parent;
+  } else if (isArray(result)) {
+    currDialogFolder = result[0].parent;
+  } else if (result instanceof Folder) {
+    currDialogFolder = result;
+  }
+
+  if(result === null && settings.multiFile) {
+    result = [];
+  }
+
+  return result;
+}
+
+// internal helper to get a style by name, wether it is nested in a stlye group or not
+var findInStylesByName = function(allStylesCollection, name) {
+  for (var i = 0; i < allStylesCollection.length; i++) {
+    if (allStylesCollection[i].name === name) {
+      return allStylesCollection[i];
+    }
+  }
+  return null;
+};
+
+// get the name of parent functions; helpful for more meaningful error messages
+// level describes how many levels above to find the function whose function name is returned
+var getParentFunctionName = function(level) {
+    var stackArray = $.stack.
+          replace(/\((.+?)\)/g, "").
+          split(/[\n]/);
+    return stackArray[stackArray.length - 2 - level];
+}
+
+var checkNull = function (obj) {
+  if(obj === null || typeof obj === undefined) error("Received null object.");
+};
+
+var isEnum = function(base, value) {
+  var props = base.reflect.properties;
+  for (var i = 0; i < props.length; i++) {
+    if (base[props[i].name] == value) return true;
+  }
+  return false;
+}
+
+var executionDuration = function() {
+  var duration = pub.millis();
+  return duration < 1000 ? duration + "ms" : (duration / 1000).toPrecision(3) + "s";
+}
+
+var error = function(msg) {
+  println(ERROR_PREFIX + msg);
+  throw new Error(ERROR_PREFIX + msg);
+};
+
+var warning = function(msg) {
+  println(WARNING_PREFIX + msg);
+};
+
+var clearConsole = function() {
+  var bt = new BridgeTalk();
+  bt.target = "estoolkit";
+  bt.body = "app.clc()"; // works just with cs6
+  bt.onError = function(errObj) {};
+  bt.onResult = function(resObj) {};
+  bt.send();
+};
+
+                 - Ken Frederick http://kennethfrederick.de/
+
+                 - Timo Rychert http://timorychert.de/
+                 - Fabian Morón Zirfas http://fabianmoronzirfas.me/
+// ----------------------------------------
+// src/includes/structure.js
+// ----------------------------------------
+
+var forEachTextCollection = function(container, collection, cb) {
+  // var collection;
+  if(container instanceof Document) {
+    collection = container.stories.everyItem()[collection];
+  } else {
+    collection = container.textFrames.everyItem()[collection];
+  }
+
+  for (var i = 0; i < collection.length; i++) {
+    if(cb(collection[i], i) === false) {
+      return false;
+    }
+  }
+  return true;
+};
+
+
+var textCollection = function(collection, legalContainers, container, cb) {
+
+  checkNull(container);
+
+  if(!(container.hasOwnProperty("contents") || container instanceof Document || container instanceof Page)) {
+    error(collection + "(), wrong object type. Use: " + legalContainers);
+  }
+
+  if(cb instanceof Function) {
+    // callback function is passed
+    if (container instanceof Document || container instanceof Page) {
+      return forEachTextCollection(container, collection, cb);
+    }
+    return forEach(container[collection], cb);
+
+  }
+    // no callback function is passed
+  if(container instanceof Document) {
+    return container.stories.everyItem()[collection];
+  } else if (container instanceof Page) {
+    return container.textFrames.everyItem()[collection];
+  }
+  return container[collection];
+
+
+};
+/**
+ * @description Suspends the calling thread for a number of milliseconds.<br>
+ * During a sleep period, checks at 100 millisecond intervals to see whether the sleep should be terminated.
+ *
+ * @cat    Environment
+ * @method delay
+ * @param  {Number} milliseconds  The delay time in milliseconds.
+ */
+pub.delay = function (milliseconds) {
+  $.sleep(milliseconds);
+};
+
+/**
+ * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function with each story of the given document.
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method stories
+ * @param  {Document} doc The document instance to iterate the stories in
+ * @param  {Function} [cb] The callback function to call with each story. When this function returns false the loop stops. Passed arguments: story, loopCount.
+ * @return {Stories} A collection of Story objects.
+ *
+ * @example
+ * stories(doc(), function(story, loopCount){
+ *   println("Number of words in each Story:");
+ *   println(story.words.length);
+ * });
+ */
+pub.stories = function(doc, cb) {
+
+  checkNull(doc);
+
+  if(arguments.length === 1 && doc instanceof Document) {
+    return doc.stories;
+  } else if (cb instanceof Function) {
+    return forEach(doc.stories, cb);
+  }
+  error("stories(), incorrect call. Wrong parameters!");
+  return null;
+};
+
+/**
+ * @description If no callback function is given it returns a Collection of paragraphs in the container otherwise calls the given callback function with each paragraph of the given document, page, story or textFrame.
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method paragraphs
+ * @param  {Document|Page|Story|TextFrame} container The document, story, page or textFrame instance to iterate the paragraphs in.
+ * @param  {Function} [cb]  Optional: The callback function to call with each paragraph. When this function returns false the loop stops. Passed arguments: para, loopCount.
+ * @return {Paragraphs} A collection of Paragraph objects.
+ */
+pub.paragraphs = function(container, cb) {
+
+  var legalContainers = "Document, Story, Page or TextFrame.";
+  return textCollection("paragraphs", legalContainers, container, cb);
+
+};
+
+/**
+ * @description If no callback function is given it returns a Collection of lines in the container otherwise calls the given callback function with each line of the given document, page, story, textFrame or paragraph.
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method lines
+ * @param  {Document|Page|Story|TextFrame|Paragraph} container The document, page, story, textFrame or paragraph instance to iterate the lines in.
+ * @param  {Function} [cb] Optional: The callback function to call with each line. When this function returns false the loop stops. Passed arguments: line, loopCount.
+ * @return {Lines} A collection of Line objects.
+ */
+pub.lines = function(container, cb) {
+
+  var legalContainers = "Document, Story, Page, TextFrame or Paragraph.";
+  return textCollection("lines", legalContainers, container, cb);
+
+};
+
+/**
+ * @description If no callback function is given it returns a Collection of words in the container otherwise calls the given callback function with each word of the given document, page, story, textFrame, paragraph or line.
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method words
+ * @param  {Document|Page|Story|TextFrame|Paragraph|Line} container The document, page, story, textFrame, paragraph or line instance to iterate the words in.
+ * @param  {Function} [cb] The callback function to call with each word. When this function returns false the loop stops. Passed arguments: word, loopCount.
+ * @return {Words} A collection of Word objects.
+ */
+pub.words = function(container, cb) {
+
+  var legalContainers = "Document, Story, Page, TextFrame, Paragraph or Line.";
+  return textCollection("words", legalContainers, container, cb);
+
+};
+
+/**
+ * @description If no callback function is given it returns a Collection of characters in the container otherwise calls the given callback function with each character of the given document, page, story, textFrame, paragraph, line or word.
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method characters
+ * @param  {Document|Page|Story|TextFrame|Paragraph|Line|Word} container The document, page, story, textFrame, paragraph, line or word instance to  iterate the characters in.
+ * @param  {Function} [cb] Optional: The callback function to call with each character. When this function returns false the loop stops. Passed arguments: character, loopCount
+ * @return {Characters} A collection of Character objects.
+ */
+pub.characters = function(container, cb) {
+
+  var legalContainers = "Document, Story, Page, TextFrame, Paragraph, Line or Word.";
+  return textCollection("characters", legalContainers, container, cb);
+
+};
+
+
+/**
+ * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function for each of the PageItems in the given Document, Page, Layer or Group.
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method items
+ * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in
+ * @param  {Function|Boolean} [cb] Optional: The callback function to call for each PageItem. When this function returns false the loop stops. Passed arguments: item, loopCount.
+ * @return {PageItems} A collection of PageItem objects.
+ */
+pub.items = function(container, cb) {
+
+  if (container instanceof Document
+    || container instanceof Page
+    || container instanceof Layer
+    || container instanceof Group) {
+
+    if(arguments.length === 1 || cb === false) {
+      return container.allPageItems;
+    } else if(cb instanceof Function) {
+      return forEach(container.allPageItems, cb);
+    }
+  }
+  error("items(), Not a valid PageItem container, should be Document, Page, Layer or Group");
+  return null;
+};
+
+
+/**
+ * @description Removes all PageItems (including locked ones) in the given Document, Page, Layer or Group. If the selected container is a Group, the Group itself will be removed as well.
+ *
+ * @cat    Document
+ * @method clear
+ * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in.
+ */
+pub.clear = function(container) {
+
+  if (container instanceof Document
+    || container instanceof Page
+    || container instanceof Layer) {
+
+    container.pageItems.everyItem().locked = false;
+    container.pageItems.everyItem().remove();
+
+  } else if (container instanceof Group) {
+
+    container.locked = false;
+    container.remove();
+
+  } else {
+    error("clear(), not a valid container! Use: Document, Page, Layer or Group.");
+  }
+};
+
+/**
+ * @description Removes the provided Page, Layer, PageItem, Swatch, etc.
+ *
+ * @cat    Document
+ * @method remove
+ * @param  {PageItem} obj The object to be removed.
+ */
+pub.remove = function(obj) {
+
+  if(obj.hasOwnProperty("remove")) {
+    obj.remove();
+  } else {
+    error("remove(), provided object cannot be removed.");
+  }
+};
+
+
+  Web Site       - http://basiljs.ch
+  Github Repo.   - https://github.com/basiljs/basil.js
+  Processing     - http://processing.org
+  Processing.js  - http://processingjs.org
+// ----------------------------------------
+// src/includes/environment.js
+// ----------------------------------------
+
+/**
+ * @description Sets or possibly creates the current document and returns it.
+ * If the param doc is not given the current document gets set to the active document
+ * in the application. If no document at all is open, a new document gets created.
+ *
+ * @cat    Document
+ * @method doc
+ * @param  {Document} [doc] The document to set the current document to.
+ * @return {Document} The current document instance.
+ */
+pub.doc = function(doc) {
+  if (doc instanceof Document) {
+    // reset the settings of the old doc, before activating the new doc
+    resetDocSettings();
+    setCurrDoc(doc);
+  }
+  return currentDoc();
+};
+
+/**
+ * @description Sets the size of the current document, if arguments are given.
+ * If only one argument is given, both the width and the height are set to this value.
+ * Alternatively, a string can be given as the first argument to apply an existing page size preset ("A4", "Letter" etc.).
+ * In this case, either PORTRAIT or LANDSCAPE can be used as a second argument to determine the orientation of the page.
+ * If no argument is given, an object containing the current document's width and height is returned.
+ *
+ * @cat    Document
+ * @method size
+ * @param  {Number|String} [widthOrPageSize] The desired width of the current document or the name of a page size preset.
+ * @param  {Number|String} [heightOrOrientation] The desired height of the current document. If not provided the width will be used as the height. If the first argument is a page size preset, the second argument can be used to set the orientation.
+ * @return {Object} Object containing the current `width` and `height` of the document.
+ *
+ * @example <caption>Sets the document size to 70 x 100 units</caption>
+ * size(70, 100);
+ *
+ * @example <caption>Sets the document size to 70 x 70</caption>
+ * size(70);
+ *
+ * @example <caption>Sets the document size to A4, keeps the current orientation in place</caption>
+ * size("A4");
+ *
+ * @example <caption>Sets the document size to A4, set the orientation to landscape</caption>
+ * size("A4", LANDSCAPE);
+ */
+pub.size = function(widthOrPageSize, heightOrOrientation) {
+  if(app.documents.length === 0) {
+    // there are no documents
+    warning("size()", "You have no open document.");
+    return;
+  }
+  if (arguments.length === 0) {
+    // no arguments given
+    // return the current values
+    return {width: pub.width, height: pub.height};
+  }
+
+  var doc = currentDoc();
+
+  if(isString(widthOrPageSize)) {
+    try {
+      doc.documentPreferences.pageSize = widthOrPageSize;
+    } catch (e) {
+      error("size(), could not find a page size preset named \"" + widthOrPageSize + "\".");
+    }
+    if(heightOrOrientation === pub.PORTRAIT || heightOrOrientation === pub.LANDSCAPE) {
+      doc.documentPreferences.pageOrientation = heightOrOrientation;
+    }
+    pub.width = $.global.width = doc.documentPreferences.pageWidth;
+    pub.height = $.global.height = doc.documentPreferences.pageHeight;
+    return {width: pub.width, height: pub.height};
+  } else if(arguments.length === 1) {
+    // only one argument set the first to the secound
+    heightOrOrientation = widthOrPageSize;
+  }
+  // set the document's pageHeight and pageWidth
+  doc.properties = {
+    documentPreferences: {
+      pageHeight: heightOrOrientation,
+      pageWidth: widthOrPageSize
+    }
+  };
+  // set height and width
+  pub.width = $.global.width = widthOrPageSize;
+  pub.height = $.global.height = heightOrOrientation;
+
+  return {width: pub.width, height: pub.height};
+
+};
+
+/**
+ * @description Closes the current document. If no saveOptions argument is used, the user will be asked if they want to save or not.
+ *
+ * @cat    Document
+ * @method close
+ * @param  {Object|Boolean} [saveOptions] The InDesign SaveOptions constant or either true for triggering saving before closing or false for closing without saving.
+ * @param  {File} [file] The InDesign file instance to save the document to.
+ */
+pub.close = function(saveOptions, file) {
+  if (currDoc) {
+    if(saveOptions === false) {
+      saveOptions = SaveOptions.NO;
+    } else if(saveOptions === true) {
+      saveOptions = SaveOptions.YES;
+    } else if(saveOptions === undefined) {
+      saveOptions = SaveOptions.ASK;
+    } else {
+      if(!isEnum(SaveOptions, saveOptions)) {
+        error("close(), wrong saveOptions argument. Use True, False, InDesign SaveOptions constant or leave empty.");
+      }
+    }
+
+    resetDocSettings();
+
+    try {
+      currDoc.close(saveOptions, file);
+    } catch (e) {
+      // the user has cancelled a save dialog, the doc will not be saved
+      currDoc.close(saveOptions.NO);
+    }
+    resetCurrDoc();
+  }
+};
+
+/**
+ * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
+ *
+ * @cat    Document
+ * @method revert
+ * @return {Document} The reverted document.
+ */
+pub.revert = function() {
+
+  if(currDoc.saved && currDoc.modified) {
+    var currFile = currDoc.fullName;
+    currDoc.close(SaveOptions.NO);
+    currDoc = null;
+    app.open(File(currFile));
+    currentDoc();
+  } else if(!currDoc.saved) {
+    currDoc.close(SaveOptions.NO);
+    currDoc = null;
+    app.documents.add();
+    currentDoc();
+  }
+
+  return currDoc;
+};
+
+/**
+ * @description Use this to set the dimensions of the canvas. Choose between PAGE (default), MARGIN, BLEED resp. FACING_PAGES, FACING_MARGINS and FACING_BLEEDS for book setups with facing page. Please note: Setups with more than two facing pages are not yet supported.<br>
+ * Please note that you will loose your current MatrixTransformation. You should set the canvasMode before you attempt to use translate(), rotate() and scale();
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method canvasMode
+ * @param  {String} mode The canvas mode to set.
+ * @return {String} The current canvas mode.
+ */
+pub.canvasMode = function (m) {
+  if(arguments.length === 0) {
+    return currCanvasMode;
+  } else if (m === pub.PAGE ||
+             m === pub.MARGIN ||
+             m === pub.BLEED ||
+             m === pub.FACING_PAGES ||
+             m === pub.FACING_MARGINS ||
+             m === pub.FACING_BLEEDS) {
+    currCanvasMode = m;
+    updatePublicPageSizeVars();
+  } else {
+    error("canvasMode(), there is a problem setting the canvasMode. Please check the reference for details.");
+  }
+  return currCanvasMode;
+};
+
+
+/**
+ * @description Returns the current horizontal and vertical pasteboard margins and sets them if both arguements are given.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method pasteboard
+ * @param  {Number} h The desired horizontal pasteboard margin.
+ * @param  {Number} v The desired vertical pasteboard margin.
+ * @return {Array} The current horizontal, vertical pasteboard margins.
+ */
+pub.pasteboard = function (h, v) {
+  if(arguments.length == 0) {
+    return currentDoc().pasteboardPreferences.pasteboardMargins;
+  } else if(arguments.length == 1) {
+    error("pasteboard() requires both a horizontal and vertical value. Please check the reference for details.");
+  }else if (typeof h === "number" && typeof v === "number") {
+    currentDoc().pasteboardPreferences.pasteboardMargins = [h, v];
+    return currentDoc().pasteboardPreferences.pasteboardMargins;
+  }else {
+    error("pasteboard(), there is a problem setting the pasteboard. Please check the reference for details.");
+  }
+};
+
+/**
+ * @description Returns the current page and sets it if argument page is given. Numbering starts with 1.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method page
+ * @param  {Page|Number|PageItem} [page] The page object or page number to set the current page to. If you pass a PageItem the current page will be set to it's containing page.
+ * @return {Page} The current page instance.
+ */
+pub.page = function(page) {
+  if (page instanceof Page) {
+    currPage = page;
+  } else if (typeof page !== "undefined" && page.hasOwnProperty("parentPage")) {
+    currPage = page.parentPage; // page is actually a PageItem
+  } else if (typeof page === "number") {
+    if(page < 1) {
+      p = 0;
+    } else {
+      p = page - 1;
+    }
+    var tempPage = currentDoc().pages[p];
+    try {
+      tempPage.id;
+    } catch (e) {
+      error("page(), " + page + " does not exist.");
+    }
+    currPage = tempPage;
+  } else if (typeof page !== "undefined") {
+    error("page(), bad type for page().");
+  }
+  updatePublicPageSizeVars();
+  if (currentDoc().windows.length) {
+    app.activeWindow.activePage = currPage;
+  } // focus in GUI if not in HIDDEN
+  return currentPage();
+};
+
+/**
+ * @description Adds a new page to the document. Set the optional location parameter to either AT_END (default), AT_BEGINNING, AFTER or BEFORE. AFTER and BEFORE will use the current page as insertion point.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method addPage
+ * @param  {String} [location] The location placement mode.
+ * @return {Page} The new page.
+ */
+pub.addPage = function(location) {
+
+  checkNull(location);
+
+  if(arguments.length === 0) {
+    location = pub.AT_END;
+  } // default
+
+  var nP;
+  try {
+
+    switch (location) {
+
+      case pub.AT_END:
+        nP = currentDoc().pages.add(location);
+        break;
+
+      case pub.AT_BEGINNING:
+        nP = currentDoc().pages.add(location);
+        break;
+
+      case pub.AFTER:
+        nP = currentDoc().pages.add(location, pub.page());
+        break;
+
+      case pub.BEFORE:
+        nP = currentDoc().pages.add(location, pub.page());
+        break;
+
+      default:
+        throw new Error();
+        break;
+    }
+
+    pub.page(nP);
+    return nP;
+
+  } catch (e) {
+    error("addPage(), invalid location argument passed to addPage()");
+  }
+};
+
+
+/**
+ * @description Removes a page from the current document. This will either be the current Page if the parameter page is left empty, or the given Page object or page number.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method removePage
+ * @param  {Page|Number} [page] The page to be removed as Page object or page number.
+ */
+pub.removePage = function (page) {
+  checkNull(page);
+  if(typeof page === "number" || arguments.length === 0 || page instanceof Page) {
+    var p = pub.page(page);
+    p.remove();
+    currPage = null; // reset!
+    currentPage();
+  } else {
+    error("removePage(), invalid call. Wrong parameter!");
+  }
+};
+
+/**
+ * @description Returns the current page number of either the current page or the given Page object.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method pageNumber
+ * @param  {Page} [pageObj] The page you want to know the number of.
+ * @return {Number} The page number within the document.
+ */
+pub.pageNumber = function (pageObj) {
+  checkNull(pageObj);
+  if (typeof pageObj === "number") {
+    error("pageNumber(), cannot be called with a Number argument.");
+  }
+  if (pageObj instanceof Page) {
+    return parseInt(pageObj.name); // current number of given page
+  }
+  return parseInt(pub.page().name); // number of current page
+};
+
+/**
+ * @description Set the next page of the document to be the active one. Returns new active page.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method nextPage
+ * @return {Page} The active page.
+ */
+pub.nextPage = function () {
+  var p = pub.doc().pages.nextItem(currentPage());
+  return pub.page(p);
+};
+
+
+/**
+ * @description Set the previous page of the document to be the active one. Returns new active page.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method previousPage
+ * @return {Page} The active page.
+ */
+pub.previousPage = function () {
+  var p = pub.doc().pages.previousItem(currentPage());
+  return pub.page(p);
+};
+
+
+/**
+ * @description Returns the number of all pages in the current document. If a number is given as an argument,
+ * it will set the document's page count to the given number by either adding pages or removing
+ * pages until the number is reached. If pages are added, the master page of the document's last
+ * page will be applied to the new pages.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method pageCount
+ * @param  {Number} [pageCount] New page count of the document (integer between 1 and 9999).
+ * @return {Number} The amount of pages.
+ */
+pub.pageCount = function(pageCount) {
+  if(arguments.length) {
+    if(pub.isInteger(pageCount) && pageCount > 0 && pageCount < 10000) {
+      currentDoc().documentPreferences.pagesPerDocument = pageCount;
+    } else {
+      error("pageCount(), wrong arguments! Use an integer between 1 and 9999 to set page count.");
+    }
+  }
+  return currentDoc().pages.count();
+};
+
+
+/**
+ * @description The number of all stories in the current document.
+ *
+ * @cat    Document
+ * @subcat Story
+ * @method storyCount
+ * @return {Number} count The amount of stories.
+ */
+pub.storyCount = function() {
+  return currentDoc().stories.count();
+};
+
+/**
+ * @description Adds a page item or a string to an existing story. You can control the position of the insert via the last parameter. It accepts either an InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
+ *
+ * @cat    Document
+ * @subcat Story
+ * @method addToStory
+ * @param  {Story} story The story.
+ * @param  {PageItem|String} itemOrString The itemOrString either a PageItem, a String or one the following constants: AT_BEGINNING and AT_END.
+ * @param  {InsertionPoint|String} insertionPointOrMode InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
+ */
+pub.addToStory = function(story, itemOrString, insertionPointorMode) {
+
+  checkNull(story);
+  checkNull(itemOrString);
+
+  // init
+  var libFileName = "addToStoryLib.indl";
+
+  var libFile = new File(Folder.temp + "/" + libFileName);
+  addToStoryCache = app.libraries.itemByName(libFileName);
+  // if and a cache is existing from previous executions, remove it
+  if (addToStoryCache.isValid) {
+    addToStoryCache.close();
+    libFile.remove();
+  }
+  // create an InDesign library for caching the page items
+  addToStoryCache = app.libraries.add(libFile);
+
+
+  if (story instanceof Story && arguments.length >= 2) {
+    // add string
+    if (isString(itemOrString)) {
+      if (insertionPointorMode instanceof InsertionPoint) {
+        insertionPointorMode.contents = itemOrString;
+      } else if (insertionPointorMode === pub.AT_BEGINNING) {
+        story.insertionPoints.firstItem().contents = itemOrString;
+      } else {
+        story.insertionPoints.lastItem().contents = itemOrString;
+      }
+    } else {
+      // store the item as first asset in cache
+      addToStoryCache.store(itemOrString);
+
+      var insertionPoint = null;
+      if (insertionPointorMode instanceof InsertionPoint) {
+        insertionPoint = insertionPointorMode;
+      } else if (insertionPointorMode === pub.AT_BEGINNING) {
+        insertionPoint = story.insertionPoints.firstItem();
+      } else {
+        insertionPoint = story.insertionPoints.lastItem();
+      }
+
+      // place & remove from cache
+      addToStoryCache.assets.firstItem().placeAsset(insertionPoint);
+      addToStoryCache.assets.firstItem().remove();
+    }
+  } else {
+    error("addToStory(), wrong arguments! Please use: addToStory(story, itemOrString, insertionPointorMode). Parameter insertionPointorMode is optional.");
+  }
+};
+
+
+/**
+ * @description Returns the current layer if no argument is given. Sets active layer if layer object or name of existing layer is given. Newly creates layer and sets it to active if new name is given.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method layer
+ * @param  {Layer|String} [layer] The layer or layer name to set the current layer to.
+ * @return {Layer} The current layer instance.
+ */
+pub.layer = function(layer) {
+  checkNull(layer);
+  if (layer instanceof Layer) {
+    currLayer = layer;
+    currentDoc().activeLayer = currLayer;
+  } else if (typeof layer === "string") {
+    var layers = currentDoc().layers;
+    currLayer = layers.item(layer);
+    if (!currLayer.isValid) {
+      currLayer = layers.add({name: layer});
+    } else {
+      currentDoc().activeLayer = currLayer;
+    }
+  } else if (arguments.length > 0) {
+    error("layer(), wrong arguments. Use layer object or string instead.");
+  }
+  return currentLayer();
+};
+
+
+/**
+ * @description Arranges a page item or a layer before or behind other page items or layers. If using the constants `FORWARD` or `BACKWARD` the object is sent forward or back one step. The constants `FRONT` or `BACK` send the object to the very front or very back. Using `FRONT` or `BACK` together with the optional reference object, sends the object in front or behind this reference object.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method arrange
+ * @param  {PageItem|Layer} pItemOrLayer The page item or layer to be moved to a new position.
+ * @param  {String} positionOrDirection The position or direction to move the page item or layer. Can be `FRONT`, `BACK`, `FORWARD` or `BACKWARD`.
+ * @param  {PageItem|Layer} [reference] A reference object to move the page item or layer behind or in front of.
+ * @return {PageItem|Layer} The newly arranged page item or layer.
+ */
+pub.arrange = function(pItemOrLayer, positionOrDirection, reference) {
+  checkNull(pItemOrLayer);
+
+  if(pItemOrLayer.hasOwnProperty("parentPage")) {
+    if(positionOrDirection === pub.BACKWARD) {
+      pItemOrLayer.sendBackward();
+    } else if (positionOrDirection === pub.FORWARD) {
+      pItemOrLayer.bringForward();
+    } else if (positionOrDirection === pub.BACK) {
+      pItemOrLayer.sendToBack(reference);
+    } else if (positionOrDirection === pub.FRONT) {
+      pItemOrLayer.bringToFront(reference);
+    } else {
+      error("arrange(), not a valid position or direction. Please use FRONT, BACK, FORWARD or BACKWARD.");
+    }
+  } else if (pItemOrLayer instanceof Layer) {
+    if(positionOrDirection === pub.BACKWARD) {
+      if(pItemOrLayer.index === currentDoc().layers.length - 1) return;
+      pItemOrLayer.move(LocationOptions.AFTER, currentDoc().layers[pItemOrLayer.index + 1]);
+    } else if (positionOrDirection === pub.FORWARD) {
+      if(pItemOrLayer.index === 0) return;
+      pItemOrLayer.move(LocationOptions.BEFORE, currentDoc().layers[pItemOrLayer.index - 1]);
+    } else if (positionOrDirection === pub.BACK) {
+      if(!(reference instanceof Layer)) {
+        pItemOrLayer.move(LocationOptions.AT_END);
+      } else {
+        pItemOrLayer.move(LocationOptions.AFTER, reference);
+      }
+    } else if (positionOrDirection === pub.FRONT) {
+      if(!(reference instanceof Layer)) {
+        pItemOrLayer.move(LocationOptions.AT_BEGINNING);
+      } else {
+        pItemOrLayer.move(LocationOptions.BEFORE, reference);
+      }
+    } else {
+      error("arrange(), not a valid position or direction. Please use FRONT, BACK, FORWARD or BACKWARD.");
+    }
+  } else {
+    error("arrange(), invalid first parameter. Use page item or layer.");
+  }
+
+  return pItemOrLayer;
+};
+
+
+/**
+ *  @description Returns the Group instance and sets it if argument Group is given.
+ *  Groups items to a new group. Returns the resulting group instance. If a string is given as the only
+ *  argument, the group by the given name will be returned.
+ *
+ *  @cat    Document
+ *  @subCat Page
+ *  @method group
+ *  @param  {Array} pItems An array of page items (must contain at least two items) or name of group instance.
+ *  @param  {String} [name] The name of the group, only when creating a group from page items.
+ *  @return {Group} The group instance.
+ */
+pub.group = function (pItems, name) {
+  checkNull(pItems);
+  var group;
+  if(pItems instanceof Array) {
+    if(pItems.length < 2) {
+      error("group(), the array passed to group() must at least contain two page items.");
+    }
+    // creates a group from Page Items
+    group = currentDoc().groups.add(pItems);
+    if(typeof name !== "undefined") {
+      group.name = name;
+    }
+  } else if(typeof pItems === "string") {
+    // get the Group of the given name
+    group = currentDoc().groups.item(pItems);
+    if (!group.isValid) {
+      error("group(), a group with the provided name doesn't exist.");
+    }
+  } else {
+    error("group(), not a valid argument. Use an array of page items to group or a name of an existing group.");
+  }
+
+  return group;
+};
+
+
+/**
+ *  @description Ungroups an existing group. Returns an array of the items that were within the group before ungroup() was called.
+ *
+ *  @cat    Document
+ *  @subCat Page
+ *  @method ungroup
+ *  @param  {Group|String} group The group instance or name of the group to ungroup.
+ *  @return {Array} An array of the ungrouped page items.
+ */
+pub.ungroup = function(group) {
+  checkNull(group);
+  var ungroupedItems = null;
+  if(group instanceof Group) {
+    ungroupedItems = pub.items(group);
+    group.ungroup();
+  } else if(typeof group === "string") {
+    // get the Group of the given name
+    group = currentDoc().groups.item(group);
+    if (!group.isValid) {
+      error("ungroup(), a group with the provided name doesn't exist.");
+    }
+    ungroupedItems = pub.items(group);
+    group.ungroup();
+  } else {
+    error("ungroup(), not a valid group. Please select a valid group.");
+  }
+  return ungroupedItems;
+};
+
+
+/**
+ * @description Returns items tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label).
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method labels
+ * @param  {String} label The label identifier.
+ * @param  {Function} [cb] The callback function to call with each item in the search result. When this function returns false the loop stops. Passed arguments: item, loopCount.
+ * @return {Array} Array of concrete PageItem instances, e.g. TextFrame or SplineItem.
+ */
+pub.labels = function(label, cb) {
+  checkNull(label);
+  var result = [];
+  var doc = currentDoc();
+  for (var i = 0, len = doc.pageItems.length; i < len; i++) {
+    var pageItem = doc.pageItems[i];
+    if (pageItem.label === label) {
+      // push pageItem's 1st element to get the concrete PageItem instance, e.g. a TextFrame
+      result.push(pageItem.getElements()[0]);
+    }
+  }
+  if (arguments.length === 2 && cb instanceof Function) {
+    return forEach(result, cb);
+  }
+  if(result.length === 0) {
+    error("labels(), no item found with the given label '" + label + "'. Check for line breaks and whitespaces in the script label panel.");
+  }
+  return result;
+};
+
+
+/**
+ * @description Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of `labels()`, when you know you just have one thing with that label and don't want to deal with a single-element array.
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method label
+ * @param  {String} label The label identifier.
+ * @return {PageItem} The first PageItem with the given label.
+ */
+pub.label = function(label) {
+  checkNull(label);
+  var doc = currentDoc();
+  for (var i = 0, len = doc.pageItems.length; i < len; i++) {
+    var pageItem = doc.pageItems[i];
+    if (pageItem.label === label) {
+      return pageItem;
+    }
+  }
+  error("label(), no item found with the given label '" + label + "'. Check for line breaks and whitespaces in the script label panel.");
+};
+
+
+/**
+ * @description Returns the first currently selected object. Use this if you know you only have one selected item and don't want to deal with an array.
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method selection
+ * @return {Object} The first selected object.
+ */
+pub.selection = function() {
+  if(app.selection.length === 0) {
+    error("selection(), selection is empty. Please select something.");
+  }
+  return app.selection[0];
+};
+
+/**
+ * @description Returns the currently selected object(s)
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method selections
+ * @param  {Function} [cb] The callback function to call with each item in the selection. When this function returns false the loop stops. Passed arguments: item, loopCount.
+ * @return {Array} Array of selected object(s).
+ */
+pub.selections = function(cb) {
+  if(app.selection.length === 0) {
+    error("selections(), selection is empty. Please select something.");
+  }
+  if (arguments.length === 1 && cb instanceof Function) {
+    return forEach(app.selection, cb);
+  }
+  return app.selection;
+};
+
+/**
+ * @description Returns the first item on the active page that is named by the given name in the Layers pane (Window -> Layer).
+ *
+ * @cat    Document
+ * @subcat Multi-Getters
+ * @method nameOnPage
+ * @return {Object} The first object on the active page with the given name.
+ */
+pub.nameOnPage = function(name) {
+  checkNull(name);
+  var result = null;
+  var page = currentPage();
+  for (var i = 0, len = page.allPageItems.length; i < len; i++) {
+    var pageItem = page.allPageItems[i];
+    if (pageItem.name === name) {
+      result = pageItem.getElements()[0];
+      break;
+    }
+  }
+  if(result === null) {
+    error("nameOnPage(), no item found with the name '" + name + "' on page " + pub.pageNumber());
+  }
+  return result;
+};
+
+
+/**
+ * @description Sets the units of the document (like right clicking the rulers). By default basil uses the units of the user's document or the user's default units.
+ *
+ * @cat    Document
+ * @method units
+ * @param  {String} [units] Supported units: PT, PX, CM, MM or IN.
+ * @return {String} Current unit setting.
+ */
+var unitsCalledCounter = 0;
+pub.units = function (units) {
+  checkNull(units);
+  if (arguments.length === 0) {
+    return currUnits;
+  }
+
+  if (units === pub.PT || units === 2054188905) {
+    units = pub.PT;
+    unitType = MeasurementUnits.points;
+  } else if(units === pub.MM || units === 2053991795) {
+    units = pub.MM;
+    unitType = MeasurementUnits.millimeters;
+  } else if(units === pub.CM || units === 2053336435) {
+    units = pub.CM;
+    unitType = MeasurementUnits.centimeters;
+  } else if(units === pub.IN || units === 2053729891) {
+    units = pub.IN;
+    unitType = MeasurementUnits.inches;
+  } else if(units === pub.PX || units === 2054187384) {
+    units = pub.PX;
+    unitType = MeasurementUnits.pixels;
+  } else if(isEnum(MeasurementUnits, units)) {
+    // valid enumerator with invalid basil.js unit (from documents that are set to PICAS, CICEROS etc.)
+    warning("The document's current units are not supported by basil.js. Units will be set to Points.");
+    units = pub.PT;
+    unitType = MeasurementUnits.points;
+  } else {
+    error("units(), invalid unit. Use: PT, MM, CM, IN or PX.");
+  }
+
+  currentDoc().viewPreferences.horizontalMeasurementUnits = unitType;
+  currentDoc().viewPreferences.verticalMeasurementUnits = unitType;
+  currUnits = units;
+
+  updatePublicPageSizeVars();
+
+  if (unitsCalledCounter === 1) {
+    warning("Please note that units() will reset the current transformation matrix.");
+  }
+  unitsCalledCounter++;
+  return currUnits;
+};
+
+/**
+ * @description Creates a vertical guide line at the current spread and current layer.
+ *
+ * @cat    Document
+ * @method guideX
+ * @param  {Number} x Position of the new guide line.
+ * @return {Guide} New guide line.
+ */
+pub.guideX = function (x) {
+  checkNull(x);
+  var guides = currentPage().guides;
+  var guide = guides.add(currentLayer());
+  guide.fitToPage = true;
+  guide.orientation = HorizontalOrVertical.VERTICAL;
+  guide.location = x;
+  return guide;
+};
+
+
+/**
+ * @description Creates a horizontal guide line at the current spread and current layer.
+ *
+ * @cat    Document
+ * @method guideY
+ * @param  {Number} y Position of the new guide line.
+ * @return {Guide} New guide line.
+ */
+pub.guideY = function (y) {
+  checkNull(y);
+  var guides = currentPage().guides;
+  var guide = guides.add(currentLayer());
+  guide.fitToPage = true;
+  guide.orientation = HorizontalOrVertical.HORIZONTAL;
+  guide.location = y;
+  return guide;
+};
+
+
+/**
+ * @description Sets the margins of a given page. If 1 value is given, all 4 sides are set equally. If 4 values are given, the current page will be adjusted. Adding a 5th value will set the margin of a given page. Calling the function without any values, will return the margins for the current page.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method margins
+ * @param  {Number} [top] Top margin or all if only one.
+ * @param  {Number} [right] Right margin.
+ * @param  {Number} [bottom] Bottom margin.
+ * @param  {Number} [left] Left margin.
+ * @param  {Number} [pageNumber] Sets margins to selected page, currentPage() if left blank.
+ * @return {Object} Current page margins with the properties: top, right, bottom, left.
+ */
+pub.margins = function(top, right, bottom, left, pageNumber) {
+  if (arguments.length === 0) {
+    return {top: pub.page(pageNumber).marginPreferences.top,
+      right: pub.page(pageNumber).marginPreferences.right,
+      bottom: pub.page(pageNumber).marginPreferences.bottom,
+      left: pub.page(pageNumber).marginPreferences.left
+    };
+  } else if (arguments.length === 1) {
+    right = bottom = left = top;
+  }
+  if(pageNumber !== undefined) {
+    pub.page(pageNumber).marginPreferences.top = top;
+    pub.page(pageNumber).marginPreferences.right = right;
+    pub.page(pageNumber).marginPreferences.bottom = bottom;
+    pub.page(pageNumber).marginPreferences.left = left;
+  }else{
+    currentPage().marginPreferences.top = top;
+    currentPage().marginPreferences.right = right;
+    currentPage().marginPreferences.bottom = bottom;
+    currentPage().marginPreferences.left = left;
+  }
+};
+
+
+/**
+ * @description Sets the document bleeds. If one value is given, all 4 are set equally. If 4 values are given, the top/right/bottom/left document bleeds will be adjusted. Calling the function without any values, will return the document bleed settings.
+ *
+ * @cat    Document
+ * @subcat Page
+ * @method bleeds
+ * @param  {Number} [top] Top bleed or all if only one.
+ * @param  {Number} [right] Right bleed.
+ * @param  {Number} [bottom] Bottom bleed.
+ * @param  {Number} [left] Left bleed.
+ * @return {Object} Current document bleeds settings.
+ */
+pub.bleeds = function(top, right, bottom, left) {
+  if (arguments.length === 0) {
+    return {top: currentDoc().documentPreferences.documentBleedTopOffset,
+      right: currentDoc().documentPreferences.documentBleedOutsideOrRightOffset,
+      bottom: currentDoc().documentPreferences.documentBleedBottomOffset,
+      left: currentDoc().documentPreferences.documentBleedInsideOrLeftOffset
+    };
+  } else if (arguments.length === 1) {
+    right = bottom = left = top;
+  }else{
+    currentDoc().documentPreferences.documentBleedUniformSize = false;
+  }
+  currentDoc().documentPreferences.documentBleedTopOffset = top;
+  currentDoc().documentPreferences.documentBleedOutsideOrRightOffset = right;
+  currentDoc().documentPreferences.documentBleedBottomOffset = bottom;
+  currentDoc().documentPreferences.documentBleedInsideOrLeftOffset = left;
+};
+
+
+/**
+ * @description Inspects a given object or any other data item and prints the result to the console. This is useful for inspecting or debugging any kind of variable or data item. The optional settings object allows to control the function's output. The following parameters can be set in the settings object:<br>
+ * `showProps`: Show or hide properties. Default: `true`<br>
+ * `showValues`: Show or hide values. Default: `true`<br>
+ * `showMethods`: Show or hide methods. Default: `false`<br>
+ * `maxLevel`: Chooses how many levels of properties should be inspected recursively. Default: `1`<br>
+ * `propList`: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: `[]` (no propList)<br>
+ * If no settings object is set, the default values will be used.
+ *
+ * @cat    Output
+ * @method inspect
+ * @param  {Object} obj An object or any other data item to be inspected.
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {Boolean} [settings.showProps] Show or hide properties. Default: `true`
+ * @param  {Boolean} [settings.showValues] Show or hide values. Default: `true`
+ * @param  {Boolean} [settings.showMethods] Show or hide methods. Default: `false`
+ * @param  {Number} [settings.maxLevel] How many levels of properties should be inspected recursively. Default: `1`
+ * @param  {Array} [settings.propList] Array of properties to show. Default: `[]` (no propList)
+ *
+ * @example <caption>Inspecting a string</caption>
+ * inspect("foo");
+ *
+ * @example <caption>Inspecting the current page, its methods and an additional level of properties</caption>
+ * inspect(page(), {showMethods: true, maxLevel: 2})
+ *
+ * @example <caption>Inspecting an ellipse, listing only the properties "geometricBounds" and "strokeWeight"</caption>
+ * var myEllipse = ellipse(0, 0, 10, 10);
+ * inspect(myEllipse, {maxLevel: 2, propList: ["geometricBounds, strokeWeight"]});
+ */
+pub.inspect = function (obj, settings, level, branchArray, branchEnd) {
+
+  var output, indent;
+  output = indent = "";
+
+  if (!level) {
+    level = 0;
+    branchArray = [];
+
+    if(!settings) {
+      settings = {};
+    }
+
+    // set settings object to given values or defaults
+    settings.showProps = settings.hasOwnProperty("showProps") ? settings.showProps : true;
+    settings.showValues = settings.hasOwnProperty("showValues") ? settings.showValues : true;
+    settings.showMethods = settings.hasOwnProperty("showMethods") ? settings.showMethods : false;
+    settings.maxLevel = settings.hasOwnProperty("maxLevel") ? settings.maxLevel : 1;
+    settings.propList = settings.hasOwnProperty("propList") ? settings.propList : [];
+
+    if(obj === null || obj === undefined) {
+      println(obj + "");
+      return;
+    }
+
+    if(obj.constructor.name === "Array") {
+      if(obj.length > 0 && obj.reflect.properties.length < 3) {
+        // fixing InDesign's buggy implementation of certain arrays
+        // see: https://forums.adobe.com/message/9408120#9408120
+        obj = Array.prototype.slice.call(obj, 0);
+      }
+      output += "[" + obj.join(", ") + "] (Array)";
+    } else if (obj.constructor.name === "String") {
+      output += "\"" + obj + "\" (String)";
+    } else {
+      output += obj + " (" + obj.constructor.name + ")";
+    }
+  } else {
+    // setting up tree structure indent
+    if(branchArray.length < level) {
+      branchArray.push(branchEnd);
+    } else if (branchArray.length > level) {
+      branchArray.pop();
+    }
+    if(branchEnd) {
+      if(!(level === 1 && settings.showMethods)) {
+        branchArray[branchArray.length - 1] = true;
+      }
+    }
+    for (var i = 0; i < level; i++) {
+      if(branchArray[i]) {
+        indent += "    ";
+      } else {
+        indent += "|   ";
+      }
+    }
+  }
+
+  if(settings.showProps) {
+    var propArray, value, usePropList;
+
+    if(level === 0 && settings.propList.length > 0 && settings.propList.constructor.name === "Array") {
+      usePropList = true;
+      propArray = settings.propList.reverse();
+    } else if (obj.constructor.name === "Array") {
+      // correct sorting for Array number properties (0, 1, 2 etc.)
+      propArray = obj.reflect.properties.sort(function(a, b) {return a - b}).reverse();
+    } else {
+      propArray = obj.reflect.properties.sort().reverse();
+    }
+
+    if(propArray.length > 1 || usePropList) {
+      output += "\n" + indent + "|";
+
+      for (var i = propArray.length - 1; i >= 0; i--) {
+        if(propArray[i] == "__proto__" || propArray[i] == "__count__" || propArray[i] == "__class__"|| propArray[i] == "reflect") {
+          if(!i) {
+            output += "\n" + indent;
+          }
+          continue;
+        }
+
+        if(settings.showValues) {
+
+          try {
+            var propValue = obj[propArray[i]];
+            if (usePropList && !obj.hasOwnProperty(propArray[i]) && propArray[i] != "length") {
+              // in case a non-existing prop is passed via propList
+              // "length" needs special handling as it is not correctly recognized as a property
+              value = ": The inspected item has no such property.";
+            } else if (propValue === null || propValue === undefined) {
+              value = ": " + propValue;
+            } else if (propValue.constructor.name === "Array") {
+              if(propValue.length > 0 && propValue.reflect.properties.length < 3) {
+                propValue = Array.prototype.slice.call(propValue, 0);
+              }
+              value = ": Array (" + propValue.length + ")";
+              if(propValue.length && level < settings.maxLevel - 1) {
+                // recursive inspecting of Array properties
+                value += pub.inspect(propValue, settings, level + 1, branchArray, !i);
+              }
+            } else if (typeof propValue === "object" && propValue.constructor.name !== "Enumerator"  && propValue.constructor.name !== "Date") {
+              value = ": " + propValue;
+              if(level < settings.maxLevel - 1) {
+                // recursive inspecting of Object properties
+                value += pub.inspect(propValue, settings, level + 1, branchArray, !i);
+              }
+            } else {
+              value = ": " + propValue.toString();
+            }
+          } catch (e) {
+            if(e.number === 30615) {
+              value = ": The property is not applicable in the current state.";
+            } else if (e.number === 55) {
+              value = ": Object does not support the property '" + propArray[i] + "'.";
+            } else {
+              // other InDesign specific error messages
+              value = ": " + e.message;
+            }
+          }
+
+        } else {
+          value = "";
+        }
+
+        output += "\n" + indent + "|-- " + propArray[i] + value;
+
+
+        if(!i && !branchEnd && level !== 0) {
+          // separation space when a sub-branch ends
+          output += "\n" + indent;
+        }
+      } // end for-loop
+    } // end if(propArray.length > 1 || usePropList)
+  } // end if(settings.showProps)
+
+  if(level === 0 && settings.showMethods) {
+
+    var methodArray = settings.showMethods ? obj.reflect.methods.sort().reverse() : [];
+
+    if(methodArray.length) {
+      output += "\n|" +
+                "\n|   METHODS";
+    }
+
+    for (var i = methodArray.length - 1; i >= 0; i--) {
+      if(methodArray[i].name.charAt(0) === "=") {continue;}
+      output += "\n|-- " + methodArray[i] + "()";
+    }
+  }
+
+  if(level > 0) {
+    // return for recursive calls
+    return output;
+  }
+  // print for top level call
+  println(output);
+
+};
+
+// ----------------------------------------
+// Files & Folders
+
+/**
+ * @description Returns a file object.<br>
+ * Note that the resulting file object can either refer to an already existing file or if the file does not exist, it can create a preliminary "virtual" file that refers to a file that could be created later (i.e. by an export command).
+ *
+ * @cat    Files
+ * @method file
+ * @param  {String} filePath The file path.
+ * @return {File} File at the given path.
+ *
+ * @example <caption>Get an image file from the desktop and place it in the document</caption>
+ * var myImage = file("~/Desktop/myImage.jpg");
+ * image(myImage, 0, 0);
+ *
+ * @example <caption>Create a file and export it to the desktop</caption>
+ * var myExportFile = file("~/Desktop/myNewExportFile.pdf");
+ * savePDF(myExportFile);
+ */
+pub.file = function(filePath) {
+  if(! isString(filePath)) {
+    error("file(), wrong argument. Use a string that describes a file path.");
+  }
+
+  // check if user is referring to a file in the data directory
+  if(currentDoc().saved) {
+    var file = new File(pub.projectFolder() + "/data/" + filePath);
+    if(file.exists) {
+      return file;
+    }
+  }
+
+  // add leading slash to avoid errors on file creation
+  if(filePath[0] !== "~" && filePath[0] !== "/") {
+    filePath = "/" + filePath;
+  }
+
+  return new File(filePath);
+};
+
+/**
+ * @description Returns a folder object.<br>
+ * Note that the resulting folder object can either refer to an already existing folder or if the folder does not exist, it can create a preliminary "virtual" folder that refers to a folder that could be created later.
+ *
+ * @cat    Files
+ * @method folder
+ * @param  {String} [folderPath] The path of the folder.
+ * @return {Folder} Folder at the given path. If no path is given, but the document is already saved, the document's data folder will be returned.
+ *
+ * @example <caption>Get a folder from the desktop and load its files</caption>
+ * var myImageFolder = folder("~/Desktop/myImages/");
+ * var myImageFiles = files(myImageFolder);
+ *
+ * @example <caption>Get the data folder, if the document is already saved</caption>
+ * var myDataFolder = folder();
+ */
+pub.folder = function(folderPath) {
+  if(folderPath === undefined) {
+    if(currentDoc().saved) {
+      return new Folder(pub.projectFolder() + "/data/");
+    } else {
+      error("folder(), no data folder. The document has not been saved yet, so there is no data folder to access.");
+    }
+  }
+  if(! isString(folderPath)) {
+    error("folder(), wrong argument. Use a string that describes the path of a folder.");
+  }
+
+  // check if user is referring to a folder in the data directory
+  if(currentDoc().saved) {
+    var folder = new Folder(pub.projectFolder() + "/data/" + folderPath);
+    if(folder.exists) {
+      return folder;
+    }
+  }
+
+  // add leading slash to avoid errors on folder creation
+  if(folderPath[0] !== "~" && folderPath[0] !== "/") {
+    folderPath = "/" + folderPath;
+  }
+
+  return new Folder(folderPath);
+};
+
+/**
+ * @description Gets all files of a folder and returns them in an array of file objects.
+ * The settings object can be used to restrict the search to certain file types only, to include hidden files and to include files in subfolders.
+ *
+ * @cat    Files
+ * @method files
+ * @param  {Folder|String} [folder] The folder that holds the files or a string describing the path to that folder.
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String|Array} [settings.filter] Suffix(es) of file types to include. Default: `"*"` (include all file types)
+ * @param  {Boolean} [settings.hidden] Hidden files will be included. Default: `false`
+ * @param  {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: `false`
+ * @return {Array} Array of the resulting file(s). If no files are found, an empty array will be returned.
+ *
+ * @example <caption>Get a folder from the desktop and load all its JPEG files</caption>
+ * var myImageFolder = folder("~/Desktop/myImages/");
+ * var myImageFiles = files(myImageFolder, {filter: ["jpeg", "jpg"]});
+ *
+ * @example <caption>If the document is saved, load all files from its data folder, including from its subfolders</caption>
+ * var myDataFolder = folder();
+ * var allMyDataFiles = files(myDataFolder, {recursive: true});
+ */
+pub.files = function(folder, settings, collectedFiles) {
+  var topLevel;
+  if (collectedFiles === undefined) {
+    if(folder === undefined && currentDoc().saved) {
+      folder = pub.folder();
+    } else if (folder === undefined) {
+      error("files(), missing first argument. Use folder or a string to describe a folder path or save your document to access the data folder.");
+    }
+    if(isString(folder)) {
+      folder = pub.folder(folder);
+    }
+    if(!(folder instanceof Folder)) {
+      error("files(), wrong first argument. Use folder or a string to describe a folder path.");
+    } else if (!folder.exists) {
+      error("files(), the folder \"" + folder + "\" does not exist.");
+    }
+
+    topLevel = true;
+    collectedFiles = [];
+
+    if(!settings) {
+      settings = {};
+    }
+
+    // set settings object to given values or defaults
+    settings.filter = settings.hasOwnProperty("filter") ? settings.filter : "*";
+    settings.hidden = settings.hasOwnProperty("hidden") ? settings.hidden : false;
+    settings.recursive = settings.hasOwnProperty("recursive") ? settings.recursive : false;
+
+    if(!(settings.filter instanceof Array)) {
+      settings.filter = [settings.filter];
+    }
+  } else {
+    topLevel = false;
+  }
+
+  if(settings.recursive) {
+    var folderItems = folder.getFiles();
+    for (var i = folderItems.length - 1; i >= 0; i--) {
+      if (folderItems[i] instanceof Folder) {
+        if(!settings.hidden && folderItems[i].displayName[0] === ".") continue;
+        collectedFiles = pub.files(folderItems[i], settings, collectedFiles);
+      }
+    }
+  }
+
+  for (var i = settings.filter.length - 1; i >= 0; i--) {
+    var mask = "*." + settings.filter[i];
+    var fileItems = folder.getFiles(mask);
+    for (var j = fileItems.length - 1; j >= 0; j--) {
+      if(!settings.hidden && fileItems[j].displayName[0] === ".") continue;
+      if(!(fileItems[j] instanceof File)) continue;
+      collectedFiles.push(fileItems[j]);
+    }
+  }
+
+  return topLevel ? collectedFiles.reverse() : collectedFiles;
+};
+
+/**
+ * @description Opens a selection dialog that allows to select one file. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
+ *
+ * @cat    Files
+ * @method selectFile
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
+ * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
+ * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
+ * @return {File|Null} The selected file. If the user cancels, `null` will be returned.
+ *
+ * @example <caption>Open file selection dialog with a prompt text</caption>
+ * selectFile({prompt: "Please select a file."});
+ *
+ * @example <caption>Open selection dialog starting at the user's desktop, allowing to only select PNG or JPEG files</caption>
+ * selectFile({folder: "~/Desktop/", filter: ["jpeg", "jpg", "png"]});
+ */
+pub.selectFile = function(settings) {
+  return createSelectionDialog(settings);
+};
+
+/**
+ * @description Opens a selection dialog that allows to select one or multiple files. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
+ *
+ * @cat    Files
+ * @method selectFiles
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
+ * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
+ * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
+ * @return {Array} Array of the selected file(s). If the user cancels, an empty array will be returned.
+ *
+ * @example <caption>Open file selection dialog with a prompt text</caption>
+ * selectFiles({prompt: "Please select your files."});
+ *
+ * @example <caption>Open selection dialog starting at the user's desktop, allowing to only select PNG or JPEG files</caption>
+ * selectFiles({folder: "~/Desktop/", filter: ["jpeg", "jpg", "png"]});
+ */
+pub.selectFiles = function(settings) {
+  if(!settings) {
+    settings = {};
+  }
+  settings.multiFile = true;
+
+  return createSelectionDialog(settings);
+};
+
+/**
+ * @description Opens a selection dialog that allows to select a folder. The settings object can be used to add a prompt text at the top of the dialog and to set the dialog's starting folder.
+ *
+ * @cat    Files
+ * @method selectFolder
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: `""` (no prompt)
+ * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
+ * @return {Folder|Null} The selected folder. If the user cancels, `null` will be returned.
+ *
+ * @example <caption>Open folder selection dialog with a prompt text</caption>
+ * selectFolder({prompt: "Please select a folder."});
+ *
+ * @example <caption>Open folder selection dialog starting at the user's desktop</caption>
+ * selectFolder({folder: "~/Desktop/"});
+ */
+pub.selectFolder = function(settings) {
+  if(!settings) {
+    settings = {};
+  }
+  settings.folderSelect = true;
+
+  return createSelectionDialog(settings);
+};
+
+
+// ----------------------------------------
+// Date
+
+/**
+ * @description The year() function returns the current year as an integer (2012, 2013 etc).
+ *
+ * @cat    Environment
+ * @subcat Date
+ * @method year
+ * @return {Number} The current year.
+ */
+pub.year = function() {
+  return (new Date()).getFullYear();
+};
+
+
+/**
+ * @description The month() function returns the current month as a value from 1 - 12.
+ *
+ * @cat    Environment
+ * @subcat Date
+ * @method month
+ * @return {Number} The current month number.
+ */
+pub.month = function() {
+  return (new Date()).getMonth() + 1;
+};
+
+
+/**
+ * @description The day() function returns the current day as a value from 1 - 31.
+ *
+ * @cat    Environment
+ * @subcat Date
+ * @method day
+ * @return {Number} The current day number.
+ */
+pub.day = function() {
+  return (new Date()).getDate();
+};
+
+
+/**
+ * @description The weekday() function returns the current weekday as a string from Sunday, Monday, Tuesday...
+ *
+ * @cat    Environment
+ * @subcat Date
+ * @method weekday
+ * @return {String} The current weekday name.
+ */
+pub.weekday = function() {
+  var weekdays = new Array("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday");
+  return weekdays[(new Date()).getDay()];
+};
+
+
+/**
+ * @description The hour() function returns the current hour as a value from 0 - 23.
+ *
+ * @cat    Environment
+ * @subcat Date
+ * @method hour
+ * @return {Number} The current hour.
+ */
+pub.hour = function() {
+  return (new Date()).getHours();
+};
+
+
+/**
+ * @description The minute() function returns the current minute as a value from 0 - 59.
+ *
+ * @cat    Environment
+ * @subcat Date
+ * @method minute
+ * @return {Number} The current minute.
+ */
+pub.minute = function() {
+  return (new Date()).getMinutes();
+};
+
+
+/**
+ * @description The second() function returns the current second as a value from 0 - 59.
+ *
+ * @cat    Environment
+ * @subcat Date
+ * @method second
+ * @return {Number} The current second.
+ */
+pub.second = function() {
+  return (new Date()).getSeconds();
+};
+
+
+/**
+ * @description Returns the number of milliseconds (thousandths of a second) since starting an applet.
+ *
+ * @cat    Environment
+ * @subcat Date
+ * @method millis
+ * @return {Number} The current milli.
+ */
+pub.millis = function() {
+  return Date.now() - startTime;
+};
+
+
+/**
+ * @description The millisecond() function differs from millis(), in that it returns the exact millisecond (thousandths of a second) of the current time.
+ *
+ * @cat    Environment
+ * @subcat Date
+ * @method millisecond
+ * @return {Number} The current millisecond.
+ */
+pub.millisecond = function() {
+  return (new Date()).getMilliseconds();
+};
+
+
+/**
+ * @description The timestamp() function returns the current date formatted as YYYYMMDD_HHMMSS for useful unique filenaming.
+ *
+ * @cat    Environment
+ * @subcat Date
+ * @method timestamp
+ * @return {String} The current time in YYYYMMDD_HHMMSS.
+ */
+pub.timestamp = function() {
+  var dt = new Date();
+  var dtf = dt.getFullYear();
+  dtf += pub.nf(dt.getMonth() + 1, 2);
+  dtf += pub.nf(dt.getDate(), 2);
+  dtf += "_";
+  dtf += pub.nf(dt.getHours(), 2);
+  dtf += pub.nf(dt.getMinutes(), 2);
+  dtf += pub.nf(dt.getSeconds(), 2);
+  return dtf;
+};
+
+
+  basil.js was conceived and is generously supported by
+  The Visual Communication Institute / The Basel School of Design
+  Department of the Academy of Art and Design Basel (HGK FHNW)
+
+  http://thebaselschoolofdesign.ch
+
+  Please note: Big general parts e.g. random() of the basil.js source code are copied
+  from processing.js by the Processing.js team. We would have had a hard time
+  to figure all of that out on our own!
+// ----------------------------------------
+// src/includes/data.js
+// ----------------------------------------
+
+pub.JSON = {
+  /**
+   * @description Function parses and validates a string as JSON-object. Usage:<br>
+   * var obj = JSON.decode(str);
+   * var str = JSON.encode(obj);
+   *
+   * @cat    Data
+   * @subcat JSON
+   * @method JSON.decode
+   * @param  {String} String to be parsed as JSON-object.
+   * @return {Object} Returns JSON-object or throws an error if invalid JSON has been provided.
+  */
+  // From: jQuery JavaScript Library v1.7.1 http://jquery.com/
+  decode: function(data) {
+    if (typeof data !== "string" || !data) {
+      return null;
+    }
+    var rvalidchars = /^[\],:{}\s]*$/,
+      rvalidescape = /\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g,
+      rvalidtokens = /"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g,
+      rvalidbraces = /(?:^|:|,)(?:\s*\[)+/g;
+
+    // Make sure the incoming data is actual JSON
+    // Logic borrowed from http://json.org/json2.js
+    if (rvalidchars.test(data.replace(rvalidescape, "@")
+      .replace(rvalidtokens, "]")
+      .replace(rvalidbraces, ""))) {
+      return (new Function("return " + data))();
+    }
+    error("JSON.decode(), invalid JSON: " + data);
+  },
+  /**
+   * Function convert an javascript object to a JSON-string. Usage:<br>
+   * var str = JSON.encode(obj);
+   * var obj = JSON.decode(str);
+   *
+   * @cat    Data
+   * @subcat JSON
+   * @method JSON.encode
+   * @param  {Object} Object to be converted to a JSON-string
+   * @return {String} Returns JSON-string
+   */
+  // From: https://gist.github.com/754454
+  encode: function(obj) {
+    var t = typeof (obj);
+    if (t !== "object" || obj === null) {
+      // simple data type
+      if (t === "string") obj = "\"" + obj + "\"";
+      return String(obj);
+    } else {
+      // recurse array or object
+      var n, v, json = [], arr = (obj && obj.constructor === Array);
+
+      for (n in obj) {
+        v = obj[n];
+        t = typeof (v);
+        if (obj.hasOwnProperty(n)) {
+          if (t === "string") v = "\"" + v + "\""; else if (t === "object" && v !== null) v = pub.JSON.encode(v);
+          json.push((arr ? "" : "\"" + n + "\":") + String(v));
+        }
+      }
+      return (arr ? "[" : "{") + String(json) + (arr ? "]" : "}");
+    }
+  }
+};
+
+// Taken and hijacked from d3.js robust csv parser. Hopefully Michael Bostock won't mind.
+// https://github.com/mbostock/d3/tree/master/src/dsv
+pub.CSV = new CSV();
+function CSV() {
+  var reParse = null,
+    reFormat = null,
+    delimiterStr = null,
+    delimiterCode = null;
+
+  initDelimiter(",");
+  function initDelimiter(delimiter) {
+    reParse = new RegExp("\r\n|[" + delimiter + "\r\n]", "g"), // field separator regex
+    reFormat = new RegExp("[\"" + delimiter + "\n]"),
+    delimiterCode = delimiter.charCodeAt(0);
+    delimiterStr = delimiter;
+  }
+
+  /**
+   * @description Sets the delimiter of the CSV decode and encode function.
+   *
+   * @cat    Data
+   * @subcat CSV
+   * @method CSV.delimiter
+   * @param  {String} [delimiter] Optional Sets the delimiter for CSV parsing
+   * @return {String} Returns the current delimiter if called without argument
+  */
+  this.delimiter = function(delimiter) {
+    if (arguments.length === 0) return delimiterStr;
+    if (typeof delimiter === "string") {
+      initDelimiter(delimiter);
+    } else {
+      error("CSV.delimiter, separator has to be a character or string");
+    }
+  };
+
+  /**
+   * @description Function parses a string as CSV-object Array. Usage:<br>
+   * var arr = CSV.decode(str);
+   * var str = CSV.encode(arr);
+   *
+   * @cat    Data
+   * @subcat CSV
+   * @method CSV.decode
+   * @param  {String} String to be parsed as CSV-object.
+   * @return {Array} Returns CSV-object Array
+  */
+  this.decode = function(text) {
+    var header;
+    return parseRows(text, function(row, i) {
+      if (i) {
+        var o = {}, j = -1, m = header.length;
+        while (++j < m) o[header[j]] = row[j];
+        return o;
+      } else {
+        header = row;
+        return null;
+      }
+    });
+  };
+
+  /**
+   * @description Function convert an javascript array of objects to a CSV-string. Usage:<br>
+   * var str = CSV.encode(arr);
+   * var arr = CSV.decode(str);
+   *
+   * @cat    Data
+   * @subcat CSV
+   * @method CSV.encode
+   * @param  {Array} Array to be converted to a CSV-string
+   * @return {String} Returns CSV-string
+   */
+  this.encode = function(rows) {
+    var csvStrings = [];
+    var header = [];
+    var firstRow = rows[0]; // all rows have to have the same properties keys
+    // gather infos for the header
+    for (var propname in firstRow) {
+      if (firstRow.hasOwnProperty(propname)) {
+        header.push(propname);
+      }
+    }
+    csvStrings.push(formatRow(header));
+    for (var i = 0; i < rows.length; i++) {
+      var row = rows[i];
+      var tokens = [];
+      for (var ii = 0; ii < header.length; ii++) {
+        tokens.push(row[header[ii]]);
+      }
+      csvStrings.push(formatRow(tokens));
+    }
+    return csvStrings.join("\n");
+  };
+
+  function formatRow(row) {
+    return row.map(formatValue).join(delimiterStr);
+  }
+
+  function formatValue(text) {
+    return reFormat.test(text) ? "\"" + text.replace(/\"/g, "\"\"") + "\"" : text;
+  }
+
+  function parseRows(text, f) {
+    var EOL = {}, // sentinel value for end-of-line
+      EOF = {}, // sentinel value for end-of-file
+      rows = [], // output rows
+      n = 0, // the current line number
+      t, // the current token
+      eol; // is the current token followed by EOL?
+
+    reParse.lastIndex = 0; // work-around bug in FF 3.6
+
+    function token() {
+      if (reParse.lastIndex >= text.length) return EOF; // special case: end of file
+      if (eol) { eol = false; return EOL; } // special case: end of line
+
+      // special case: quotes
+      var j = reParse.lastIndex;
+      if (text.charCodeAt(j) === 34) {
+        var i = j;
+        while (i++ < text.length) {
+          if (text.charCodeAt(i) === 34) {
+            if (text.charCodeAt(i + 1) !== 34) break;
+            i++;
+          }
+        }
+        reParse.lastIndex = i + 2;
+        var c = text.charCodeAt(i + 1);
+        if (c === 13) {
+          eol = true;
+          if (text.charCodeAt(i + 2) === 10) reParse.lastIndex++;
+        } else if (c === 10) {
+          eol = true;
+        }
+        return text.substring(j + 1, i).replace(/""/g, "\"");
+      }
+
+      // common case
+      var m = reParse.exec(text);
+      if (m) {
+        eol = m[0].charCodeAt(0) !== delimiterCode;
+        return text.substring(j, m.index);
+      }
+      reParse.lastIndex = text.length;
+      return text.substring(j);
+    }
+
+    while ((t = token()) !== EOF) {
+      var a = [];
+      while (t !== EOL && t !== EOF) {
+        a.push(t);
+        t = token();
+      }
+      if (f && !(a = f(a, n++))) continue;
+      rows.push(a);
+    }
+
+    return rows;
+  }
+}
+
+// -- Conversion --
+
+
+/**
+ * @description Converts a byte, char, int, or color to a String containing the
+ * equivalent binary notation. For example color(0, 102, 153, 255)
+ * will convert to the String "11111111000000000110011010011001". This
+ * function can help make your geeky debugging sessions much happier.
+ *
+
+ * @cat    Data
+ * @subcat Conversion
+ * @method binary
+ * @param  {Number} num value to convert
+ * @param  {Number} [numBits] number of digits to return
+ * @return {String} A formatted string
+ */
+ // From: http://processingjs.org/reference/binary_/
+pub.binary = function(num, numBits) {
+  var bit;
+  if (numBits > 0) bit = numBits;
+  else if (num instanceof Char) {
+    bit = 16;
+    num |= 0;
+  } else {
+    bit = 32;
+    while (bit > 1 && !(num >>> bit - 1 & 1)) bit--;
+  }
+  var result = "";
+  while (bit > 0) result += num >>> --bit & 1 ? "1" : "0";
+  return result;
+};
+
+/**
+ * @description Converts a String representation of a binary number to its
+ * equivalent integer value. For example, unbinary("00001000") will
+ * return 8.
+ *
+ * @cat    Data
+ * @subcat Conversion
+ * @method unbinary
+ * @param  {String} binaryString value to convert
+ * @return {Number} The integer representation
+ */
+ // From: http://processingjs.org/reference/unbinary_/
+pub.unbinary = function(binaryString) {
+  var i = binaryString.length - 1,
+    mask = 1,
+    result = 0;
+  while (i >= 0) {
+    var ch = binaryString[i--];
+    if (ch !== "0" && ch !== "1") throw "the value passed into unbinary was not an 8 bit binary number";
+    if (ch === "1") result += mask;
+    mask <<= 1;
+  }
+  return result;
+};
+
+
+var decimalToHex = function(d, padding) {
+  padding = padding === undefined || padding === null ? padding = 8 : padding;
+  if (d < 0) d = 4294967295 + d + 1;
+  var hex = Number(d).toString(16).toUpperCase();
+  while (hex.length < padding) hex = "0" + hex;
+  if (hex.length >= padding) hex = hex.substring(hex.length - padding, hex.length);
+  return hex;
+};
+
+/**
+ * @description Convert a number to a hex representation.
+ *
+ * @cat    Data
+ * @subcat Conversion
+ * @method hex
+ * @param  {Number} value The number to convert
+ * @param  {Number} [len] The length of the hex number to be created, default: 8
+ * @return {String} The hex representation as a string
+ */
+pub.hex = function(value, len) {
+  if (arguments.length === 1) len = 8;
+  return decimalToHex(value, len);
+};
+
+var unhexScalar = function(hex) {
+  var value = parseInt("0x" + hex, 16);
+  if (value > 2147483647) value -= 4294967296;
+  return value;
+};
+
+/**
+ * @description Convert a hex representation to a number.
+ *
+ * @cat    Data
+ * @subcat Conversion
+ * @method unhex
+ * @param  {String} hex The hex representation
+ * @return {Number} The number
+ */
+pub.unhex = function(hex) {
+  if (hex instanceof Array) {
+    var arr = [];
+    for (var i = 0; i < hex.length; i++) arr.push(unhexScalar(hex[i]));
+    return arr;
+  }
+  return unhexScalar(hex);
+};
+
+
+// -- String Functions --
+
+
+
+/**
+ * @description Removes multiple, leading or trailing spaces and punctuation from "words". E.g. converts "word!" to "word". Especially useful together with words();
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method trimWord
+ * @param  {String} s The String to trim
+ * @return {String} The trimmed string
+ */
+ // from: https://stackoverflow.com/a/25575009/3399765
+pub.trimWord = function(s) {
+  s = s.replace(/\s*/g, "")
+       .replace(/\n*/g, "")
+       .replace(/(^[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]*)|([\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]*$)/gi, "");
+  return s;
+};
+
+/**
+ * @description Combines an array of Strings into one String, each separated by
+ * the character(s) used for the separator parameter. To join arrays
+ * of ints or floats, it's necessary to first convert them to strings
+ * using nf() or nfs().
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method join
+ * @param  {Array} array A string array
+ * @param  {String} separator The separator to be inserted
+ * @return {String} The joined string
+ */
+ // http://processingjs.org/reference/join_/
+pub.join = function(array, separator) {
+  return array.join(separator);
+};
+
+/**
+ * @description The split() function breaks a string into pieces using a
+ * character or string as the divider. The delim parameter specifies the
+ * character or characters that mark the boundaries between each piece. A
+ * String[] array is returned that contains each of the pieces.
+ * <br><br>
+ * If the result is a set of numbers, you can convert the String[] array
+ * to to a float[] or int[] array using the datatype conversion functions
+ * int() and float() (see example above).
+ * <br><br>
+ * The splitTokens() function works in a similar fashion, except that it
+ * splits using a range of characters instead of a specific character or
+ * sequence.
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method split
+ * @param  {String} str the String to be split
+ * @param  {String} [delim] The string used to separate the data
+ * @return {Array} Array of strings
+ */
+ // http://processingjs.org/reference/split_/
+pub.split = function(str, delim) {
+  return str.split(delim);
+};
+
+/**
+ * @description The splitTokens() function splits a String at one or many character
+ * "tokens." The tokens parameter specifies the character or characters
+ * to be used as a boundary.
+ * <br><br>
+ * If no tokens character is specified, any whitespace character is used
+ * to split. Whitespace characters include tab (\t), line feed (\n),
+ * carriage return (\r), form feed (\f), and space. To convert a String
+ * to an array of integers or floats, use the datatype conversion functions
+ * int() and float() to convert the array of Strings.
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method splitTokens
+ * @param  {String} str the String to be split
+ * @param  {String} [tokens] list of individual characters that will be used as separators
+ * @return {Array} Array of strings
+ */
+ // From: http://processingjs.org/reference/splitTokens_/
+pub.splitTokens = function(str, tokens) {
+  if (arguments.length === 1) tokens = "\n\t\r\u000c ";
+  tokens = "[" + tokens + "]";
+  var ary = [];
+  var index = 0;
+  var pos = str.search(tokens);
+  while (pos >= 0) {
+    if (pos === 0) str = str.substring(1);
+    else {
+      ary[index] = str.substring(0, pos);
+      index++;
+      str = str.substring(pos);
+    }
+    pos = str.search(tokens);
+  }
+  if (str.length > 0) ary[index] = str;
+  if (ary.length === 0) ary = undefined;
+  return ary;
+};
+
+
+pub.match = function(str, regexp) {
+  return str.match(regexp);
+};
+
+
+pub.matchAll = function(aString, aRegExp) {
+  var results = [],
+    latest;
+  var regexp = new RegExp(aRegExp, "g");
+  while ((latest = regexp.exec(aString)) !== null) {
+    results.push(latest);
+    if (latest[0].length === 0)++regexp.lastIndex;
+  }
+  return results.length > 0 ? results : null;
+};
+
+function nfCoreScalar(value, plus, minus, leftDigits, rightDigits, group) {
+  var sign = value < 0 ? minus : plus;
+  var autoDetectDecimals = rightDigits === 0;
+  var rightDigitsOfDefault = rightDigits === undefined || rightDigits < 0 ? 0 : rightDigits;
+  var absValue = Math.abs(value);
+  if (autoDetectDecimals) {
+    rightDigitsOfDefault = 1;
+    absValue *= 10;
+    while (Math.abs(Math.round(absValue) - absValue) > 1.0E-6 && rightDigitsOfDefault < 7) {
+      ++rightDigitsOfDefault;
+      absValue *= 10;
+    }
+  } else if (rightDigitsOfDefault !== 0) absValue *= Math.pow(10, rightDigitsOfDefault);
+  var number, doubled = absValue * 2;
+  if (Math.floor(absValue) === absValue) number = absValue;
+  else if (Math.floor(doubled) === doubled) {
+    var floored = Math.floor(absValue);
+    number = floored + floored % 2;
+  } else number = Math.round(absValue);
+  var buffer = "";
+  var totalDigits = leftDigits + rightDigitsOfDefault;
+  while (totalDigits > 0 || number > 0) {
+    totalDigits--;
+    buffer = "" + number % 10 + buffer;
+    number = Math.floor(number / 10);
+  }
+  if (group !== undefined) {
+    var i = buffer.length - 3 - rightDigitsOfDefault;
+    while (i > 0) {
+      buffer = buffer.substring(0, i) + group + buffer.substring(i);
+      i -= 3;
+    }
+  }
+  if (rightDigitsOfDefault > 0) return sign + buffer.substring(0, buffer.length - rightDigitsOfDefault) + "." + buffer.substring(buffer.length - rightDigitsOfDefault, buffer.length);
+  return sign + buffer;
+}
+function nfCore(value, plus, minus, leftDigits, rightDigits, group) {
+  if (value instanceof Array) {
+    var arr = [];
+    for (var i = 0, len = value.length; i < len; i++) arr.push(nfCoreScalar(value[i], plus, minus, leftDigits, rightDigits, group));
+    return arr;
+  }
+  return nfCoreScalar(value, plus, minus, leftDigits, rightDigits, group);
+}
+
+/**
+ * @description Utility function for formatting numbers into strings. There
+ * are two versions, one for formatting floats and one for formatting
+ * ints. The values for the digits, left, and right parameters should
+ * always be positive integers.
+ * <br><br>
+ * As shown in the above example, nf() is used to add zeros to the
+ * left and/or right of a number. This is typically for aligning a list
+ * of numbers. To remove digits from a floating-point number, use the
+ * int(), ceil(), floor(), or round() functions.
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method nf
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
+ * @return {String} The formatted string
+ */
+ // From: http://processingjs.org/reference/nf_/
+pub.nf = function(value, leftDigits, rightDigits) {
+  return nfCore(value, "", "-", leftDigits, rightDigits);
+};
+
+/**
+ * @description Utility function for formatting numbers into strings. Similar to nf()
+ * but leaves a blank space in front of positive numbers so they align
+ * with negative numbers in spite of the minus symbol. There are two
+ * versions, one for formatting floats and one for formatting ints. The
+ * values for the digits, left, and right parameters should always be
+ * positive integers.
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method nfs
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
+ * @return {String} The formatted string
+ */
+ // From: http://processingjs.org/reference/nfs_/
+pub.nfs = function(value, leftDigits, rightDigits) {
+  return nfCore(value, " ", "-", leftDigits, rightDigits);
+};
+
+/**
+ * @description Utility function for formatting numbers into strings. Similar to nf()
+ * but puts a "+" in front of positive numbers and a "-" in front of
+ * negative numbers. There are two versions, one for formatting floats
+ * and one for formatting ints. The values for the digits, left, and right
+ * parameters should always be positive integers.
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method nfp
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
+ * @return {String} The formatted string
+ */
+ // From: http://processingjs.org/reference/nfp_/
+pub.nfp = function(value, leftDigits, rightDigits) {
+  return nfCore(value, "+", "-", leftDigits, rightDigits);
+};
+
+/**
+ * @description Utility function for formatting numbers into strings and placing
+ * appropriate commas to mark units of 1000. There are two versions, one
+ * for formatting ints and one for formatting an array of ints. The value
+ * for the digits parameter should always be a positive integer.
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method nfc
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
+ * @return {String} The formatted string
+ */
+ // From: http://processingjs.org/reference/nfc_/
+pub.nfc = function(value, leftDigits, rightDigits) {
+  return nfCore(value, "", "-", leftDigits, rightDigits, ",");
+};
+
+
+/**
+ * @description Removes whitespace characters from the beginning and end of a String.
+ * In addition to standard whitespace characters such as space, carriage
+ * return, and tab, this function also removes the Unicode "nbsp" character.
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method trim
+ * @param  {String|Array} str A string or an array of strings to be trimmed
+ * @return {String|Array} Returns the input in a trimmed way
+ */
+ // From: http://processingjs.org/reference/trim_/
+pub.trim = function(str) {
+  if (str instanceof Array) {
+    var arr = [];
+    for (var i = 0; i < str.length; i++) arr.push(str[i].replace(/^\s*/, "").replace(/\s*$/, "").replace(/\r*$/, ""));
+    return arr;
+  }
+  return str.replace(/^\s*/, "").replace(/\s*$/, "").replace(/\r*$/, "");
+};
+
+/**
+ * @description Checks whether an URL string is valid.
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method isURL
+ * @param  {String} url An url string to be checked
+ * @return {Boolean} Returns either true or false
+ */
+var isURL = pub.isURL = function(url) {
+  var pattern = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
+  return pattern.test(url);
+};
+
+/**
+ * @description Checks whether a string ends with a specific character or string.
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method endsWith
+ * @param  {String} str A string to be checked
+ * @param  {String} suffix The string to look for
+ * @return {Boolean} Returns either true or false
+ */
+var endsWith = pub.endsWith = function(str, suffix) {
+  if(!isString(str) || !isString(suffix)) {
+    error("endsWith() requires two strings, the string to be checked and the suffix to look for.");
+  }
+  return str.indexOf(suffix, str.length - suffix.length) !== -1;
+};
+
+/**
+ * @description Checks whether a string starts with a specific character or string.
+ *
+ * @cat    Data
+ * @subcat String Functions
+ * @method startsWith
+ * @param  {String} str A string to be checked
+ * @param  {String} prefix The string to look for
+ * @return {Boolean} Returns either true or false
+ */
+var startsWith = pub.startsWith = function(str, prefix) {
+  if(!isString(str) || !isString(prefix)) {
+    error("startsWith() requires two strings, the string to be checked and the prefix to look for.");
+  }
+  return str.indexOf(prefix) === 0;
+};
+
+
+/**
+ * @description Checks whether a var is an Array, returns true if this is the case
+ *
+ * @cat    Data
+ * @subcat Type-Check
+ * @method isArray
+ * @param  {Object|String|Number|Boolean} obj The object to check
+ * @return {Boolean} returns true if this is the case
+ */
+var isArray = pub.isArray = function(obj) {
+  return Object.prototype.toString.call(obj) === "[object Array]";
+};
+
+/**
+ * @description Checks whether a var is a number, returns true if this is the case
+ *
+ * @cat    Data
+ * @subcat Type-Check
+ * @method isNumber
+ * @param  {Object|String|Number|Boolean}  num The number to check
+ * @return {Boolean} returns true if this is the case
+ */
+var isNumber = pub.isNumber = function(num) {
+  if (num === null) {
+    return false;
+  }
+  if (isNaN(num)) {
+    return false;
+  }
+  return isFinite(num) && num.constructor.name === "Number";
+};
+
+
+/**
+ * @description Checks whether a var is an integer, returns true if this is the case.
+ *
+ * @cat    Data
+ * @subcat Type-Check
+ * @method isInteger
+ * @param  {Object|String|Number|Boolean}  num The number to check.
+ * @return {Boolean} Returns true if the given argument is an integer.
+ */
+var isInteger = pub.isInteger = function(num) {
+  return Object.prototype.toString.call(num) === "[object Number]" && num % 1 === 0;
+};
+
+/**
+ * @description Checks whether a var is a string, returns true if this is the case
+ *
+ * @cat    Data
+ * @subcat Type-Check
+ * @method isString
+ * @param  {Object|String|Number|Boolean} str The string to check
+ * @return {Boolean} returns true if this is the case
+ */
+var isString = pub.isString = function(str) {
+  return Object.prototype.toString.call(str) === "[object String]";
+};
+
+/**
+ * @description Checks whether a var is an InDesign text object, returns true if this is the case
+ * NB: a InDesign TextFrame will return false as it is just a container holding text.
+ * So you could say that isText() refers to all the things inside a TextFrame.
+ *
+ * @cat    Document
+ * @subcat Type-Check
+ * @method isText
+ * @param  {Character|InsertionPoint|Line|Paragraph|TextColumn|TextStyleRange|Word}  obj The object to check
+ * @return {Boolean} returns true if this is the case
+ */
+var isText = pub.isText = function(obj) {
+
+  return obj instanceof Character ||
+         obj instanceof InsertionPoint ||
+         obj instanceof Word ||
+         obj instanceof Line ||
+         obj instanceof TextStyleRange ||
+         obj instanceof Paragraph ||
+         obj instanceof TextColumn ||
+         obj instanceof Text ||
+         obj.constructor.name === "Characters" ||
+         obj.constructor.name === "InsertionPoints" ||
+         obj.constructor.name === "Words" ||
+         obj.constructor.name === "Lines" ||
+         obj.constructor.name === "TextStyleRanges" ||
+         obj.constructor.name === "Paragraphs" ||
+         obj.constructor.name === "TextColumns";
+};
+
+
+var initDataFile = function(file) {
+
+  if(!(isString(file) || file instanceof File)) {
+    error(getParentFunctionName(1) + "(), invalid first argument. Use File or a String describing a file path.");
+  }
+
+  var result = null;
+  if (file instanceof File) {
+    result = file;
+  } else {
+    result = new File(pub.projectFolder().absoluteURI + "/data/" + file);
+  }
+  if (!result.exists) {
+    error(getParentFunctionName(1) + "(), could not load file. The file \"" + result + "\" does not exist.");
+  }
+  return result;
+};
+
+var initExportFile = function(file) {
+
+  if(!(isString(file) || file instanceof File)) {
+    error(getParentFunctionName(1) + "(), invalid first argument. Use File or a String describing a file path.");
+  }
+
+  var result, tmpPath = null;
+  var isFile = file instanceof File;
+  var filePath = isFile ? file.absoluteURI : file;
+
+  // if parent folder already exists, the rest can be skipped
+  if(isFile && File(filePath).parent.exists) {
+    // remove file as in some circumstances file cannot be overwritten
+    // (if file is on top level outside user folder)
+    // also improves performance considerably
+    File(filePath).remove();
+    return File(filePath);
+  }
+
+  // clean up string path
+  if((!isFile) && filePath[0] !== "~") {
+    if(filePath[0] !== "/") {
+      filePath = "/" + filePath;
+    }
+    // check if file path is a relative URI ( /Users/username/examples/... )
+    // if so, turn it into an absolute URI ( ~/examples/... )
+    var userRelURI = Folder("~").relativeURI;
+    if(startsWith(filePath, userRelURI)) {
+      filePath = "~" + filePath.substring(userRelURI.length);
+    }
+  }
+
+  // clean up path and convert to array
+  var pathNormalized = filePath.split("/");
+  for (var i = 0; i < pathNormalized.length; i++) {
+    if (pathNormalized[i] === "" || pathNormalized[i] === ".") {
+      pathNormalized.splice(i, 1);
+    }
+  }
+
+  if(filePath[0] === "~") {
+    tmpPath = "~";
+    pathNormalized.splice(0, 1);
+  } else if (isFile) {
+    // file objects that are outside the user folder
+    tmpPath = "";
+  } else {
+    // string paths relative to the project folder
+    tmpPath = pub.projectFolder().absoluteURI;
+  }
+  var fileName = pathNormalized[pathNormalized.length - 1];
+
+  // does the path contain folders? if not, create them ...
+  if (pathNormalized.length > 1) {
+    var folders = pathNormalized.slice(0, -1);
+    for (var i = 0; i < folders.length; i++) {
+      tmpPath += "/" + folders[i];
+      var f = new Folder(tmpPath);
+      if (!f.exists) {
+        f.create();
+
+        if(!f.exists) {
+          // in some cases, folder creation does not throw an error, yet folder does not exist
+          error(getParentFunctionName(1) + "(), folder \"" + tmpPath + "\" could not be created.\n\n" +
+            "InDesign cannot create top level folders outside the user folder. If you are trying to write to such a folder, first create it manually.");
+        }
+      }
+    }
+  }
+
+  if(File(tmpPath + "/" + fileName).exists) {
+    // remove existing file to avoid save errors
+    File(tmpPath + "/" + fileName).remove();
+  }
+
+  return File(tmpPath + "/" + fileName);
+};
+
+/**
+ * @description Get the folder of the active document as a Folder object. Use .absoluteURI to access a string representation of the folder path.
+ *
+ * @cat    Document
+ * @subcat Misc
+ * @method projectFolder
+ * @return {Folder} The folder of the the active document
+ */
+pub.projectFolder = function() {
+  if(!currentDoc().saved) {
+    error("The current document must be saved before its project directory can be accessed.");
+  }
+  return currentDoc().filePath;
+};
+
+
+/**
+ * @description Executes a shell command and returns the result, currently Mac only.
+ * <br><br>
+ * BE CAREFUL!
+ *
+ * @cat    Data
+ * @subcat Input
+ * @method shellExecute
+ * @param  {String} cmd The shell command to execute
+ * @return {String}
+ */
+pub.shellExecute = function(cmd) {
+  if (Folder.fs === "Macintosh") {
+    try {
+      return app.doScript("return do shell script item 1 of arguments", ScriptLanguage.applescriptLanguage, [cmd]);
+    } catch (e) {
+      error("shellExecute(): " + e);
+    }
+  } else {
+    error("shellExecute() is a Mac only feature at the moment. Sorry!");
+  }
+};
+
+/**
+ * @description Reads the contents of a file or loads an URL into a String.
+ * If the file is specified by name as String, it must be located in the document's data directory.
+ *
+ * @cat    Data
+ * @subcat Input
+ * @method loadString
+ * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
+ * @return {String}  String file or URL content.
+ */
+pub.loadString = function(file) {
+  if (isURL(file)) {
+    return getURL(file);
+  } else {
+    var inputFile = initDataFile(file),
+      data = null;
+    inputFile.open("r");
+    data = inputFile.read();
+    inputFile.close();
+    return data;
+  }
+};
+
+var getURL = function(url) {
+  if (isURL(url)) {
+    if (Folder.fs === "Macintosh") {
+      return pub.shellExecute("curl -m 15 -L '" + url + "'");
+    } else {
+      error(getParentFunctionName(1) + "(), loading of strings via an URL is a Mac only feature at the moment. Sorry!");
+    }
+  } else {
+    error(getParentFunctionName(1) + "(), the url " + url + " is invalid. Please double check!");
+  }
+};
+
+/**
+ * @description Reads the contents of a file or loads an URL and creates a String array of its individual lines.
+ * If the file is specified by name as String, it must be located in the document's data directory.
+ *
+ * @cat    Data
+ * @subcat Input
+ * @method loadStrings
+ * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
+ * @return {Array}  Array of the individual lines in the given File or URL
+ */
+pub.loadStrings = function(file) {
+  if (isURL(file)) {
+    var result = getURL(file);
+    return result.match(/[^\r\n]+/g);
+  } else {
+    var inputFile = initDataFile(file),
+      result = [];
+    inputFile.open("r");
+    while (!inputFile.eof) {
+      result.push(inputFile.readln());
+    }
+    inputFile.close();
+    return result;
+  }
+};
+
+
+// ----------------------------------------
+// Output
+
+/**
+ * @description Prints a message line to the console output in the ExtendScript editor.
+ *
+ * @cat Output
+ * @method println
+ * @param {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
+ */
+var println = pub.println = function() {
+  var msg = Array.prototype.slice.call(arguments).join(" ");
+  $.writeln(msg);
+  if (progressPanel)
+    progressPanel.writeMessage(msg + "\n");
+};
+
+/**
+ * @description Prints a message to the console output in the ExtendScript editor, but unlike println() it doesn't return the carriage to a new line at the end.
+ *
+ * @cat    Output
+ * @method print
+ * @param  {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
+ */
+pub.print = function() {
+  var msg = Array.prototype.slice.call(arguments).join(" ");
+  $.write(msg);
+  if (progressPanel)
+    progressPanel.writeMessage(msg);
+};
+
+/**
+ * @description Print numerous information about the current environment to the console
+ *
+ * @cat    Output
+ * @method printInfo
+ */
+pub.printInfo = function() {
+
+  pub.println("###");
+  pub.println("OS: " + $.os);
+  pub.println("ExtendScript Build: " + $.build);
+  pub.println("ExtendScript Version:" + $.version);
+  pub.println("Engine: " + $.engineName);
+  pub.println("memCache: " + $.memCache + " bytes");
+  pub.println("###");
+
+};
+
+/**
+ * @description Writes an array of strings to a file, one line per string.
+ * If the given file exists it gets overridden.
+ *
+ * @cat    Output
+ * @method saveStrings
+ * @param  {String|File} file The file name or a File instance
+ * @param  {Array} strings The string array to be written
+ * @return {File} The file the strings were written to.
+ */
+pub.saveStrings = function(file, strings) {
+  if(!isArray(strings)) {
+    error("saveStrings(), invalid second argument. Use an array of strings.");
+  }
+  var outputFile = initExportFile(file);
+  outputFile.open("w");
+  outputFile.lineFeed = Folder.fs === "Macintosh" ? "Unix" : "Windows";
+  outputFile.encoding = "UTF-8";
+  forEach(strings, function(s) {
+    outputFile.writeln(s);
+  });
+  outputFile.close();
+  return outputFile;
+};
+
+/**
+ * @description Writes a string to a file.
+ * If the given file exists it gets overridden.
+ *
+ * @cat    Output
+ * @method saveString
+ * @param  {String|File} file The file name or a File instance.
+ * @param  {String} string The string to be written.
+ * @return {File} The file the string was written to.
+ */
+pub.saveString = function(file, string) {
+  if(!isString(string)) {
+    error("saveString(), invalid second argument. Use a string.");
+  }
+  var outputFile = initExportFile(file);
+  outputFile.open("w");
+  outputFile.lineFeed = Folder.fs === "Macintosh" ? "Unix" : "Windows";
+  outputFile.encoding = "UTF-8";
+  outputFile.write(string);
+  outputFile.close();
+  return outputFile;
+};
+
+/**
+ * @description Exports the current document as PDF to the documents folder. Please note, that export options default to the last used export settings.
+ *
+ * @cat    Output
+ * @method savePDF
+ * @param  {String|File} file The file name or a File instance.
+ * @param  {Boolean} [showOptions] Whether to show the export dialog.
+ * @return {File} The exported PDF file.
+ */
+pub.savePDF = function(file, showOptions) {
+  var outputFile = initExportFile(file);
+  if (showOptions !== true) showOptions = false;
+  try{
+    var myPDF = currentDoc().exportFile(ExportFormat.PDF_TYPE, outputFile, showOptions);
+  } catch(e) {
+    error("savePDF(), PDF could not be saved. Possibly you are trying to save to a write protected location.\n\n" +
+      "InDesign cannot create top level folders outside the user folder. If you are trying to write to such a folder, first create it manually.");
+  }
+  return outputFile;
+};
+
+/**
+ * @description Exports the current document as PNG (or sequence of PNG files) to the documents folder. Please note, that export options default to the last used export settings.
+ *
+ * @cat    Output
+ * @method savePNG
+ * @param  {String|File} file The file name or a File instance
+ * @param  {Boolean} [showOptions] Whether to show the export dialog
+ * @return {File} The exported PNG file.
+ */
+pub.savePNG = function(file, showOptions) {
+  var outputFile = initExportFile(file);
+  if (showOptions !== true) showOptions = false;
+  try{
+    currentDoc().exportFile(ExportFormat.PNG_FORMAT, outputFile, showOptions);
+  } catch(e) {
+    error("savePNG(), PNG could not be saved. Possibly you are trying to save to a write protected location.\n\n" +
+      "InDesign cannot create top level folders outside the user folder. If you are trying to write to such a folder, first create it manually.");
+  }
+  return outputFile;
+};
+
+/**
+ * @description Downloads an URL to a file, currently Mac only.
+ *
+ * @cat    Output
+ * @method download
+ * @param  {String} url The download url
+ * @param  {String|File} [file] A relative file path in the project folder or a File instance
+ */
+pub.download = function(url, file) {
+  var projPath = pub.projectFolder().fsName.replace(" ", "\\ ");
+  // var scriptPath = "~/Documents/basiljs/bundle/lib/download.sh";
+  // This is more portable then a fixed location
+  // the Script looks for the lib folder next to itself
+  var currentBasilFolderPath = File($.fileName).parent.fsName;
+  var scriptPath = currentBasilFolderPath + "/lib/download.sh";
+  if(File(scriptPath).exists === true) {
+    // the script is there. Great
+    scriptPath = File(scriptPath).fsName;
+  } else {
+    // if not lets create it on the fly
+    var scriptContent = [
+      "#!/bin/bash",
+      "mkdir -p \"$1\"",
+      "cd \"$1\"",
+      "if [ -z \"$3\" ]",
+      "  then",
+      "    # echo \"-O\"",
+      "    curl -L -O $2",
+      "  else",
+      "    # echo \"-o\"",
+      "    curl -L -o \"$3\" $2",
+      "fi"];
+    // check if the lib folder is there.
+    if(Folder(currentBasilFolderPath + "/lib").exists !== true) {
+      // no its not lets create ot
+      // should be functionalized
+      // will be needed for loop and stop.jsx as well
+      var res = Folder(currentBasilFolderPath + "/lib").create();
+      if(res === false) {
+        // ! Error creating folder :-(
+        // uh this should never happen
+        error("An error occurred while creating the \"/lib\" folder. Please report this issue");
+        return;
+      }
+    } // end of lib folder check
+    // the folder should be there.
+    // lets get it
+    var libFolder = Folder(currentBasilFolderPath + "/lib");
+    // now create the script file
+    var downloadScript = new File(libFolder.fsName + "/download.sh");
+    downloadScript.open("w", undefined, undefined);
+    // set encoding and linefeeds
+    downloadScript.lineFeed = "Unix";
+    downloadScript.encoding = "UTF-8";
+    downloadScript.write(scriptContent.join("\n"));
+    downloadScript.close();
+  } // end of file and folder creation
+
+  if (isURL(url)) {
+    var cmd = null;
+
+    if (file) {
+      if (file instanceof File) {
+        var downloadFolder = file.parent.fsName;
+        var fileName = file.displayName;
+        downloadFolder = downloadFolder.replace(" ", "\\ ");
+        fileName = fileName.replace(" ", "\\ ");
+        cmd = ["sh", scriptPath, downloadFolder, url, fileName].join(" ");
+
+      } else {
+        var downloadFolder = file.substr(0, file.lastIndexOf("/"));
+        var fileName = file.substr(file.lastIndexOf("/") + 1);
+
+        // get rif of some special cases
+        if(startsWith(downloadFolder, "./")) downloadFolder.substr(2);
+        if(startsWith(downloadFolder, "/")) downloadFolder.substr(1);
+
+        downloadFolder = downloadFolder.replace(" ", "\\ ");
+        fileName = fileName.replace(" ", "\\ ");
+        downloadFolder = projPath + "/data/" + downloadFolder;
+        cmd = ["sh", scriptPath, downloadFolder, url, fileName].join(" ");
+
+      }
+
+    } else {
+      var downloadFolder = projPath + "/data/download";
+      var cmd = ["sh", scriptPath, downloadFolder, url].join(" ");
+    }
+
+    println(cmd);
+    pub.shellExecute(cmd);
+
+  } else {
+    error("The url " + url + " is not a valid one. Please double check!");
+  }
+};
+
+
+
+// ----------------------------------------
+// src/includes/shape.js
+// ----------------------------------------
+
+/**
+ * @description Draws an ellipse (oval) in the display window. An ellipse with an equal width and height is a circle.
+ * The first two parameters set the location, the third sets the width, and the fourth sets the height.
+ *
+ * @cat    Document
+ * @subcat Primitives
+ * @method ellipse
+ * @param  {Number} x X-coordinate of the ellipse.
+ * @param  {Number} y Y-coordinate of the ellipse.
+ * @param  {Number} w Width of the ellipse.
+ * @param  {Number} h Height of the ellipse.
+ * @return {Oval} New Oval (in InDesign Scripting terms the corresponding type is Oval, not Ellipse).
+ */
+pub.ellipse = function(x, y, w, h) {
+  if (arguments.length !== 4) error("ellipse(), not enough parameters to draw an ellipse! Use: x, y, w, h");
+  var ellipseBounds = [];
+  if (currEllipseMode === pub.CORNER) {
+    ellipseBounds[0] = y;
+    ellipseBounds[1] = x;
+    ellipseBounds[2] = y + h;
+    ellipseBounds[3] = x + w;
+  } else if (currEllipseMode === pub.CORNERS) {
+    ellipseBounds[0] = y;
+    ellipseBounds[1] = x;
+    ellipseBounds[2] = h;
+    ellipseBounds[3] = w;
+  } else if (currEllipseMode === pub.CENTER) {
+    ellipseBounds[0] = y - (h / 2);
+    ellipseBounds[1] = x - (w / 2);
+    ellipseBounds[2] = y + (h / 2);
+    ellipseBounds[3] = x + (w / 2);
+  } else if (currEllipseMode === pub.RADIUS) {
+    ellipseBounds[0] = y - h;
+    ellipseBounds[1] = x - w;
+    ellipseBounds[2] = y + h;
+    ellipseBounds[3] = x + w;
+  }
+
+  if(w === 0 || h === 0)
+    {return false;}
+
+  var ovals = currentPage().ovals;
+  var newOval = ovals.add(currentLayer());
+
+  newOval.strokeWeight = currStrokeWeight;
+  newOval.strokeTint = currStrokeTint;
+  newOval.fillColor = currFillColor;
+  newOval.fillTint = currFillTint;
+  newOval.strokeColor = currStrokeColor;
+  newOval.geometricBounds = ellipseBounds;
+
+  if (currEllipseMode === pub.CENTER || currEllipseMode === pub.RADIUS) {
+    newOval.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
+                       AnchorPoint.CENTER_ANCHOR,
+                       currMatrix.adobeMatrix(x, y));
+  } else {
+    newOval.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
+                   AnchorPoint.TOP_LEFT_ANCHOR,
+                   currMatrix.adobeMatrix(x, y));
+  }
+  return newOval;
+};
+
+/**
+ * @description Draws a line (a direct path between two points) to the page.
+ *
+ * @cat    Document
+ * @subcat Primitives
+ * @method line
+ * @param  {Number} x1 X-coordinate of Point 1.
+ * @param  {Number} y1 Y-coordinate of Point 1.
+ * @param  {Number} x2 X-coordinate of Point 2.
+ * @param  {Number} y2 Y-coordinate of Point 2.
+ * @return {GraphicLine} New GraphicLine.
+ *
+ * @example
+ * var vec1 = new Vector( x1, y1 );
+ * var vec2 = new Vector( x2, y2 );
+ * line( vec1, vec2 );
+ */
+pub.line = function(x1, y1, x2, y2) {
+  if (arguments.length !== 4) {
+    error("line(), not enough parameters to draw a line! Use: x1, y1, x2, y2");
+  }
+  var lines = currentPage().graphicLines;
+  var newLine = lines.add(currentLayer());
+  newLine.strokeWeight = currStrokeWeight;
+  newLine.strokeTint = currStrokeTint;
+  newLine.fillColor = currFillColor;
+  newLine.fillTint = currFillTint;
+  newLine.strokeColor = currStrokeColor;
+  newLine.paths.item(0).entirePath = [[x1, y1], [x2, y2]];
+  newLine.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
+                   AnchorPoint.CENTER_ANCHOR,
+                   currMatrix.adobeMatrix( (x1 + x2) / 2, (y1 + y2) / 2 ));
+  return newLine;
+};
+
+/**
+ * @description Using the beginShape() and endShape() functions allows to create more complex forms.
+ * beginShape() begins recording vertices for a shape and endShape() stops recording.
+ * After calling the beginShape() function, a series of vertex() commands must follow.
+ * To stop drawing the shape, call endShape(). The shapeMode parameter allows to close the shape
+ * (to connect the beginning and the end).
+ *
+ * @cat    Document
+ * @subcat Primitives
+ * @method beginShape
+ * @param  {String} shapeMode Set to CLOSE if the new Path should be auto-closed.
+ */
+pub.beginShape = function(shapeMode) {
+  currVertexPoints = [];
+  currPathPointer = 0;
+  currPolygon = null;
+  if(typeof shapeMode != null) {
+    currShapeMode = shapeMode;
+  } else {
+    currShapeMode = null;
+  }
+};
+
+/**
+ * @description Shapes are constructed by connecting a series of vertices. vertex() is used to
+ * specify the vertex coordinates of lines and polygons. It is used exclusively between
+ * the beginShape() and endShape() functions.
+ * <br><br>
+ * Use either vertex(x, y) for drawing straight corners or
+ * vertex(x, y, xLeftHandle, yLeftHandle, xRightHandle, yRightHandle) for drawing bezier shapes.
+ * You can also mix the two approaches.
+ *
+ * @cat    Document
+ * @subcat Primitives
+ * @method vertex
+ * @param  {Number} x X-coordinate of the vertex.
+ * @param  {Number} y Y-coordinate of the vertex.
+ * @param  {Number} [xLeftHandle] X-coordinate of the left-direction point.
+ * @param  {Number} [yLeftHandle] Y-coordinate of the left-direction point.
+ * @param  {Number} [xRightHandle] X-coordinate of the right-direction point.
+ * @param  {Number} [yRightHandle] Y-coordinate of the right-direction point.
+ */
+pub.vertex = function() {
+  if (isArray(currVertexPoints)) {
+    if (arguments.length === 2) {
+      currVertexPoints.push([arguments[0], arguments[1]]);
+    } else if (arguments.length === 6) {
+      // [[xL1, YL1], [x1, y1], [xR1, yR1]]
+      currVertexPoints.push([[arguments[2], arguments[3]],
+                              [arguments[0], arguments[1]],
+                              [arguments[4], arguments[5]]]);
+    } else {
+      error("vertex(), wrong argument count: Please use either vertex(x, y) or vertex(x, y, xLeftHandle, yLeftHandle, xRightHandle, yRightHandle)!");
+    }
+  } else {
+    notCalledBeginShapeError();
+  }
+};
+
+/**
+ * @description The arc() function draws an arc. Arcs are drawn along the outer edge of an ellipse
+ * defined by the x, y, width and height parameters.
+ * The origin or the arc's ellipse may be changed with the ellipseMode() function.
+ * The start and stop parameters specify the angles at which to draw the arc.
+ *
+ * @cat    Document
+ * @subcat Primitives
+ * @method arc
+ * @param  {Number} cx X-coordinate of the arc's center.
+ * @param  {Number} cy Y-coordinate of the arc's center.
+ * @param  {Number} w Width of the arc's ellipse.
+ * @param  {Number} h Height of the arc's ellipse.
+ * @param  {Number} startAngle Starting angle of the arc in radians.
+ * @param  {Number} endAngle Ending angle of the arc in radians.
+ * @param  {String} [mode] Mode to define the rendering technique of the arc: OPEN (default), CHORD, or PIE.
+ * @return {GraphicLine|Polygon} The resulting GraphicLine or Polygon object (in InDesign Scripting terms the corresponding type is GraphicLine or Polygon, not Arc).
+ *
+ */
+pub.arc = function(cx, cy, w, h, startAngle, endAngle, mode) {
+  if (w <= 0 || endAngle < startAngle) {
+    return false;
+  }
+  if (arguments.length < 6) error("arc(), not enough parameters to draw an arc! Use: x, y, w, h, startAngle, endAngle");
+
+  var o = pub.radians(1); // add 1 degree to ensure angles of 360 degrees are drawn
+  startAngle %= pub.TWO_PI + o;
+  endAngle %= pub.TWO_PI + o;
+  w /= 2;
+  h /= 2;
+
+  if (currEllipseMode === pub.CORNER) {
+    cx = (cx - w);
+    cy = (cy + h);
+  }
+  else if (currEllipseMode === pub.CORNERS) {
+    // cx = (cx-w);
+    // cy = (cy-h);
+    // w -= cx;
+    // h -= cy;
+  }
+  else if (currEllipseMode === pub.RADIUS) {
+    w *= 2;
+    h *= 2;
+  }
+
+  var delta = pub.abs(endAngle - startAngle);
+  var direction = (startAngle < endAngle) ? 1 : -1;
+  var thetaStart = startAngle;
+
+  if(mode == pub.CHORD) {
+    pub.beginShape(pub.CLOSE);
+  }
+  else if(mode == pub.PIE) {
+    pub.beginShape(pub.CLOSE);
+    pub.vertex(cx, cy);
+  }
+  else {
+    pub.beginShape();
+  }
+  for (var theta = pub.min(pub.TWO_PI, delta); theta > pub.EPSILON;) {
+    var thetaEnd = thetaStart + direction * pub.min(theta, pub.HALF_PI);
+    var points = calculateEllipticalArc(w, h, thetaEnd, thetaStart);
+
+    pub.vertex(
+      cx + points.startx,
+      cy + points.starty,
+      cx + points.startx,
+      cy + points.starty,
+      cx + points.handle1x,
+      cy + points.handle1y
+    );
+    pub.vertex(
+      cx + points.endx,
+      cy + points.endy,
+      cx + points.handle2x,
+      cy + points.handle2y,
+      cx + points.endx,
+      cy + points.endy
+    );
+
+    theta -= pub.abs(thetaEnd - thetaStart);
+    thetaStart = thetaEnd;
+  }
+  return pub.endShape();
+};
+
+/*
+ * Cubic bezier approximation of a eliptical arc
+ *
+ * intial source code:
+ * Golan Levin
+ * golan@flong.com
+ * http://www.flong.com/blog/2009/bezier-approximation-of-a-circular-arc-in-processing/
+ *
+ * The solution is taken from this PDF by Richard DeVeneza:
+ * http://www.tinaja.com/glib/bezcirc2.pdf
+ * linked from this excellent site by Don Lancaster:
+ * http://www.tinaja.com/cubic01.asp
+ *
+ */
+function calculateEllipticalArc(w, h, startAngle, endAngle) {
+  var theta = (endAngle - startAngle);
+
+  var x0 = pub.cos(theta / 2.0);
+  var y0 = pub.sin(theta / 2.0);
+  var x3 = x0;
+  var y3 = 0 - y0;
+  var x1 = (4.0 - x0) / 3.0;
+  var y1 = ((1.0 - x0) * (3.0 - x0)) / (3.0 * y0);
+  var x2 = x1;
+  var y2 = 0 - y1;
+
+  var bezAng = startAngle + theta / 2.0;
+  var cBezAng = pub.cos(bezAng);
+  var sBezAng = pub.sin(bezAng);
+
+  return {
+    startx:   w * (cBezAng * x0 - sBezAng * y0),
+    starty:   h * (sBezAng * x0 + cBezAng * y0),
+    handle1x: w * (cBezAng * x1 - sBezAng * y1),
+    handle1y: h * (sBezAng * x1 + cBezAng * y1),
+
+    handle2x: w * (cBezAng * x2 - sBezAng * y2),
+    handle2y: h * (sBezAng * x2 + cBezAng * y2),
+    endx:     w * (cBezAng * x3 - sBezAng * y3),
+    endy:     h * (sBezAng * x3 + cBezAng * y3)
+  };
+}
+
+/**
+ * @description addPath() is used to create multi component paths. Call addPath() to add
+ * the vertices drawn so far to a single path. New vertices will then end up in a new path and
+ * endShape() will return a multi path object. All component paths will account for
+ * the setting (see CLOSE) given in beginShape(shapeMode).
+ *
+ * @cat    Document
+ * @subcat Primitives
+ * @method addPath
+ */
+pub.addPath = function() {
+  doAddPath();
+  currPathPointer++;
+};
+
+/**
+ * @description The endShape() function is the companion to beginShape() and may only be called
+ * after beginShape().
+ *
+ * @cat    Document
+ * @subcat Primitives
+ * @method endShape
+ * @return {GraphicLine|Polygon} The GraphicLine or Polygon object that was created.
+ */
+pub.endShape = function() {
+  doAddPath();
+  currPolygon.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
+                   AnchorPoint.TOP_LEFT_ANCHOR,
+                   currMatrix.adobeMatrix(currPolygon.geometricBounds[1], currPolygon.geometricBounds[0]));
+  return currPolygon;
+};
+
+function doAddPath() {
+  if (isArray(currVertexPoints)) {
+    if (currVertexPoints.length > 0) {
+
+      if(currPolygon === null) {
+        addPolygon();
+      } else {
+        currPolygon.paths.add();
+      }
+
+      currPolygon.paths.item(currPathPointer).entirePath = currVertexPoints;
+      currVertexPoints = [];
+    }
+  } else {
+    notCalledBeginShapeError();
+  }
+}
+
+function addPolygon() {
+  if (currShapeMode === pub.CLOSE) {
+    currPolygon = currentPage().polygons.add(currentLayer());
+  } else {
+    currPolygon = currentPage().graphicLines.add(currentLayer());
+  }
+
+  currPolygon.strokeWeight = currStrokeWeight;
+  currPolygon.strokeTint = currStrokeTint;
+  currPolygon.fillColor = currFillColor;
+  currPolygon.fillTint = currFillTint;
+  currPolygon.strokeColor = currStrokeColor;
+}
+
+
+function notCalledBeginShapeError () {
+  error("endShape(), you have to call first beginShape(), before calling vertex() and endShape()");
+}
+
+/**
+ * @description Draws a rectangle on the page.<br>
+ * By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, however, may be changed with the rectMode() function.<br>
+ * The fifth, sixth, seventh and eighth parameters, if specified, determine corner radius for the top-right, top-left, lower-right and lower-left corners, respectively. If only a fifth parameter is provided, all corners will be set to this radius.
+ *
+ * @cat    Document
+ * @subcat Primitives
+ * @method rect
+ * @param  {Number} x X-coordinate of the rectangle.
+ * @param  {Number} y Y-coordinate of the rectangle.
+ * @param  {Number} w Width of the rectangle.
+ * @param  {Number} h Height of the rectangle.
+ * @param  {Number} [tl] Radius of top left corner or radius of all 4 corners (optional).
+ * @param  {Number} [tr] Radius of top right corner (optional).
+ * @param  {Number} [br] Radius of bottom right corner (optional).
+ * @param  {Number} [bl] Radius of bottom left corner (optional).
+ * @return {Rectangle} The rectangle that was created.
+ */
+pub.rect = function(x, y, w, h, tl, tr, br, bl) {
+  if (w === 0 || h === 0) {
+    // InDesign doesn't draw a rectangle if width or height are set to 0
+    return false;
+  }
+  if (arguments.length < 4) error("rect(), not enough parameters to draw a rect! Use: x, y, w, h");
+
+  var rectBounds = [];
+  if (currRectMode === pub.CORNER) {
+    rectBounds[0] = y;
+    rectBounds[1] = x;
+    rectBounds[2] = y + h;
+    rectBounds[3] = x + w;
+  } else if (currRectMode === pub.CORNERS) {
+    rectBounds[0] = y;
+    rectBounds[1] = x;
+    rectBounds[2] = h;
+    rectBounds[3] = w;
+  } else if (currRectMode === pub.CENTER) {
+    rectBounds[0] = y - (h / 2);
+    rectBounds[1] = x - (w / 2);
+    rectBounds[2] = y + (h / 2);
+    rectBounds[3] = x + (w / 2);
+  } else if (currRectMode === pub.RADIUS) {
+    rectBounds[0] = y - h;
+    rectBounds[1] = x - w;
+    rectBounds[2] = y + h;
+    rectBounds[3] = x + w;
+  }
+
+  var newRect = currentPage().rectangles.add(currentLayer());
+  newRect.geometricBounds = rectBounds;
+  newRect.strokeWeight = currStrokeWeight;
+  newRect.strokeTint = currStrokeTint;
+  newRect.fillColor = currFillColor;
+  newRect.fillTint = currFillTint;
+  newRect.strokeColor = currStrokeColor;
+
+  if (currRectMode === pub.CENTER || currRectMode === pub.RADIUS) {
+    newRect.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
+                       AnchorPoint.CENTER_ANCHOR,
+                       currMatrix.adobeMatrix(x, y));
+  } else {
+    newRect.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
+                   AnchorPoint.TOP_LEFT_ANCHOR,
+                   currMatrix.adobeMatrix(x, y));
+  }
+
+  if(arguments.length > 4) {
+    for(var i = 4; i < arguments.length;i++){
+      if(arguments[i] < 0 ){
+        error("rect(), needs positive values as arguments for the rounded corners.");
+      }
+    }
+    newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;
+    if(arguments.length === 8) {
+      newRect.topLeftCornerRadius = tl;
+      newRect.topRightCornerRadius = tr;
+      newRect.bottomRightCornerRadius = br;
+      newRect.bottomLeftCornerRadius = bl;
+    } else {
+      newRect.topLeftCornerRadius = newRect.topRightCornerRadius = newRect.bottomRightCornerRadius = newRect.bottomLeftCornerRadius = tl;
+    }
+  }
+  return newRect;
+};
+
+
+// -- Attributes --
+
+/**
+ * @description Modifies the location from which rectangles or text frames draw. The default
+ * mode is rectMode(CORNER), which specifies the location to be the upper left
+ * corner of the shape and uses the `w` and `h` parameters to specify the
+ * width and height. The syntax rectMode(CORNERS) uses the `x` and `y`
+ * parameters of `rect()` or `text()` to set the location of one corner
+ * and uses the `w` and `h` parameters to set the opposite corner.
+ * The syntax `rectMode(CENTER)` draws the shape from its center point and
+ * uses the `w` and `h` parameters to specify the shape's
+ * width and height. The syntax `rectMode(RADIUS)` draws the shape from its
+ * center point and uses the `w` and `h` parameters to specify
+ * half of the shape's width and height.
+ *
+ * @cat    Document
+ * @subcat Attributes
+ * @method rectMode
+ * @param  {String} mode The rectMode to switch to: either CORNER, CORNERS, CENTER, or RADIUS.
+ *
+ */
+pub.rectMode = function (mode) {
+  if (arguments.length === 0) return currRectMode;
+  if (mode === pub.CORNER || mode === pub.CORNERS || mode === pub.CENTER || mode === pub.RADIUS) {
+    currRectMode = mode;
+    return currRectMode;
+  } else {
+    error("rectMode(), unsupported rectMode. Use: CORNER, CORNERS, CENTER, RADIUS.");
+  }
+};
+
+/**
+ * @description The origin of new ellipses is modified by the `ellipseMode()` function.
+ * The default configuration is `ellipseMode(CENTER)`, which specifies the
+ * location of the ellipse as the center of the shape. The RADIUS mode is
+ * the same, but the `w` and `h` parameters to `ellipse()` specify the
+ * radius of the ellipse, rather than the diameter. The CORNER mode draws
+ * the shape from the upper-left corner of its bounding box. The CORNERS
+ * mode uses the four parameters to `ellipse()` to set two opposing corners
+ * of the ellipse's bounding box.
+ *
+ * @cat    Document
+ * @subcat Attributes
+ * @method ellipseMode
+ * @param  {String} mode The ellipse mode to switch to: either CENTER, RADIUS, CORNER, or CORNERS.
+ */
+pub.ellipseMode = function (mode) {
+  if (arguments.length === 0) return currEllipseMode;
+  if (mode === pub.CORNER || mode === pub.CORNERS || mode === pub.CENTER || mode === pub.RADIUS) {
+    currEllipseMode = mode;
+    return currEllipseMode;
+  } else {
+    error("ellipseMode(), unsupported ellipseMode. Use: CENTER, RADIUS, CORNER, CORNERS.");
+  }
+};
+
+/**
+ * @description Sets the width of the stroke used for lines and the border around shapes.
+ *
+ * @cat    Document
+ * @subcat Attributes
+ * @method strokeWeight
+ * @param  {Number} weight The width of the stroke in points.
+ */
+pub.strokeWeight = function (weight) {
+  if (typeof weight === "string" || typeof weight === "number") {
+    currStrokeWeight = weight;
+  } else {
+    error("strokeWeight(), not supported type. Please make sure the strokeweight is a number or string");
+  }
+};
+
+/**
+ * @description Returns the object style of a given page item or the object style with the given name. If an
+ * object style of the given name does not exist, it gets created. Optionally a props object of
+ * property name/value pairs can be used to set the object style's properties.
+ *
+ * @cat    Typography
+ * @method objectStyle
+ * @param  {PageItem|String} itemOrName A page item whose style to return or the name of the object style to return.
+ * @param  {Object} [props] An object of property name/value pairs to set the style's properties.
+ * @return {ObjectStyle} The object style instance.
+ */
+pub.objectStyle = function(itemOrName, props) {
+  var styleErrorMsg = "objectStyle(), wrong parameters. Use: pageItem|name and props. Props is optional.";
+
+  if(!arguments || arguments.length > 2) {
+    error(styleErrorMsg);
+  }
+
+  var style;
+  if(itemOrName.hasOwnProperty("appliedObjectStyle")) {
+    // pageItem is given
+    style = itemOrName.appliedObjectStyle;
+  } else if(isString(itemOrName)) {
+    // name is given
+    style = findInStylesByName(currentDoc().allObjectStyles, itemOrName);
+    if(!style) {
+      style = currentDoc().objectStyles.add({name: itemOrName});
+    }
+  } else {
+    error(styleErrorMsg);
+  }
+
+  if(props) {
+    try {
+      style.properties = props;
+    } catch (e) {
+      error("objectStyle(), wrong props parameter. Use object of property name/value pairs.");
+    }
+  }
+
+  return style;
+};
+
+/**
+ * @description Applies an object style to the given page item. The object style can be given as
+ * name or as an object style instance.
+ *
+ * @cat    Typography
+ * @method applyObjectStyle
+ * @param  {PageItem} item The page item to apply the style to.
+ * @param  {ObjectStyle|String} style An object style instance or the name of the object style to apply.
+ * @return {PageItem} The page item that the style was applied to.
+ */
+
+pub.applyObjectStyle = function(item, style) {
+
+  if(isString(style)) {
+    var name = style;
+    style = findInStylesByName(currentDoc().allObjectStyles, name);
+    if(!style) {
+      error("applyObjectStyle(), an object style named \"" + name + "\" does not exist.");
+    }
+  }
+
+  if(!(item.hasOwnProperty("appliedObjectStyle")) || !(style instanceof ObjectStyle)) {
+    error("applyObjectStyle(), wrong parameters. Use: pageItem, objectStyle|name");
+  }
+
+  item.appliedObjectStyle = style;
+
+  return item;
+};
+
+/**
+ * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use `rectMode()` to set center point.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method duplicate
+ * @param  {PageItem|Page} item The page item or page to duplicate.
+ * @return {Object} The new page item or page.
+ */
+pub.duplicate = function(item) {
+
+  if(!(item instanceof Page) && typeof (item) !== "undefined" && item.hasOwnProperty("duplicate")) {
+
+    var newItem = item.duplicate(currentPage().parent);
+    newItem.move(currentLayer());
+
+    return newItem;
+
+  } else if(item instanceof Page) {
+
+    var newPage = item.duplicate(LocationOptions.AFTER, pub.page());
+    return newPage;
+
+  } else {
+    error("Please provide a valid Page or PageItem as parameter for duplicate().");
+  }
+
+};
+
+
+// ----------------------------------------
+// src/includes/color.js
+// ----------------------------------------
+
+/**
+ * @description Sets the color or gradient used to fill shapes.
+ *
+ * @cat    Color
+ * @method fill
+ * @param  {Color|Gradient|Swatch|Numbers|String} fillColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
+ * @param  {String} [name] If created with numbers, a custom swatch name can be given.
+ */
+pub.fill = function (fillColor) {
+
+  checkNull(fillColor);
+  if (fillColor instanceof Color || fillColor instanceof Swatch || fillColor instanceof Gradient) {
+    currFillColor = fillColor;
+  } else {
+    if (arguments.length === 1) {
+      if (typeof arguments[0] === "string") {
+        currFillColor = pub.swatch(arguments[0]);
+      }else{
+        currFillColor = pub.color(arguments[0]);
+      }
+    } else if (arguments.length === 2) {
+      currFillColor = pub.color(arguments[0], arguments[1]);
+    } else if (arguments.length === 3) {
+      currFillColor = pub.color(arguments[0], arguments[1], arguments[2]);
+    } else if (arguments.length === 4) {
+      currFillColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3]);
+    } else if (arguments.length === 5) {
+      currFillColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+    } else {
+      error("fill(), wrong parameters. Use:\n"
+        + "Swatch name or\n"
+        + "GRAY, [name] or\n"
+        + "R, G, B, [name] or\n"
+        + "C, M, Y, K, [name].\n"
+        + "Name is optional.");
+    }
+  }
+};
+
+/**
+ * @description Disables filling geometry. If both noStroke() and noFill() are called,
+ * newly drawn shapes will be invisible.
+ *
+ * @cat    Color
+ * @method noFill
+ */
+pub.noFill = function () {
+  currFillColor = noneSwatchColor;
+};
+
+/**
+ * @description Sets the color or gradient used to draw lines and borders around shapes.
+ *
+ * @cat Color
+ * @method stroke
+ * @param {Color|Gradient|Swatch|Numbers|String} strokeColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
+ */
+pub.stroke = function (strokeColor) {
+  checkNull(strokeColor);
+  if (strokeColor instanceof Color || strokeColor instanceof Swatch || strokeColor instanceof Gradient) {
+    currStrokeColor = strokeColor;
+  } else {
+    if (arguments.length === 1) {
+      if (typeof arguments[0] === "string") {
+        currStrokeColor = pub.swatch(arguments[0]);
+      }else{
+        currStrokeColor = pub.color(arguments[0]);
+      }
+    } else if (arguments.length === 2) {
+      currStrokeColor = pub.color(arguments[0], arguments[1]);
+    } else if (arguments.length === 3) {
+      currStrokeColor = pub.color(arguments[0], arguments[1], arguments[2]);
+    } else if (arguments.length === 4) {
+      currStrokeColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3]);
+    } else if (arguments.length === 5) {
+      currStrokeColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+    } else {
+      error("stroke(), wrong parameters. Use:\n"
+        + "Swatch name or\n"
+        + "GRAY, [name] or\n"
+        + "R, G, B, [name] or\n"
+        + "C, M, Y, K, [name].\n"
+        + "Name is optional.");
+    }
+  }
+};
+
+/**
+ * @description Disables drawing the stroke. If both noStroke() and noFill() are called,
+ * newly drawn shapes will be invisible.
+ *
+ * @cat    Color
+ * @method noStroke
+ */
+pub.noStroke = function () {
+  currStrokeColor = noneSwatchColor;
+};
+
+/**
+ * @description Sets the tint of the color used to fill shapes.
+ *
+ * @cat    Color
+ * @method fillTint
+ * @param  {Number} tint Number from 0 to 100
+ */
+pub.fillTint = function (tint) {
+  checkNull(tint);
+  if (typeof tint === "string" || typeof tint === "number") {
+    currFillTint = tint;
+  } else {
+    error("fillTint(), unsupported type. Please make sure the fillTint is a number or string");
+  }
+};
+
+/**
+ * @description Sets the tint of the color used to draw lines and borders around shapes.
+ *
+ * @cat    Color
+ * @method strokeTint
+ * @param  {Number} tint Number from 0 to 100.
+ */
+pub.strokeTint = function (tint) {
+  checkNull(tint);
+  if (typeof tint === "string" || typeof tint === "number") {
+    currStrokeTint = tint;
+  } else {
+    error("strokeTint(), unsupported type. Please make sure the strokeTint parameter is a number or string");
+  }
+};
+
+/**
+ * @description Sets the colormode for creating new colors with color() to RGB or CMYK. The default color mode is RGB.
+ *
+ * @cat    Color
+ * @method colorMode
+ * @param  {Number} colorMode RGB or CMYK.
+ */
+pub.colorMode = function(colorMode) {
+  checkNull(colorMode);
+  if (arguments.length === 0) {
+    return currColorMode;
+  }
+  if (colorMode === pub.RGB || colorMode === pub.CMYK) {
+    currColorMode = colorMode;
+  } else {
+    error("colorMode(), unsupported colormode, use: RGB or CMYK");
+  }
+};
+
+/**
+ * @description Sets the gradient mode for gradient() to LINEAR or RADIAL. The default gradient mode is LINEAR.
+ *
+ * @cat    Color
+ * @method gradientMode
+ * @param  {String} gradientMode LINEAR or RADIAL.
+ */
+pub.gradientMode = function(gradientMode) {
+  checkNull(gradientMode);
+  if (arguments.length === 0) {
+    return currGradientMode;
+  }
+  if (gradientMode === pub.LINEAR || gradientMode === pub.RADIAL) {
+    currGradientMode = gradientMode;
+  } else {
+    error("gradientMode(), unsupported gradient mode, use: LINEAR or RADIAL");
+  }
+};
+
+/**
+ * @description Gets a swatch by name.
+ *
+ * @cat    Color
+ * @method swatch
+ * @param  {String} swatchName Returns the swatch color/gradient for a given name by string.
+ */
+pub.swatch = function(){
+  var newSwatch;
+  var props = {};
+  if (arguments.length === 1) {
+    var a = arguments[0];
+    if (typeof a === "string") {
+      newSwatch = currentDoc().swatches.itemByName(a);
+      if(newSwatch.isValid){
+          return newSwatch;
+        }else{
+          error("A swatch with the provided name doesn't exist.");
+        }
+    }else{
+      error("swatch() requires a string, the name of an existing swatch.");
+    }
+  }
+}
+
+/**
+ * @description Creates a new RGB / CMYK color and adds it to the document, or gets a color by name from the document. The default color mode is RGB.
+ *
+ * @cat    Color
+ * @method color
+ * @param  {String|Numbers} Get color: the color name. Create new color: GRAY,[name] / R,G,B,[name] / C,M,Y,K,[name]. Name is always optional.
+ * @return {Color} Found or new color
+ */
+pub.color = function() {
+  var newCol;
+  var props = {};
+  var a = arguments[0],
+    b = arguments[1],
+    c = arguments[2],
+    d = arguments[3],
+    e = arguments[4];
+  var colorErrorMsg = "color(), wrong parameters. Use:\n"
+      + "GRAY,[name] or \n"
+      + "R,G,B,[name] in colorMode(RGB) or\n"
+      + "C,M,Y,K,[name] in colorMode(CMYK).\n"
+      + "Name is optional.\n"
+      + "NB: In InDesign colors don't have an alpha value, use opacity() to set alpha.";
+
+  if (arguments.length === 1) {
+    // get color by name
+    if (typeof a === "string") {
+      newCol = currentDoc().colors.itemByName(a); // check color
+      if (newCol.isValid) {
+        return newCol;
+      } else {
+        error("color(), a color with the provided name doesn't exist.");
+      }
+    } else if (typeof a === "number") {
+      // GRAY
+      if (currColorMode === pub.RGB) {
+        a = pub.constrain(a, 0, 255);
+        props.model = ColorModel.PROCESS;
+        props.space = ColorSpace.RGB;
+        props.colorValue = [a, a, a];
+        props.name = "R=" + a + " G=" + a + " B=" + a;
+      } else {
+        a = pub.constrain(a, 0, 100);
+        props.model = ColorModel.PROCESS;
+        props.space = ColorSpace.CMYK;
+        props.colorValue = [0, 0, 0, a];
+        props.name = "C=" + 0 + " M=" + 0 + " Y=" + 0 + " K=" + a;
+      }
+    } else {
+      error("color(), wrong type of first parameter.");
+    }
+
+  } else if (arguments.length === 2) {
+    // GRAY + name
+    if (currColorMode === pub.RGB) {
+      a = pub.constrain(a, 0, 255);
+      props.model = ColorModel.PROCESS;
+      props.space = ColorSpace.RGB;
+      props.colorValue = [a, a, a];
+      props.name = b;
+    } else {
+      a = pub.constrain(a, 0, 100);
+      props.model = ColorModel.PROCESS;
+      props.space = ColorSpace.CMYK;
+      props.colorValue = [0, 0, 0, a];
+      props.name = b;
+    }
+
+  } else if (arguments.length === 3) {
+    // R G B
+    if (currColorMode === pub.RGB) {
+      a = pub.constrain(a, 0, 255);
+      b = pub.constrain(b, 0, 255);
+      c = pub.constrain(c, 0, 255);
+      props.model = ColorModel.PROCESS;
+      props.space = ColorSpace.RGB;
+      props.colorValue = [a, b, c];
+      props.name = "R=" + a + " G=" + b + " B=" + c;
+    } else {
+      error(colorErrorMsg);
+    }
+
+
+  } else if (arguments.length === 4 && typeof d === "string") {
+    // R G B + name
+    if (currColorMode === pub.RGB) {
+      a = pub.constrain(a, 0, 255);
+      b = pub.constrain(b, 0, 255);
+      c = pub.constrain(c, 0, 255);
+      props.model = ColorModel.PROCESS;
+      props.space = ColorSpace.RGB;
+      props.colorValue = [a, b, c];
+      props.name = d;
+    } else {
+      error(colorErrorMsg);
+    }
+
+  } else if (arguments.length === 4 && typeof d === "number") {
+    // C M Y K
+    if (currColorMode === pub.CMYK) {
+      a = pub.constrain(a, 0, 100);
+      b = pub.constrain(b, 0, 100);
+      c = pub.constrain(c, 0, 100);
+      d = pub.constrain(d, 0, 100);
+      props.model = ColorModel.PROCESS;
+      props.space = ColorSpace.CMYK;
+      props.colorValue = [a, b, c, d];
+      props.name = "C=" + a + " M=" + b + " Y=" + c + " K=" + d;
+    } else {
+      error(colorErrorMsg);
+    }
+
+  } else if (arguments.length === 5 && typeof e === "string" && currColorMode === pub.CMYK) {
+    // C M Y K + name
+    a = pub.constrain(a, 0, 100);
+    b = pub.constrain(b, 0, 100);
+    c = pub.constrain(c, 0, 100);
+    d = pub.constrain(d, 0, 100);
+    props.model = ColorModel.PROCESS;
+    props.space = ColorSpace.CMYK;
+    props.colorValue = [a, b, c, d];
+    props.name = e;
+
+  } else {
+    error(colorErrorMsg);
+  }
+
+  // check whether color was already created and added to colors,
+  // keeps the document clean ...
+  newCol = currentDoc().colors.itemByName(props.name);
+  if (!newCol.isValid) {
+    newCol = currentDoc().colors.add();
+  }
+  newCol.properties = props;
+  return newCol;
+};
+
+/**
+ * @description Creates a new gradient and adds it to the document, or gets a gradient by name from the document.<br>
+ * If two colors are given as the first two parameters, a gradient is created that blends between these two colors. If an array of colors is used
+ * as the first parameter, a gradient with the contained colors will be created. The colors will be distributed evenly. If additionally to this array
+ * a second array of gradient stop positions is given, the colors will be positioned at the given gradient stops. Possible gradient stop positions
+ * range from 0 to 100. All parameter options allow for an additional name parameter at the end to name the new gradient.
+ * If a string is used as the only parameter, the gradient with that name will be returned, if it exists in the document.
+ *
+ * @cat    Color
+ * @method gradient
+ * @param  {Color|Array|String} c1 First color of the gradient. Alternatively: Array of colors/gradients or name of gradient to get.
+ * @param  {Color|Array|String} c2 Second color of the gradient. Alternatively: Array of gradient stop positions (if first parameter is an array of colors).
+ * @param  {String} [name] Optional name of the gradient.
+ * @return {Gradient} Found or new gradient
+ */
+pub.gradient = function() {
+  var newGrad;
+  // var props = {};
+  var a = arguments[0],
+    b = arguments[1],
+    c = arguments[2];
+  var gradientErrorMsg = "gradient(), wrong parameters. Use:\n"
+      + "c1,c2,[name] or\n"
+      + "arrayOfColors,[name] or\n"
+      + "arrayOfColors,arrayOfGradientStops,[name] or\n"
+      + "gradientName";
+
+  if (typeof a === "string" && arguments.length === 1) {
+    // get gradient by name
+    newGrad = currentDoc().gradients.itemByName(a);
+    if (newGrad.isValid) {
+      return newGrad;
+    } else {
+      error("gradient(), a gradient with the provided name doesn't exist.");
+    }
+  } else if (a instanceof Color && b instanceof Color && (typeof c === "string" || arguments.length === 2)) {
+    // c1 and c2
+    if (typeof c === "string") {
+      if(currentDoc().colors.itemByName(c).isValid) {
+        error("gradient(), \"" + c + "\" already exists as a color. Use another name for the gradient.");
+      }
+      if(currentDoc().gradients.itemByName(c).isValid) {
+        currentDoc().gradients.itemByName(c).remove();
+        warning("gradient(), a gradient named \"" + c + "\" already existed. The old gradient is replaced by a new one.");
+      }
+      newGrad = currentDoc().gradients.add({name: c});
+    } else {
+      newGrad = currentDoc().gradients.add();
+    }
+    newGrad.gradientStops[0].stopColor = a;
+    newGrad.gradientStops[1].stopColor = b;
+    if(currGradientMode === pub.LINEAR) {
+      newGrad.type = GradientType.LINEAR;
+    } else {
+      newGrad.type = GradientType.RADIAL;
+    }
+    return newGrad;
+  } else if (a instanceof Array) {
+    // array of colors
+    var customStopLocations = false;
+    if(arguments.length > 3) {
+      error(gradientErrorMsg);
+    }
+    if(arguments.length > 1 && !(b instanceof Array || typeof b === "string")) {
+      error(gradientErrorMsg);
+    }
+    if(arguments.length === 3 && !(typeof c === "string")) {
+      error(gradientErrorMsg);
+    }
+    if(arguments.length > 1 && b instanceof Array) {
+      customStopLocations = true;
+    }
+    if(customStopLocations && !(a.length === b.length)) {
+      error("gradient(), arrayOfColors and arrayOfGradientStops need to have the same length.");
+    }
+    var z = arguments[arguments.length - 1];
+    if (typeof z === "string") {
+      if(currentDoc().colors.itemByName(z).isValid) {
+        error("gradient(), \"" + z + "\" already exists as a color. Use another name for the gradient.");
+      }
+      if(currentDoc().gradients.itemByName(z).isValid) {
+        currentDoc().gradients.itemByName(z).remove();
+        warning("gradient(), a gradient named \"" + z + "\" already existed. The old gradient is replaced by a new one.");
+      }
+      newGrad = currentDoc().gradients.add({name: z});
+    } else {
+      newGrad = currentDoc().gradients.add();
+    }
+    for (var i = 0; i < a.length; i++) {
+      if(!(a[i] instanceof Color || a[i] instanceof Swatch)) {
+        error("gradient(), element #" + (i + 1) + " of the given arrayOfColors is not a color or swatch.");
+      }
+      if(i > newGrad.gradientStops.length - 1) {
+        newGrad.gradientStops.add();
+      }
+      newGrad.gradientStops[i].stopColor = a[i];
+      if(customStopLocations) {
+        if(!(typeof b[i] === "number")) {
+          error("gradient(), element #" + (i + 1) + " of the given arrayOfGradientStops is not a number.");
+        }
+        newGrad.gradientStops[i].location = pub.constrain(b[i], 0, 100);
+      } else {
+        newGrad.gradientStops[i].location = pub.map(i, 0, a.length - 1, 0, 100);
+      }
+    }
+    if(currGradientMode === pub.LINEAR) {
+      newGrad.type = GradientType.LINEAR;
+    } else {
+      newGrad.type = GradientType.RADIAL;
+    }
+    return newGrad;
+  } else {
+    error(gradientErrorMsg);
+  }
+};
+
+/**
+ * @description Sets the opacity property of an object.
+ *
+ * @cat    Color
+ * @method opacity
+ * @param  {Object} obj The object to set opacity of.
+ * @param  {Number} opacity The opacity value from 0 to 100.
+ */
+pub.opacity = function(obj, opacity) {
+  checkNull(obj);
+  if (obj.hasOwnProperty("transparencySettings")) {
+    obj.transparencySettings.blendingSettings.opacity = opacity;
+  } else {
+    warning("opacity(), the object " + obj.toString() + " doesn't have an opacity property");
+  }
+};
+
+/**
+ * @description Sets the Effects blendMode property of an object.
+ *
+ * @cat    Color
+ * @method blendMode
+ * @param  {Object} obj The object to set blendMode of.
+ * @param  {Number} blendMode The blendMode must be one of the InDesign BlendMode enum values:
+ *    - `BlendMode.NORMAL`
+ *    - `BlendMode.MULTIPLY`
+ *    - `BlendMode.SCREEN`
+ *    - `BlendMode.OVERLAY`
+ *    - `BlendMode.SOFT_LIGHT`
+ *    - `BlendMode.HARD_LIGHT`
+ *    - `BlendMode.COLOR_DODGE`
+ *    - `BlendMode.COLOR_BURN`
+ *    - `BlendMode.DARKEN`
+ *    - `BlendMode.LIGHTEN`
+ *    - `BlendMode.DIFFERENCE`
+ *    - `BlendMode.EXCLUSION`
+ *    - `BlendMode.HUE`
+ *    - `BlendMode.SATURATION`
+ *    - `BlendMode.COLOR`
+ *    - `BlendMode.LUMINOSITY`
+ */
+pub.blendMode = function(obj, blendMode) {
+  checkNull(obj);
+  if (obj.hasOwnProperty("transparencySettings")) {
+    obj.transparencySettings.blendingSettings.blendMode = blendMode;
+  } else {
+    warning("blendMode(), the object " + obj.toString() + " doesn't have a blendMode property");
+  }
+};
+
+/**
+ * @description Calculates a color or colors between two colors at a specific increment.<br>
+ * The amt parameter is the amount to interpolate between the two values where 0.0 equals the first color, 0.5 is half-way in between and 1.0 equals the second color.
+ * N.B.: Both colors must be either CMYK or RGB.
+ *
+ * @cat    Color
+ * @method lerpColor
+ * @param  {Color} c1   Input color 1.
+ * @param  {Color} c2   Input color 2.
+ * @param  {Number} amt The amount to interpolate between the two colors.
+ * @return {Color} Interpolated color
+ */
+pub.lerpColor = function (c1, c2, amt) {
+  checkNull(c1);
+  checkNull(c2);
+  if ((c1 instanceof Color || c1 instanceof Swatch) &&
+     (c2 instanceof Color || c2 instanceof Swatch) &&
+      typeof amt === "number") {
+    if (c1.space === ColorSpace.CMYK && c2.space === ColorSpace.CMYK) {
+      var C1 = c1.colorValue[0];
+      var M1 = c1.colorValue[1];
+      var Y1 = c1.colorValue[2];
+      var K1 = c1.colorValue[3];
+
+      var C2 = c2.colorValue[0];
+      var M2 = c2.colorValue[1];
+      var Y2 = c2.colorValue[2];
+      var K2 = c2.colorValue[3];
+
+      var COut = Math.round(pub.lerp(C1, C2, amt));
+      var MOut = Math.round(pub.lerp(M1, M2, amt));
+      var YOut = Math.round(pub.lerp(Y1, Y2, amt));
+      var KOut = Math.round(pub.lerp(K1, K2, amt));
+      return pub.color(COut, MOut, YOut, KOut);
+
+    } else if (c1.space === ColorSpace.RGB && c2.space === ColorSpace.RGB) {
+      var R1 = c1.colorValue[0];
+      var G1 = c1.colorValue[1];
+      var B1 = c1.colorValue[2];
+
+      var R2 = c2.colorValue[0];
+      var G2 = c2.colorValue[1];
+      var B2 = c2.colorValue[2];
+
+      var ROut = Math.round(pub.lerp(R1, R2, amt));
+      var GOut = Math.round(pub.lerp(G1, G2, amt));
+      var BOut = Math.round(pub.lerp(B1, B2, amt));
+      return pub.color(ROut, GOut, BOut);
+
+    } else {
+      error("lerpColor(), both colors must be either CMYK or RGB.");
+    }
+  } else {
+    error("lerpColor(), wrong parameters. Use: two colors (of the same type) and a number.");
+  }
+};
+
+  The Lorem ipsum string of LOREM is taken from https://indieweb.org/Lorem_ipsum and
+// ----------------------------------------
+// src/includes/typography.js
+// ----------------------------------------
+
+/**
+ * @description Creates a text frame on the current layer on the current page in the current document.
+ * The text frame gets created in the position specified by the x and y parameters.
+ * The default document font will be used unless a font is set with the textFont() function.
+ * The default document font size will be used unless a font size is set with the textSize() function.
+ * Change the color of the text with the fill() function.
+ * The text displays in relation to the textAlign() and textYAlign() functions.
+ * The width and height parameters define a rectangular area.
+ *
+ * @cat    Typography
+ * @method text
+ * @param  {String} txt The text content to set in the text frame.
+ * @param  {Number} x   x-coordinate of text frame
+ * @param  {Number} y   y-coordinate of text frame
+ * @param  {Number} w   width of text frame
+ * @param  {Number} h   height of text frame
+ * @return {TextFrame}  The created text frame instance
+ */
+pub.text = function(txt, x, y, w, h) {
+  if (arguments.length !== 5) {
+    error("text(), not enough parameters to draw a text! Use: text(txt, x, y, w, h)");
+  }
+  if (!(isString(txt) || isNumber(txt))) {
+    warning("text(), the first parameter has to be a string! But is something else: " + typeof txt + ". Use: text(txt, x, y, w, h)");
+  }
+
+  var textBounds = [];
+  if (currRectMode === pub.CORNER) {
+    textBounds[0] = y;
+    textBounds[1] = x;
+    textBounds[2] = y + h;
+    textBounds[3] = x + w;
+  } else if (currRectMode === pub.CORNERS) {
+    textBounds[0] = y;
+    textBounds[1] = x;
+    textBounds[2] = h;
+    textBounds[3] = w;
+  } else if (currRectMode === pub.CENTER) {
+    textBounds[0] = y - (h / 2);
+    textBounds[1] = x - (w / 2);
+    textBounds[2] = y + (h / 2);
+    textBounds[3] = x + (w / 2);
+  } else if (currRectMode === pub.RADIUS) {
+    textBounds[0] = y - h;
+    textBounds[1] = x - w;
+    textBounds[2] = y + h;
+    textBounds[3] = x + w;
+  }
+
+  var textFrame = currentPage().textFrames.add(currentLayer());
+  textFrame.contents = txt.toString();
+  textFrame.geometricBounds = textBounds;
+  textFrame.textFramePreferences.verticalJustification = currYAlign;
+
+  pub.typo(textFrame, {
+    appliedFont: currFont,
+    pointSize: currFontSize,
+    fillColor: currFillColor,
+    justification: currAlign,
+    leading: currLeading,
+    kerningValue: currKerning,
+    tracking: currTracking
+  });
+
+
+  if (currRectMode === pub.CENTER || currRectMode === pub.RADIUS) {
+    textFrame.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
+                       AnchorPoint.CENTER_ANCHOR,
+                       currMatrix.adobeMatrix(x, y));
+  } else {
+    textFrame.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
+                   AnchorPoint.TOP_LEFT_ANCHOR,
+                   currMatrix.adobeMatrix(x, y));
+  }
+
+  return textFrame;
+};
+
+/**
+ * @description Sets text properties to the given item. If the item is not an instance the text property can be set to,
+ * the property gets set to the direct descendants of the given item, e.g. all stories of a given document.
+ * <br><br>
+ * If no value is given and the given property is a string, the function acts as a getter and returns the
+ * corresponding value(s) in an array. This can either be an array containing the value of the concrete item
+ * (e.g. character) the values of the item's descendants (e.g. paragraphs of given text frame).
+ *
+ * @cat    Typography
+ * @method typo
+ * @param  {Document|Spread|Page|Layer|Story|TextFrame|Text} item  The object to apply the property to.
+ * @param  {String|Object} property  The text property name or an object of key/value property/value pairs.
+ *                                   If property is a string and no value is given, the function acts as getter.
+ * @param  {String|Number|Object} [value]  The value to apply to the property.
+ * @return {String[]|Number[]|Object[]}  The property value(s) if the function acts as getter or the items the property
+ *                                       was assigned to.
+ */
+pub.typo = function(item, property, value) {
+  var result = [],
+    actsAsGetter = typeof property === "string" && (value === undefined || value === null),
+    getOrSetProperties = function(textItem) {
+      if (actsAsGetter) {
+        result.push(textItem[property]);
+      } else {
+        setProperties(textItem);
+      }
+    },
+    setProperties = function(textItem) {
+      if (typeof property === "string") {
+        result.push(textItem);
+        setProperty(textItem, property, value);
+      } else if (typeof property === "object") {
+        result.push(textItem);
+        for (var prop in property) {
+          setProperty(textItem, prop, property[prop]);
+        }
+      }
+    },
+    setProperty = function(textItem, prop, val) {
+      textItem[prop] = val;
+    };
+
+  if(typeof item === "string") error("typo() cannot work on strings. Please pass a Text object to modify.");
+
+  if(!isValid(item)) {
+    warning("typo(), invalid object passed");
+    return;
+  }
+
+  if (item instanceof Document ||
+      item instanceof Spread ||
+      item instanceof Page ||
+      item instanceof Layer) {
+    forEach(item.textFrames, function(textFrame) {
+      pub.typo(textFrame, property, value);
+    });
+  } else if (item instanceof Story ||
+             item instanceof TextFrame) {
+    var paras = item.paragraphs;
+    // loop backwards to prevent invalid object reference error when
+    // start of para is overflown in "invisible" textFrame area after
+    // applying prop to previous para(s)
+    for (var i = paras.length - 1; i >= 0; i--) {
+      getOrSetProperties(paras[i]);
+    }
+  } else if (isText(item)) {
+    getOrSetProperties(item);
+  }
+  return result;
+};
+
+var isValid = function (item) {
+
+  checkNull(item);
+
+  if (item.hasOwnProperty("isValid")) {
+    if (!item.isValid) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+  return true; // if does not have isValid field -> normal array element and not collection
+
+  return false;
+};
+
+/**
+ * @description Returns the current font and sets it if argument fontName is given.
+ *
+ * @cat    Typography
+ * @method textFont
+ * @param  {String} [fontName] The name of the font to set e.g. Helvetica
+ * @param  {String} [fontStyle] The font style e.g. Bold
+ * @return {Font} The current font object
+ */
+pub.textFont = function(fontName, fontStyle) {
+
+  if (arguments.length === 2) {
+    fontName = fontName + "\t" + fontStyle;
+  } else if (arguments.length === 1) {
+    fontName = fontName + "\tRegular";
+  } else if (arguments.length === 0) {
+    return currFont;
+  } else {
+    error("textFont(), wrong parameters. To set font use: fontName, fontStyle. fontStyle is optional.");
+  }
+
+  if(app.fonts.itemByName(fontName).status !== FontStatus.INSTALLED) {
+    warning("textFont(), font \"" + fontName.replace("\t", " ") + "\" not installed. "
+      + "Using current font \"" + currFont.fontFamily + " " + currFont.fontStyleName + "\" instead.");
+  } else {
+    currFont = app.fonts.itemByName(fontName);
+  }
+
+  return currFont;
+};
+
+/**
+ * @description Returns the current font size in points and sets it if argument pointSize is given.
+ *
+ * @cat    Typography
+ * @method textSize
+ * @param  {Number} [pointSize] The size in points to set.
+ * @return {Number}             The current point size.
+ */
+pub.textSize = function(pointSize) {
+  if (arguments.length === 1) {
+    currFontSize = pointSize;
+  }
+  return currFontSize;
+};
+
+/**
+ * @description Sets the current horizontal and vertical text alignment.
+ *
+ * @cat    Typography
+ * @method textAlign
+ * @param  {String} align    The horizontal text alignment to set. Must be one of the InDesign Justification enum values:
+ *                           Justification.AWAY_FROM_BINDING_SIDE<br>
+ *                           Justification.CENTER_ALIGN<br>
+ *                           Justification.CENTER_JUSTIFIED<br>
+ *                           Justification.FULLY_JUSTIFIED<br>
+ *                           Justification.LEFT_ALIGN<br>
+ *                           Justification.RIGHT_ALIGN<br>
+ *                           Justification.RIGHT_JUSTIFIED<br>
+ *                           Justification.TO_BINDING_SIDE<br>
+ * @param  {String} [yAlign] The vertical text alignment to set. Must be one of the InDesign VerticalJustification enum values:
+ *                           VerticalJustification.BOTTOM_ALIGN<br>
+ *                           VerticalJustification.CENTER_ALIGN<br>
+ *                           VerticalJustification.JUSTIFY_ALIGN<br>
+ *                           VerticalJustification.TOP_ALIGN<br>
+ */
+pub.textAlign = function(align, yAlign) {
+  currAlign = align;
+  if (arguments.length === 2) currYAlign = yAlign;
+};
+
+/**
+ * @description Returns the spacing between lines of text in units of points and sets it if argument leading is given.
+ *
+ * @cat    Typography
+ * @method textLeading
+ * @param  {Number|String} [leading] The spacing between lines of text in units of points or the default InDesign enum
+ *                                   value Leading.AUTO.
+ * @return {Number|String}           The current leading.
+ */
+pub.textLeading = function(leading) {
+  if (arguments.length === 1) {
+    currLeading = leading;
+  }
+  return currLeading;
+};
+
+/**
+ * @description Returns the current kerning and sets it if argument kerning is given.
+ *
+ * @cat    Typography
+ * @method textKerning
+ * @param  {Number} [kerning] The value to set.
+ * @return {Number}           The current kerning.
+ */
+pub.textKerning = function(kerning) {
+  if (arguments.length === 1) {
+    currKerning = kerning;
+  }
+  return currKerning;
+};
+
+/**
+ * @description Returns the current tracking and sets it if argument tracking is given.
+ *
+ * @cat    Typography
+ * @method textTracking
+ * @param  {Number} [tracking] The value to set.
+ * @return {Number}            The current tracking.
+ */
+pub.textTracking = function(tracking) {
+  if (arguments.length === 1) {
+    currTracking = tracking;
+  }
+  return currTracking;
+};
+
+/**
+ * @description Returns the character style of a given text object or the character style with the given name. If a
+ * character style of the given name does not exist, it gets created. Optionally a props object of
+ * property name/value pairs can be used to set the character style's properties.
+ *
+ * @cat    Typography
+ * @method characterStyle
+ * @param  {Text|String} textOrName  A text object whose style to return or the name of the character style to return.
+ * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
+ * @return {CharacterStyle}  The character style instance.
+ */
+pub.characterStyle = function(textOrName, props) {
+  var styleErrorMsg = "characterStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
+
+  if(!arguments || arguments.length > 2) {
+    error(styleErrorMsg);
+  }
+
+  var style;
+  if(isText(textOrName)) {
+    // text object is given
+    style = textOrName.appliedCharacterStyle;
+  } else if(isString(textOrName)) {
+    // name is given
+    style = findInStylesByName(currentDoc().allCharacterStyles, textOrName);
+    if(!style) {
+      style = currentDoc().characterStyles.add({name: textOrName});
+    }
+  } else {
+    error(styleErrorMsg);
+  }
+
+  if(props) {
+    try {
+      style.properties = props;
+    } catch (e) {
+      error("characterStyle(), wrong props parameter. Use object of property name/value pairs.");
+    }
+  }
+
+  return style;
+};
+
+/**
+ * @description Applies a character style to the given text object, text frame or story. The character style
+ * can be given as name or as character style instance.
+ *
+ * @cat    Typography
+ * @method applyCharacterStyle
+ * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
+ * @param  {CharacterStyle|String} style  A character style instance or the name of the character style to apply.
+ * @return {Text}  The text that the style was applied to.
+ */
+
+pub.applyCharacterStyle = function(text, style) {
+
+  if(isString(style)) {
+    var name = style;
+    style = findInStylesByName(currentDoc().allCharacterStyles, name);
+    if(!style) {
+      error("applyCharacterStyle(), a character style named \"" + name + "\" does not exist.");
+    }
+  }
+
+  if(!(pub.isText(text) || text instanceof TextFrame || text instanceof Story) || !(style instanceof CharacterStyle)) {
+    error("applyCharacterStyle(), wrong parameters. Use: textObject|textFrame|story, characterStyle|name");
+  }
+
+  if(text instanceof TextFrame) {
+    text = text.characters.everyItem();
+  }
+
+  text.appliedCharacterStyle = style;
+
+  return text;
+};
+
+/**
+ * @description Returns the paragraph style of a given text object or the paragraph style with the given name. If a
+ * paragraph style of the given name does not exist, it gets created. Optionally a props object of
+ * property name/value pairs can be used to set the paragraph style's properties.
+ *
+ * @cat    Typography
+ * @method paragraphStyle
+ * @param  {Text|String} textOrName  A text object whose style to return or the name of the paragraph style to return.
+ * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
+ * @return {ParagraphStyle}  The paragraph style instance.
+ */
+pub.paragraphStyle = function(textOrName, props) {
+  var styleErrorMsg = "paragraphStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
+
+  if(!arguments || arguments.length > 2) {
+    error(styleErrorMsg);
+  }
+
+  var style;
+  if(isText(textOrName)) {
+    // text object is given
+    style = textOrName.appliedParagraphStyle;
+  } else if(isString(textOrName)) {
+    // name is given
+    style = findInStylesByName(currentDoc().allParagraphStyles, textOrName);
+    if(!style) {
+      style = currentDoc().paragraphStyles.add({name: textOrName});
+    }
+  } else {
+    error(styleErrorMsg);
+  }
+
+  if(props) {
+    try {
+      style.properties = props;
+    } catch (e) {
+      error("paragraphStyle(), wrong props parameter. Use object of property name/value pairs.");
+    }
+  }
+
+  return style;
+};
+
+/**
+ * @description Applies a paragraph style to the given text object, text frame or story. The paragraph style
+ * can be given as name or as paragraph style instance.
+ *
+ * @cat    Typography
+ * @method applyParagraphStyle
+ * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
+ * @param  {ParagraphStyle|String} style  A paragraph style instance or the name of the paragraph style to apply.
+ * @return {Text}  The text that the style was applied to.
+ */
+
+pub.applyParagraphStyle = function(text, style) {
+
+  if(isString(style)) {
+    var name = style;
+    style = findInStylesByName(currentDoc().allParagraphStyles, name);
+    if(!style) {
+      error("applyParagraphStyle(), a paragraph style named \"" + name + "\" does not exist.");
+    }
+  }
+
+  if(!(pub.isText(text) || text instanceof TextFrame || text instanceof Story) || !(style instanceof ParagraphStyle)) {
+    error("applyParagraphStyle(), wrong parameters. Use: textObject|textFrame|story, paragraphStyle|name");
+  }
+
+  if(text instanceof TextFrame) {
+    text = text.paragraphs.everyItem();
+  }
+
+  text.appliedParagraphStyle = style;
+
+  return text;
+};
+
+/**
+ * @description Links the stories of two textframes to one story. Text of first textframe overflows to second one.
+ *
+ * @cat    Story
+ * @method linkTextFrames
+ * @param  {TextFrame} textFrameA
+ * @param  {TextFrame} textFrameB
+ */
+pub.linkTextFrames = function (textFrameA, textFrameB) {
+  if (textFrameA instanceof TextFrame && textFrameB instanceof TextFrame) {
+    textFrameA.nextTextFrame = textFrameB;
+  } else {
+    error("linkTextFrames(), wrong type of parameter! linkTextFrames() needs two textFrame objects to link the stories. Use: textFrameA, textFrameB");
+  }
+};
+
+/**
+ * @description Fills the given textFrame and all linked textFrame with random placeholder text. The placeholder text will be added at the end of any already existing text in the text frame.
+ *
+ * @cat    Story
+ * @method placeholder
+ * @param  {TextFrame} textFrame
+ * @return {Text} The inserted placeholder text.
+ */
+pub.placeholder = function (textFrame) {
+  if (textFrame instanceof TextFrame) {
+    var startIx = textFrame.parentStory.insertionPoints[-1].index;
+    textFrame.contents = TextFrameContents.PLACEHOLDER_TEXT;
+    var endIx = textFrame.parentStory.insertionPoints[-1].index - 1;
+    return textFrame.parentStory.characters.itemByRange(startIx, endIx);
+  } else {
+    error("placeholder(), wrong type of parameter! Use: textFrame");
+  }
+};
+  is available under a CC0 public domain dedication.
+// ----------------------------------------
+// src/includes/image.js
+// ----------------------------------------
+
+/**
+ * @description Adds an image to the document. If the image argument is given as a string the image file must be in the document's
+ * data directory which is in the same directory where the document is saved in. The image argument can also be a File
+ * instance which can be placed even before the document was saved.
+ * The second argument can either be the x position of the frame to create or an instance of a rectangle,
+ * oval or polygon to place the image in. If an x position is given, a y position must be given, too.
+ * If x and y positions are given and width and height are not given, the frame's size gets set to the original image size.
+ *
+ * @cat    Document
+ * @subcat Image
+ * @method image
+ * @param  {String|File} img The image file name in the document's data directory or a File instance.
+ * @param  {Number|Rectangle|Oval|Polygon} x The x position on the current page or the item instance to place the image in.
+ * @param  {Number} [y] The y position on the current page. Ignored if x is not a number.
+ * @param  {Number} [w] The width of the rectangle to add the image to. Ignored if x is not a number.
+ * @param  {Number} [h] The height of the rectangle to add the image to. Ignored if x is not a number.
+ * @return {Rectangle|Oval|Polygon} The item instance the image was placed in.
+ */
+pub.image = function(img, x, y, w, h) {
+  var file = initDataFile(img),
+    frame = null,
+    fitOptions = null,
+    width = null,
+    height = null,
+    imgErrorMsg = "image(), wrong parameters. Use:\n"
+      + "image( {String|File}, {Rectangle|Oval|Polygon} ) or\n"
+      + "image( {String|File}, x, y ) or\n"
+      + "image( {String|File}, x, y, w, h )";
+
+  if(arguments.length < 2 || arguments.length === 4 || arguments.length > 5) error(imgErrorMsg);
+
+  if (x instanceof Rectangle ||
+      x instanceof Oval ||
+      x instanceof Polygon) {
+    frame = x;
+    fitOptions = FitOptions.FILL_PROPORTIONALLY;
+  } else if (typeof x === "number" && typeof y === "number") {
+    width = 1;
+    height = 1;
+    if (currImageMode === pub.CORNERS) {
+      if (typeof w === "number" && typeof h === "number") {
+        width = w - x;
+        height = h - y;
+        fitOptions = FitOptions.FILL_PROPORTIONALLY;
+      } else if (arguments.length === 3) {
+        fitOptions = FitOptions.frameToContent;
+      } else {
+        error(imgErrorMsg);
+      }
+    } else {
+      if (typeof w === "number" && typeof h === "number") {
+        if (w <= 0 || h <= 0) error("image(), invalid parameters. When using image(img, x, y, w, h) with the default imageMode CORNER, parameters w and h need to be greater than 0.");
+        width = w;
+        height = h;
+        fitOptions = FitOptions.FILL_PROPORTIONALLY;
+      } else if (arguments.length === 3) {
+        fitOptions = FitOptions.frameToContent;
+      } else {
+        error(imgErrorMsg);
+      }
+    }
+
+    frame = currentPage().rectangles.add(currentLayer(),
+      {geometricBounds:[y, x, y + height, x + width]}
+    );
+  } else {
+    error(imgErrorMsg);
+  }
+
+  frame.place(file);
+
+  if (fitOptions) {
+    frame.fit(fitOptions);
+  }
+
+  if (currImageMode === pub.CENTER) {
+    var bounds = frame.geometricBounds;
+    width = bounds[3] - bounds[1];
+    height = bounds[2] - bounds[0];
+    frame.move(null, [-(width / 2), -(height / 2)]);
+    frame.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
+                       AnchorPoint.CENTER_ANCHOR,
+                       currMatrix.adobeMatrix(x, y));
+  } else {
+    frame.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
+                   AnchorPoint.TOP_LEFT_ANCHOR,
+                   currMatrix.adobeMatrix(x, y));
+  }
+
+
+  frame.strokeWeight = currStrokeWeight;
+  frame.strokeTint = currStrokeTint;
+  frame.strokeColor = currStrokeColor;
+
+  return frame;
+};
+
+/**
+ * @description Modifies the location from which images draw. The default mode is imageMode(CORNER), which specifies the location to be the upper left corner and uses the fourth and fifth parameters of image() to set the image's width and height. The syntax imageMode(CORNERS) uses the second and third parameters of image() to set the location of one corner of the image and uses the fourth and fifth parameters to set the opposite corner. Use imageMode(CENTER) to draw images centered at the given x and y position.
+ * If no parameter is passed the currently set mode is returned as String.
+ *
+ * @cat    Document
+ * @subcat Image
+ * @method imageMode
+ * @param  {String} [mode] Either CORNER, CORNERS, or CENTER.
+ * @return {String} The current mode.
+ */
+pub.imageMode = function(mode) {
+  if (arguments.length === 0) return currImageMode;
+
+  if (mode === pub.CORNER || mode === pub.CORNERS || mode === pub.CENTER) {
+    currImageMode = mode;
+  } else {
+    error("imageMode(), unsupported imageMode. Use: CORNER, CORNERS, CENTER.");
+  }
+  return currImageMode;
+};
+
+// ----------------------------------------
+// src/includes/math.js
+// ----------------------------------------
+
+var Vector = pub.Vector = function() {
+
+  /**
+   * @description A class to describe a two or three dimensional vector. This datatype stores two or three variables that are commonly used as a position, velocity, and/or acceleration. Technically, position is a point and velocity and acceleration are vectors, but this is often simplified to consider all three as vectors. For example, if you consider a rectangle moving across the screen, at any given instant it has a position (the object's location, expressed as a point.), a velocity (the rate at which the object's position changes per time unit, expressed as a vector), and acceleration (the rate at which the object's velocity changes per time unit, expressed as a vector). Since vectors represent groupings of values, we cannot simply use traditional addition/multiplication/etc. Instead, we'll need to do some "vector" math, which is made easy by the methods inside the Vector class.
+   * <br><br>
+   * Constructor of Vector, can be two- or three-dimensional.
+   *
+   * @cat    Math
+   * @subcat Vector
+   * @method Vector
+   * @param  {Number} x The first vector.
+   * @param  {Number} y The second vector.
+   * @param  {Number} [z] The third vector.
+   * @constructor
+   */
+  function Vector(x, y, z) {
+    this.x = x || 0;
+    this.y = y || 0;
+    this.z = z || 0;
+  }
+  /**
+   * @description Static function. Calculates the Euclidean distance between two points (considering a point as a vector object).
+   * Is meant to be called "static" i.e. Vector.dist(v1, v2);
+   *
+   * @cat    Math
+   * @subcat Vector
+   * @method Vector.dist
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
+   * @return {Number} The distance.
+   * @static
+   */
+  Vector.dist = function(v1, v2) {
+    return v1.dist(v2);
+  };
+
+  /**
+   * @description Static function. Calculates the dot product of two vectors.
+   * Is meant to be called "static" i.e. Vector.dot(v1, v2);
+   *
+   * @cat    Math
+   * @subcat Vector
+   * @method Vector.dot
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
+   * @return {Number} The dot product.
+   * @static
+   */
+  Vector.dot = function(v1, v2) {
+    return v1.dot(v2);
+  };
+
+  /**
+   * @description Static function. Calculates the cross product of two vectors.
+   * Is meant to be called "static" i.e. Vector.cross(v1, v2);
+   *
+   * @cat    Math
+   * @subcat Vector
+   * @method Vector.cross
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
+   * @return {Number} The cross product.
+   * @static
+   */
+  Vector.cross = function(v1, v2) {
+    return v1.cross(v2);
+  };
+
+  /**
+   * @description Static function. Calculates the angle between two vectors.
+   * Is meant to be called "static" i.e. Vector.angleBetween(v1, v2);
+   *
+   * @cat    Math
+   * @subcat Vector
+   * @method Vector.angleBetween
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
+   * @return {Number} The angle.
+   * @static
+   */
+  Vector.angleBetween = function(v1, v2) {
+    return Math.acos(v1.dot(v2) / (v1.mag() * v2.mag()));
+  };
+
+  Vector.prototype = {
+
+    /**
+     * @description Sets the x, y, and z component of the vector using three separate variables, the data from a Vector, or the values from a float array.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.set
+     * @param  {Number|Array|Vector} v Either a vector, array or x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
+     */
+    set: function(v, y, z) {
+      if (arguments.length === 1) this.set(v.x || v[0] || 0, v.y || v[1] || 0, v.z || v[2] || 0);
+      else {
+        this.x = v;
+        this.y = y;
+        this.z = z;
+      }
+    },
+    /**
+     * @description Gets a copy of the vector, returns a Vector object.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.get
+     * @return {Vector} A copy of the vector.
+     */
+    get: function() {
+      return new Vector(this.x, this.y, this.z);
+    },
+    /**
+     * @description Calculates the magnitude (length) of the vector and returns the result as a float
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.mag
+     * @return {Number} The length.
+     */
+    mag: function() {
+      var x = this.x,
+        y = this.y,
+        z = this.z;
+      return Math.sqrt(x * x + y * y + z * z);
+    },
+    /**
+     * @description Adds x, y, and z components to a vector, adds one vector to another.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.add
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
+     */
+    add: function(v, y, z) {
+      if (arguments.length === 1) {
+        this.x += v.x;
+        this.y += v.y;
+        this.z += v.z;
+      } else {
+        this.x += v;
+        this.y += y;
+        this.z += z;
+      }
+    },
+    /**
+     * @description Substract x, y, and z components or a full vector from this vector
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.sub
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
+     */
+    sub: function(v, y, z) {
+      if (arguments.length === 1) {
+        this.x -= v.x;
+        this.y -= v.y;
+        this.z -= v.z;
+      } else {
+        this.x -= v;
+        this.y -= y;
+        this.z -= z;
+      }
+    },
+    /**
+     * @description Multiplies this vector with x, y, and z components or another vector.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.mult
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
+     */
+    mult: function(v) {
+      if (typeof v === "number") {
+        this.x *= v;
+        this.y *= v;
+        this.z *= v;
+      } else {
+        this.x *= v.x;
+        this.y *= v.y;
+        this.z *= v.z;
+      }
+    },
+    /**
+     * @description Divides this vector through x, y, and z components or another vector.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.div
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
+     */
+    div: function(v) {
+      if (typeof v === "number") {
+        this.x /= v;
+        this.y /= v;
+        this.z /= v;
+      } else {
+        this.x /= v.x;
+        this.y /= v.y;
+        this.z /= v.z;
+      }
+    },
+    /**
+     * @description Calculates the distance from this vector to another as x, y, and z components or full vector.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.dist
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
+     * @return {Number} The distance.
+     */
+    dist: function(v) {
+      var dx = this.x - v.x,
+        dy = this.y - v.y,
+        dz = this.z - v.z;
+      return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    },
+    /**
+     * @description Calculates the dot product from this vector to another as x, y, and z components or full vector.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.dot
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
+     * @return {Number} The dot product.
+     */
+    dot: function(v, y, z) {
+      if (arguments.length === 1) return this.x * v.x + this.y * v.y + this.z * v.z;
+      return this.x * v + this.y * y + this.z * z;
+    },
+    /**
+     * @description Calculates the cross product from this vector to another as x, y, and z components or full vector.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.cross
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
+     * @return {Number} The cross product.
+     */
+    cross: function(v) {
+      var x = this.x,
+        y = this.y,
+        z = this.z;
+      return new Vector(y * v.z - v.y * z, z * v.x - v.z * x, x * v.y - v.x * y);
+    },
+    /**
+     * @description Normalizes the length of this vector to 1.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.normalize
+     */
+    normalize: function() {
+      var m = this.mag();
+      if (m > 0) this.div(m);
+    },
+    /**
+     * @description Normalizes the length of this vector to the given parameter.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.limit
+     * @param  {Number} high The value to scale to.
+     */
+    limit: function(high) {
+      if (this.mag() > high) {
+        this.normalize();
+        this.mult(high);
+      }
+    },
+    /**
+     * @description The 2D orientation (heading) of this vector in radian.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.heading
+     * @return {Number} A radian angle value.
+     */
+    heading: function() {
+      return -Math.atan2(-this.y, this.x);
+    },
+    /**
+     * @description Returns data about this vector as a string.
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.toString
+     * @return {String} The x, y and z components as a string.
+     */
+    toString: function() {
+      return "[" + this.x + ", " + this.y + ", " + this.z + "]";
+    },
+    /**
+     * @description Returns this vector as an array [x,y,z].
+     *
+     * @cat    Math
+     * @subcat Vector
+     * @method Vector.array
+     * @return {Array} The x, y and z components as  an Array of [x,y,z].
+     */
+    array: function() {
+      return [this.x, this.y, this.z];
+    }
+  };
+
+  function createVectorMethod(method) {
+    return function(v1, v2) {
+      var v = v1.get();
+      v[method](v2);
+      return v;
+    };
+  }
+  for (var method in Vector.prototype) if (Vector.prototype.hasOwnProperty(method) && !Vector.hasOwnProperty(method)) Vector[method] = createVectorMethod(method);
+  return Vector;
+}();
+
+
+// -- Calculation --
+
+/**
+ * @description Calculates the absolute value (magnitude) of a number. The absolute value of a number is always positive.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method abs
+ * @param  {Number} val A number.
+ * @return {Number} The absolute value of that number.
+ */
+pub.abs = Math.abs;
+
+/**
+ * @description Calculates the closest int value that is greater than or equal to the value of the parameter. For example, ceil(9.03) returns the value 10.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method ceil
+ * @param  {Number} val An arbitrary number.
+ * @return {Number} The next highest integer value.
+ */
+pub.ceil = Math.ceil;
+
+/**
+ * @description Constrains a value to not exceed a maximum and minimum value.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method constrain
+ * @param  {Number} aNumber The value to constrain.
+ * @param  {Number} aMin Minimum limit.
+ * @param  {Number} aMax Maximum limit.
+ * @return {Number} The constrained value.
+ */
+pub.constrain = function(aNumber, aMin, aMax) {
+  if(arguments.length !== 3) error("constrain(), wrong argument count.");
+  if(aNumber <= aMin) return aMin;
+  if(aNumber >= aMax) return aMax;
+  return aNumber;
+};
+
+/**
+ * @description Calculates the distance between two points.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method dist
+ * @param  {Number} x1 The x-coordinate of the first point.
+ * @param  {Number} y1 The y-coordinate of the first point.
+ * @param  {Number} x2 The x-coordinate of the second point.
+ * @param  {Number} y2 The y-coordinate of the second point.
+ * @return {Number} The distance.
+ */
+pub.dist = function() {
+  var dx, dy, dz;
+  if (arguments.length === 4) {
+    dx = arguments[0] - arguments[2];
+    dy = arguments[1] - arguments[3];
+    return Math.sqrt(dx * dx + dy * dy);
+  } else {
+    error("dist(), wrong argument count.");
+  }
+};
+
+/**
+ * @description The Math.exp() function returns ex, where x is the argument, and e is Euler's number (also known as Napier's constant), the base of the natural logarithms.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method exp
+ * @param  {Number} x A number.
+ * @return {Number} A number representing ex.
+ */
+pub.exp = Math.exp;
+
+/**
+ * @description Calculates the closest int value that is less than or equal to the value of the parameter.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method floor
+ * @param  {Number} a A number.
+ * @return {Number} Integer number.
+ */
+pub.floor = Math.floor;
+
+/**
+ * @description Calculates a number between two numbers at a specific increment. The amt parameter is the amount to interpolate between the two values where 0.0 equal to the first point, 0.1 is very near the first point, 0.5 is half-way in between, etc. The lerp function is convenient for creating motion along a straight path and for drawing dotted lines.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method lerp
+ * @param  {Number} value1 First value.
+ * @param  {Number} value2 Second value.
+ * @param  {Number} amt Amount between 0.0 and 1.0.
+ * @return {Number} The mapped value.
+ */
+pub.lerp = function(value1, value2, amt) {
+  if(arguments.length !== 3) error("lerp(), wrong argument count.");
+  return (value2 - value1) * amt + value1;
+};
+
+/**
+ * @description Calculates the natural logarithm (the base-e logarithm) of a number. This function expects the values greater than 0.0.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method log
+ * @param  {Number} x A number, must be greater then 0.0.
+ * @return {Number} The natural logarithm.
+ */
+pub.log = Math.log;
+
+/**
+ * @description Calculates the magnitude (or length) of a vector. A vector is a direction in space commonly used in computer graphics and linear algebra. Because it has no "start" position, the magnitude of a vector can be thought of as the distance from coordinate (0,0) to its (x,y) value. Therefore, mag() is a shortcut for writing "dist(0, 0, x, y)".
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method mag
+ * @param  {Number} x Coordinate.
+ * @param  {Number} y Coordinate.
+ * @param  {Number} [z] Coordinate, optional.
+ * @return {Number} The magnitude.
+ */
+pub.mag = function(a, b, c) {
+  if(!(arguments.length === 2 || arguments.length === 3)) error("mag(), wrong argument count.");
+  if (c) return Math.sqrt(a * a + b * b + c * c);
+  return Math.sqrt(a * a + b * b);
+};
+
+/**
+ * @description Re-maps a number from one range to another.<br>
+ * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method map
+ * @param  {Number} value The value to be mapped.
+ * @param  {Number} istart The start of the input range.
+ * @param  {Number} istop The end of the input range.
+ * @param  {Number} ostart The start of the output range.
+ * @param  {Number} ostop The end of the output range.
+ * @return {Number} The mapped value.
+ */
+pub.map = function(value, istart, istop, ostart, ostop) {
+  if(arguments.length !== 5) error("map(), wrong argument count. Use: map(value, istart, istop, ostart, ostop)");
+  return ostart + (ostop - ostart) * ((value - istart) / (istop - istart));
+};
+
+/**
+ * @description Determines the largest value in a sequence of numbers.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method max
+ * @param  {Number|Array} a A value or an array of Numbers.
+ * @param  {Number} [b] Another value to be compared.
+ * @param  {Number} [c] Another value to be compared.
+ * @return {Number} The highest value.
+ */
+pub.max = function() {
+  if (arguments.length === 2) return arguments[0] < arguments[1] ? arguments[1] : arguments[0];
+  var numbers = arguments.length === 1 ? arguments[0] : arguments;
+  if (!("length" in numbers && numbers.length > 0)) error("max(), non-empty array is expected");
+  var max = numbers[0],
+    count = numbers.length;
+  for (var i = 1; i < count; ++i) if (max < numbers[i]) max = numbers[i];
+  return max;
+};
+
+/**
+ * @description Determines the smallest value in a sequence of numbers.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method min
+ * @param  {Number|Array} a A value or an array of Numbers.
+ * @param  {Number} [b] Another value to be compared.
+ * @param  {Number} [c] Another value to be compared.
+ * @return {Number} The lowest value.
+ */
+pub.min = function() {
+  if (arguments.length === 2) return arguments[0] < arguments[1] ? arguments[0] : arguments[1];
+  var numbers = arguments.length === 1 ? arguments[0] : arguments;
+  if (!("length" in numbers && numbers.length > 0)) error("min(), non-empty array is expected");
+  var min = numbers[0],
+    count = numbers.length;
+  for (var i = 1; i < count; ++i) if (min > numbers[i]) min = numbers[i];
+  return min;
+};
+
+/**
+ * @description Normalizes a number from another range into a value between 0 and 1.<br>
+ * Identical to map(value, low, high, 0, 1);<br>
+ * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method norm
+ * @param  {Number} aNumber The value to be normed.
+ * @param  {Number} low The lowest value to be expected.
+ * @param  {Number} high The highest value to be expected.
+ * @return {Number} The normalized value.
+ */
+pub.norm = function(aNumber, low, high) {
+  if(arguments.length !== 3) error("norm(), wrong argument count.");
+  return (aNumber - low) / (high - low);
+};
+
+/**
+ * @description Facilitates exponential expressions. The pow() function is an efficient way of multiplying numbers by themselves (or their reciprocal) in large quantities. For example, pow(3, 5) is equivalent to the expression 3*3*3*3*3 and pow(3, -5) is equivalent to 1 / 3*3*3*3*3
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method pow
+ * @param  {Number} num Base of the exponential expression.
+ * @param  {Number} exponent Power of which to raise the base.
+ * @return {Number} the result
+ */
+pub.pow = Math.pow;
+
+/**
+ * @description Calculates the integer closest to the value parameter. For example, round(9.2) returns the value 9.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method round
+ * @param  {Number} value The value to be rounded.
+ * @return {Number} The rounded value.
+ */
+pub.round = Math.round;
+
+/**
+ * @description Squares a number (multiplies a number by itself). The result is always a positive number, as multiplying two negative numbers always yields a positive result. For example, -1 * -1 = 1.
+ *
+ * @cat    Math
+ * @subcat Calculation
+ * @method sq
+ * @param  {Number} aNumber The value to be squared.
+ * @return {Number} Squared number.
+ */
+pub.sq = function(aNumber) {
+  if(arguments.length !== 1) error("sq(), wrong argument count.");
+  return aNumber * aNumber;
+};
+
+// -- Trigonometry --
+
+/**
+ * @description Calculates the square root of a number. The square root of a number is always positive, even though there may be a valid negative root. The square root s of number a is such that s*s = a. It is the opposite of squaring.
+ *
+ * @cat    Math
+ * @subcat Trigonometry
+ * @method sqrt
+ * @param  {Number} val A value.
+ * @return {Number} Square root.
+ */
+pub.sqrt = Math.sqrt;
+
+/**
+ * @description The inverse of cos(), returns the arc cosine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ *
+ * @cat    Math
+ * @subcat Trigonometry
+ * @method acos
+ * @param  {Number} value The value whose arc cosine is to be returned.
+ * @return {Number} The arc cosine.
+ */
+pub.acos = Math.acos;
+
+/**
+ * @description The inverse of sin(), returns the arc sine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ *
+ * @cat    Math
+ * @subcat Trigonometry
+ * @method asin
+ * @param  {Number} value The value whose arc sine is to be returned.
+ * @return {Number} The arc sine.
+ */
+pub.asin = Math.asin;
+
+/**
+ * @description The inverse of tan(), returns the arc tangent of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ *
+ * @cat    Math
+ * @subcat Trigonometry
+ * @method atan
+ * @param  {Number} value The value whose arc tangent is to be returned.
+ * @return {Number} The arc tangent.
+ */
+pub.atan = Math.atan;
+
+/**
+ * @description Calculates the angle (in radians) from a specified point to the coordinate origin as measured from the positive x-axis. Values are returned as a float in the range from PI to -PI. The atan2() function is most often used for orienting geometry to the position of the cursor. Note: The y-coordinate of the point is the first parameter and the x-coordinate is the second due the the structure of calculating the tangent.
+ *
+ * @cat    Math
+ * @subcat Trigonometry
+ * @method atan2
+ * @param  {Number} y The y coordinate.
+ * @param  {Number} x The x coordinate.
+ * @return {Number} The atan2 value.
+ */
+pub.atan2 = Math.atan2;
+
+/**
+ * @description Calculates the cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range -1 to 1.
+ *
+ * @cat    Math
+ * @subcat Trigonometry
+ * @method cos
+ * @param  {Number} rad A value in radians.
+ * @return {Number} The cosine.
+ */
+pub.cos = Math.cos;
+
+/**
+ * @description Converts a radian measurement to its corresponding value in degrees. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
+ *
+ * @cat    Math
+ * @subcat Trigonometry
+ * @method degrees
+ * @param  {Number} aAngle An angle in radians.
+ * @return {Number} The given angle in degree.
+ */
+pub.degrees = function(aAngle) {
+  return aAngle * 180 / Math.PI;
+};
+
+/**
+ * @description Converts a degree measurement to its corresponding value in radians. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
+ *
+ * @cat    Math
+ * @subcat Trigonometry
+ * @method radians
+ * @param  {Number} aAngle An angle in degree.
+ * @return {Number} The given angle in radians.
+ */
+pub.radians = function(aAngle) {
+  return aAngle / 180 * Math.PI;
+};
+
+/**
+ * @description Calculates the sine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to 6.28). Values are returned in the range -1 to 1.
+ *
+ * @cat    Math
+ * @subcat Trigonometry
+ * @method sin
+ * @param  {Number} rad A value in radians.
+ * @return {Number} The sine value.
+ */
+pub.sin = Math.sin;
+
+/**
+ * @description Calculates the ratio of the sine and cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range infinity to -infinity.
+ *
+ * @cat    Math
+ * @subcat Trigonometry
+ * @method tan
+ * @param  {Number} rad A value in radians.
+ * @return {Number} The tangent value.
+ */
+pub.tan = Math.tan;
+
+// -- Random --
+
+var currentRandom = Math.random;
+
+/**
+ * @description Generates random numbers. Each time the random() function is called, it returns an unexpected value within the specified range. If one parameter is passed to the function it will return a float between zero and the value of the high parameter. The function call random(5) returns values between 0 and 5. If two parameters are passed, it will return a float with a value between the the parameters. The function call random(-5, 10.2) returns values between -5 and 10.2.<br>
+ * One parameter sets the range from 0 to the given parameter, while with two parameters present you set the range from val1 - val2.
+ *
+ * @cat    Math
+ * @subcat Random
+ * @method random
+ * @param  {Number} [low] The low border of the range.
+ * @param  {Number} [high] The high border of the range.
+ * @return {Number} A random number.
+ */
+pub.random = function() {
+  if (arguments.length === 0) return currentRandom();
+  if (arguments.length === 1) return currentRandom() * arguments[0];
+  var aMin = arguments[0],
+    aMax = arguments[1];
+  return currentRandom() * (aMax - aMin) + aMin;
+};
+
+function Marsaglia(i1, i2) {
+  var z = i1 || 362436069,
+    w = i2 || 521288629;
+  var nextInt = function() {
+    z = 36969 * (z & 65535) + (z >>> 16) & 4294967295;
+    w = 18E3 * (w & 65535) + (w >>> 16) & 4294967295;
+    return ((z & 65535) << 16 | w & 65535) & 4294967295;
+  };
+  this.nextDouble = function() {
+    var i = nextInt() / 4294967296;
+    return i < 0 ? 1 + i : i;
+  };
+  this.nextInt = nextInt;
+}
+Marsaglia.createRandomized = function() {
+  var now = new Date();
+  return new Marsaglia(now / 6E4 & 4294967295, now & 4294967295);
+};
+/**
+ * @description Sets the seed value for random().<br>
+ * By default, random() produces different results each time the program is run. Set the seed parameter to a constant to return the same pseudo-random numbers each time the software is run.
+ *
+ * @cat    Math
+ * @subcat Random
+ * @method randomSeed
+ * @param  {Number} seed The seed value.
+ */
+pub.randomSeed = function(seed) {
+  currentRandom = (new Marsaglia(seed)).nextDouble;
+};
+/**
+ * @description Random Generator with Gaussian distribution.
+ *
+ * @cat    Math
+ * @subcat Random
+ * @method Random
+ * @param  {Number} seed The seed value.
+ * @constructor
+ */
+pub.Random = function(seed) {
+  var haveNextNextGaussian = false,
+    nextNextGaussian, random;
+  /**
+   * @method Random.nextGaussian
+   * @return {Number} The next Gaussian random value.
+   */
+  this.nextGaussian = function() {
+    if (haveNextNextGaussian) {
+      haveNextNextGaussian = false;
+      return nextNextGaussian;
+    }
+    var v1, v2, s;
+    do {
+      v1 = 2 * random() - 1;
+      v2 = 2 * random() - 1;
+      s = v1 * v1 + v2 * v2;
+    } while (s >= 1 || s === 0);
+    var multiplier = Math.sqrt(-2 * Math.log(s) / s);
+    nextNextGaussian = v2 * multiplier;
+    haveNextNextGaussian = true;
+    return v1 * multiplier;
+  };
+  random = seed === undefined ? Math.random : (new Marsaglia(seed)).nextDouble;
+};
+
+function PerlinNoise(seed) {
+  var rnd = seed !== undefined ? new Marsaglia(seed) : Marsaglia.createRandomized();
+  var i, j;
+  var perm = [];
+  for (i = 0; i < 256; ++i) perm[i] = i;
+  for (i = 0; i < 256; ++i) {
+    var t = perm[j = rnd.nextInt() & 255];
+    perm[j] = perm[i];
+    perm[i] = t;
+  }
+  for (i = 0; i < 256; ++i) perm[i + 256] = perm[i];
+
+  function grad3d(i, x, y, z) {
+    var h = i & 15;
+    var u = h < 8 ? x : y,
+      v = h < 4 ? y : h === 12 || h === 14 ? x : z;
+    return ((h & 1) === 0 ? u : -u) + ((h & 2) === 0 ? v : -v);
+  }
+
+  function grad2d(i, x, y) {
+    var v = (i & 1) === 0 ? x : y;
+    return (i & 2) === 0 ? -v : v;
+  }
+
+  function grad1d(i, x) {
+    return (i & 1) === 0 ? -x : x;
+  }
+  function lerp(t, a, b) {
+    return a + t * (b - a);
+  }
+
+  this.noise3d = function(x, y, z) {
+    var X = Math.floor(x) & 255,
+      Y = Math.floor(y) & 255,
+      Z = Math.floor(z) & 255;
+    x -= Math.floor(x);
+    y -= Math.floor(y);
+    z -= Math.floor(z);
+    var fx = (3 - 2 * x) * x * x,
+      fy = (3 - 2 * y) * y * y,
+      fz = (3 - 2 * z) * z * z;
+    var p0 = perm[X] + Y,
+      p00 = perm[p0] + Z,
+      p01 = perm[p0 + 1] + Z,
+      p1 = perm[X + 1] + Y,
+      p10 = perm[p1] + Z,
+      p11 = perm[p1 + 1] + Z;
+    return lerp(fz, lerp(fy, lerp(fx, grad3d(perm[p00], x, y, z), grad3d(perm[p10], x - 1, y, z)), lerp(fx, grad3d(perm[p01], x, y - 1, z), grad3d(perm[p11], x - 1, y - 1, z))), lerp(fy, lerp(fx, grad3d(perm[p00 + 1], x, y, z - 1), grad3d(perm[p10 + 1], x - 1, y, z - 1)), lerp(fx, grad3d(perm[p01 + 1], x, y - 1, z - 1), grad3d(perm[p11 + 1], x - 1, y - 1, z - 1))));
+  };
+
+  this.noise2d = function(x, y) {
+    var X = Math.floor(x) & 255,
+      Y = Math.floor(y) & 255;
+    x -= Math.floor(x);
+    y -= Math.floor(y);
+    var fx = (3 - 2 * x) * x * x,
+      fy = (3 - 2 * y) * y * y;
+    var p0 = perm[X] + Y,
+      p1 = perm[X + 1] + Y;
+    return lerp(fy, lerp(fx, grad2d(perm[p0], x, y), grad2d(perm[p1], x - 1, y)), lerp(fx, grad2d(perm[p0 + 1], x, y - 1), grad2d(perm[p1 + 1], x - 1, y - 1)));
+  };
+
+  this.noise1d = function(x) {
+    var X = Math.floor(x) & 255;
+    x -= Math.floor(x);
+    var fx = (3 - 2 * x) * x * x;
+    return lerp(fx, grad1d(perm[X], x), grad1d(perm[X + 1], x - 1));
+  };
+}
+var noiseProfile = {
+  generator: undefined,
+  octaves: 4,
+  fallout: 0.5,
+  seed: undefined
+};
+
+/**
+ * @description Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural ordered, harmonic succession of numbers compared to the standard random() function. It was invented by Ken Perlin in the 1980s and been used since in graphical applications to produce procedural textures, natural motion, shapes, terrains etc.
+ * <br><br>
+ * The main difference to the random() function is that Perlin noise is defined in an infinite n-dimensional space where each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. basil.js can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space. The 2nd and 3rd dimension can also be interpreted as time.
+ * <br><br>
+ * The actual noise is structured similar to an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, perlin noise is computed over several octaves which are added together for the final result.
+ * <br><br>
+ * Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space the value of the coordinates doesn't matter as such, only the distance between successive coordinates does (eg. when using noise() within a loop). As a general rule the smaller the difference between coordinates, the smoother the resulting noise sequence will be. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
+ *
+ * @cat    Math
+ * @subcat Random
+ * @method noise
+ * @param  {Number} x Coordinate in x space.
+ * @param  {Number} [y] Coordinate in y space.
+ * @param  {Number} [z] Coordinate in z space.
+ * @return {Number} The noise value.
+ */
+pub.noise = function(x, y, z) {
+  if (noiseProfile.generator === undefined) noiseProfile.generator = new PerlinNoise(noiseProfile.seed);
+  var generator = noiseProfile.generator;
+  var effect = 1,
+    k = 1,
+    sum = 0;
+  for (var i = 0; i < noiseProfile.octaves; ++i) {
+    effect *= noiseProfile.fallout;
+    switch (arguments.length) {
+      case 1:
+        sum += effect * (1 + generator.noise1d(k * x)) / 2;
+        break;
+      case 2:
+        sum += effect * (1 + generator.noise2d(k * x, k * y)) / 2;
+        break;
+      case 3:
+        sum += effect * (1 + generator.noise3d(k * x, k * y, k * z)) / 2;
+        break;
+    }
+    k *= 2;
+  }
+  return sum;
+};
+
+/**
+ * @description Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overal intensity of the noise, whereas higher octaves create finer grained details in the noise sequence. By default, noise is computed over 4 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the 1st octave. This falloff amount can be changed by adding an additional function parameter. Eg. a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. Any value between 0.0 and 1.0 is valid, however note that values greater than 0.5 might result in greater than 1.0 values returned by noise().
+ * <br><br>
+ * By changing these parameters, the signal created by the noise() function can be adapted to fit very specific needs and characteristics.
+ *
+ * @cat    Math
+ * @subcat Random
+ * @method noiseDetail
+ * @param  {Number} octaves Number of octaves to be used by the noise() function.
+ * @param  {Number} fallout Falloff factor for each octave.
+ */
+pub.noiseDetail = function(octaves, fallout) {
+  noiseProfile.octaves = octaves;
+  if (fallout !== undefined) noiseProfile.fallout = fallout;
+};
+
+/**
+ * @description Sets the seed value for noise(). By default, noise() produces different results each time the program is run. Set the value parameter to a constant to return the same pseudo-random numbers each time the software is run.
+ *
+ * @cat    Math
+ * @subcat Random
+ * @method noiseSeed
+ * @param  {Number} seed Noise seed value.
+ */
+pub.noiseSeed = function(seed) {
+  noiseProfile.seed = seed;
+  noiseProfile.generator = undefined;
+};
+
+
+// ----------------------------------------
+// Transform
+// geometricBounds hint: [y1, x1, y2, x2]
+
+var precision = function(num, dec) {
+  return Math.round(num * Math.pow(10, dec)) / Math.pow(10, dec);
+};
+
+/**
+ * @description The function calculates the geometric bounds of any given page item or text. Use the `transforms()` function to modify page items.
+ * In case the object is any kind of text, additional typographic information baseline and xHeight are calculated.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method bounds
+ * @param  {PageItem|Text} obj The page item or text to calculate the geometric bounds.
+ * @return {Object} Geometric bounds object with these properties: width, height, left, right, top, bottom and for text: baseline, xHeight.
+ */
+pub.bounds = function (obj) {
+  var x1, y1, x2, y2, w, h;
+
+  if (isText(obj)) {
+    var baseline = obj.baseline;
+    var ascent = obj.ascent;
+    var descent = obj.descent;
+
+    x1 = obj.horizontalOffset;
+    y1 = baseline - ascent;
+    x2 = obj.endHorizontalOffset;
+    y2 = baseline + descent;
+    w = x2 - x1;
+    h = y2 - y1;
+
+    if (w < 0 || h < 0) {
+      warning("bounds(), not possible to get correct bounds, possible line break within textObj");
+    }
+
+    // We not sure if this 100% correct, check
+    // http://en.wikipedia.org/wiki/File:Typography_Line_Terms.svg
+    var xHeight = y1 + descent;
+
+    return {"width":w,
+            "height":h,
+            "left":x1,
+            "right":x2,
+            "top":y1,
+            "bottom":y2,
+            "baseline":baseline,
+            "xHeight":xHeight};
+  } else {
+    // is it a pageItem?
+    if (obj.hasOwnProperty("geometricBounds")) {
+      var geometricBounds = obj.geometricBounds; // [y1, x1, y2, x2]
+      x1 = geometricBounds[1];
+      y1 = geometricBounds[0];
+      x2 = geometricBounds[3];
+      y2 = geometricBounds[2];
+      w = x2 - x1;
+      h = y2 - y1;
+      return {"width":w, "height":h, "left":x1, "right":x2, "top":y1, "bottom":y2};
+    }
+    // everything else e.g. page, spread
+    else if (obj.hasOwnProperty("bounds")) {
+      var bounds = obj.bounds; // [y1, x1, y2, x2]
+      x1 = bounds[1];
+      y1 = bounds[0];
+      x2 = bounds[3];
+      y2 = bounds[2];
+      w = x2 - x1;
+      h = y2 - y1;
+      return {"width":w, "height":h, "left":x1, "right":x2, "top":y1, "bottom":y2};
+    }
+    // no idea what that might be, give up
+    else {
+      error("bounds(), invalide type of parameter! Can't get bounds for this object.");
+    }
+  }
+};
+
+
+  Supported Adobe InDesign versions: CS 5+
+
+  .--.--.- .-.-......-....--.-- -.... -..---.-.... .-- . .---.- -... -.-..---.-. ..--.-- -.. -
+*/
+/* globals init */
+// @target "InDesign";
+
+
+// ----------------------------------------
+// src/includes/transformation.js
+// ----------------------------------------
+/* global precision */
+
+/**
+ * @description Sets the reference point for transformations using the `transform()` function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.<br>
+ * Arguments can be the basil constants `TOP_LEFT`, `TOP_CENTER`, `TOP_RIGHT`, `CENTER_LEFT`, `CENTER`, `CENTER_RIGHT`, `BOTTOM_LEFT`, `BOTTOM_CENTER` or `BOTTOM_RIGHT`. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.<br>
+ * If the function is used without any arguments the currently set reference point will be returned.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method referencePoint
+ * @param  {String} [referencePoint] The reference point to set.
+ * @return {String} Current reference point setting.
+ */
+pub.referencePoint = function(rp) {
+  if(!arguments.length) {
+    return currRefPoint;
+  }
+
+  var anchorEnum;
+
+  if(rp === pub.TOP_LEFT || rp === 7 || rp === AnchorPoint.TOP_LEFT_ANCHOR) {
+    currRefPoint = pub.TOP_LEFT;
+    anchorEnum = AnchorPoint.TOP_LEFT_ANCHOR;
+  } else if(rp === pub.TOP_CENTER || rp === 8 || rp === AnchorPoint.TOP_CENTER_ANCHOR) {
+    currRefPoint = pub.TOP_CENTER;
+    anchorEnum = AnchorPoint.TOP_CENTER_ANCHOR;
+  } else if(rp === pub.TOP_RIGHT || rp === 9 || rp === AnchorPoint.TOP_RIGHT_ANCHOR) {
+    currRefPoint = pub.TOP_RIGHT;
+    anchorEnum = AnchorPoint.TOP_RIGHT_ANCHOR;
+  } else if(rp === pub.CENTER_LEFT || rp === 4 || rp === AnchorPoint.LEFT_CENTER_ANCHOR) {
+    currRefPoint = pub.CENTER_LEFT;
+    anchorEnum = AnchorPoint.LEFT_CENTER_ANCHOR;
+  } else if(rp === pub.CENTER || rp === pub.CENTER_CENTER || rp === 5 || rp === AnchorPoint.CENTER_ANCHOR) {
+    currRefPoint = pub.CENTER;
+    anchorEnum = AnchorPoint.CENTER_ANCHOR;
+  } else if(rp === pub.CENTER_RIGHT || rp === 6 || rp === AnchorPoint.RIGHT_CENTER_ANCHOR) {
+    currRefPoint = pub.CENTER_RIGHT;
+    anchorEnum = AnchorPoint.RIGHT_CENTER_ANCHOR;
+  } else if(rp === pub.BOTTOM_LEFT || rp === 1 || rp === AnchorPoint.BOTTOM_LEFT_ANCHOR) {
+    currRefPoint = pub.BOTTOM_LEFT;
+    anchorEnum = AnchorPoint.BOTTOM_LEFT_ANCHOR;
+  } else if(rp === pub.BOTTOM_CENTER || rp === 2 || rp === AnchorPoint.BOTTOM_CENTER_ANCHOR) {
+    currRefPoint = pub.BOTTOM_CENTER;
+    anchorEnum = AnchorPoint.BOTTOM_CENTER_ANCHOR;
+  } else if(rp === pub.BOTTOM_RIGHT || rp === 3 || rp === AnchorPoint.BOTTOM_RIGHT_ANCHOR) {
+    currRefPoint = pub.BOTTOM_RIGHT;
+    anchorEnum = AnchorPoint.BOTTOM_RIGHT_ANCHOR;
+  } else {
+    error("referencePoint(), wrong argument! Use reference point constant (TOP_LEFT, TOP_CENTER, ...), a digit between 1 and 9 or an InDesign anchor point enumerator.");
+  }
+
+  if(app.properties.activeWindow instanceof LayoutWindow ) {
+    app.activeWindow.transformReferencePoint = anchorEnum;
+  }
+
+  return currRefPoint;
+};
+
+/**
+ * @description Transforms a given page item. The type of transformation is determinded with the second parameter. The third parameter is the transformation value, either a number or an array of x and y values. The transformation's reference point (top left, bottom center etc.) can be set beforehand by using the `referencePoint()` function. If the third parameter is ommited, the function can be used to measure the value of the page item.
+ * There are 10 different transformation types:
+ *    - `"translate"`: Translates the page item by the given `[x, y]` values. Returns the coordinates of the page item's anchor point as an array.
+ *    - `"rotate"`: Rotates the page item to the given degree value. Returns the page item's rotation value in degrees.
+ *    - `"scale"`: Scales the page item to the given `[x, y]` scale factor values. Alternatively, a single scale factor value can be used to scale the page item uniformely. Returns the scale factor values of the page item's current scale as an array.
+ *    - `"shear"`: Shears the page item to the given degree value. Returns the page item's shear value in degrees.
+ *    - `"size"`: Sets the page item's size to the given `[x, y]` dimensions. Returns the size of the page item as an array.
+ *    - `"width"`: Sets the page item's width to the given value. Returns the width of the page item.
+ *    - `"height"`: Sets the page item's height to the given value. Returns the height of the page item.
+ *    - `"position"`: Sets the position of the page item's anchor point to the given `[x, y]` coordinates. Returns the coordinates of the page item's anchor point as an array.
+ *    - `"x"`: Sets the x-position of the page item's anchor point to the given value. Returns the x-coordinate of the page item's anchor point.
+ *    - `"y"`: Sets the y-position of the page item's anchor point to the given value. Returns the y-coordinate of the page item's anchor point.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method transform
+ * @param  {PageItem} pItem The page item to transform.
+ * @param  {String} type The type of transformation.
+ * @param  {Number|Array} [value] The value(s) of the transformation.
+ * @return {Number|Array} The current value(s) of the specified transformation.
+ *
+ * @example <caption>Rotating a rectangle to a 25 degrees angle</caption>
+ * var r = rect(20, 40, 200, 100);
+ * transform(r, "rotate", 25);
+ *
+ * @example <caption>Measure the width of a rectangle</caption>
+ * var r = rect(20, 40, random(100, 300), 100);
+ * var w = transform(r, "width");
+ * println(w); // prints the rectangle's random width between 100 and 300
+ *
+ * @example <caption>Position a rectangle's lower right corner at a certain position</caption>
+ * var r = rect(20, 40, random(100, 300), random(50, 150));
+ * referencePoint(BOTTOM_RIGHT);
+ * transform(r, "position", [40, 40]);
+ */
+pub.transform = function(pItem, type, value) {
+
+  if(!pItem || !pItem.hasOwnProperty("geometricBounds")) {
+    error("transform(), invalid first parameter. Use page item.");
+  }
+
+  app.transformPreferences.adjustStrokeWeightWhenScaling = false;
+  app.transformPreferences.whenScaling = WhenScalingOptions.ADJUST_SCALING_PERCENTAGE;
+
+  var result = null;
+  var idAnchorPoints = {
+    topLeft: AnchorPoint.TOP_LEFT_ANCHOR,
+    topCenter: AnchorPoint.TOP_CENTER_ANCHOR,
+    topRight: AnchorPoint.TOP_RIGHT_ANCHOR,
+    centerLeft: AnchorPoint.LEFT_CENTER_ANCHOR,
+    center: AnchorPoint.CENTER_ANCHOR,
+    centerRight: AnchorPoint.RIGHT_CENTER_ANCHOR,
+    bottomLeft: AnchorPoint.BOTTOM_LEFT_ANCHOR,
+    bottomCenter: AnchorPoint.BOTTOM_CENTER_ANCHOR,
+    bottomRight: AnchorPoint.BOTTOM_RIGHT_ANCHOR
+  };
+  var basilUnits = {
+    pt: MeasurementUnits.POINTS,
+    mm: MeasurementUnits.MILLIMETERS,
+    cm: MeasurementUnits.CENTIMETERS,
+    inch: MeasurementUnits.INCHES,
+    px: MeasurementUnits.PIXELS
+  }
+
+  var aPoint = idAnchorPoints[currRefPoint];
+  var unitEnum = basilUnits[currUnits];
+
+  var tm = app.transformationMatrices.add();
+  var bounds = pItem.geometricBounds;
+  var w = Math.abs(bounds[3] - bounds[1]);
+  var h = Math.abs(bounds[2] - bounds[0]);
+
+  if(type === "width") {
+    if(isNumber(value)) {
+      tm = tm.scaleMatrix(value / w, 1);
+      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
+    } else {
+      result = precision(w, 12);
+    }
+
+  } else if (type === "height") {
+    if(isNumber(value)) {
+      tm = tm.scaleMatrix(1, value / h);
+      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
+    } else {
+      result = precision(h, 12);
+    }
+
+  } else if (type === "size") {
+    if(isArray(value)) {
+      tm = tm.scaleMatrix(value[0] / w, value[1] / h);
+      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
+    } else {
+      result = [precision(w, 12), precision(h, 12)];
+    }
+
+  } else if(type === "translate" || type === "translation") {
+    if(isArray(value)) {
+
+      // for proper matrix translation, convert units to points
+      value[0] = UnitValue(value[0], unitEnum).as(MeasurementUnits.POINTS);
+      value[1] = UnitValue(value[1], unitEnum).as(MeasurementUnits.POINTS);
+
+      tm = tm.translateMatrix(value[0], value[1]);
+      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
+    }
+    result = transform(pItem, "position");
+
+  } else if (type === "rotate" || type === "rotation") {
+    if(isNumber(value)) {
+      tm = tm.rotateMatrix(-pItem.rotationAngle - value);
+      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
+    }
+    result = -pItem.rotationAngle;
+
+  } else if (type === "scale" || type === "scaling") {
+    if(isNumber(value)) {
+      tm = tm.scaleMatrix(value, value);
+      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
+    } else if(isArray(value)) {
+      tm = tm.scaleMatrix(value[0], value[1]);
+      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
+    }
+    result = [pItem.horizontalScale / 100, pItem.verticalScale / 100];
+
+  } else if (type === "shear"  || type === "shearing") {
+    if(isNumber(value)) {
+      tm = tm.shearMatrix(-pItem.shearAngle - value);
+      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
+    }
+    result = -pItem.shearAngle;
+
+  } else if (type === "position" || type === "x" || type === "y") {
+
+    // find page that holds the top left corner of the current canvas mode
+    var refPage = currPage;
+    if(!(currCanvasMode === PAGE || currCanvasMode === MARGIN || currCanvasMode === BLEED)) {
+      refPage = currPage.parent.pages.firstItem();
+    }
+
+    var topLeft = refPage.resolve([AnchorPoint.TOP_LEFT_ANCHOR, BoundingBoxLimits.GEOMETRIC_PATH_BOUNDS, CoordinateSpaces.INNER_COORDINATES], CoordinateSpaces.SPREAD_COORDINATES)[0];
+
+    topLeft[0] += UnitValue(currOriginX, unitEnum).as(MeasurementUnits.POINTS);
+    topLeft[1] += UnitValue(currOriginY, unitEnum).as(MeasurementUnits.POINTS);
+
+    var anchorPosOnSpread = pItem.resolve([aPoint, BoundingBoxLimits.GEOMETRIC_PATH_BOUNDS, CoordinateSpaces.INNER_COORDINATES], CoordinateSpaces.SPREAD_COORDINATES)[0];
+    var anchorPosOnPagePt = [anchorPosOnSpread[0] - topLeft[0], anchorPosOnSpread[1] - topLeft[1]];
+
+    // convert position to user units
+    var anchorPosOnPage = [
+      UnitValue(anchorPosOnPagePt[0], MeasurementUnits.POINTS).as(unitEnum),
+      UnitValue(anchorPosOnPagePt[1], MeasurementUnits.POINTS).as(unitEnum),
+    ];
+
+    if(type === "x") {
+      if(isNumber(value)) {
+        transform(pItem, "position", [value, anchorPosOnPage[1]]);
+        return value;
+      } else {
+        result = precision(anchorPosOnPage[0], 12);
+      }
+
+    } else if (type === "y") {
+      if(isNumber(value)) {
+        transform(pItem, "position", [anchorPosOnPage[0], value]);
+        return value;
+      } else {
+        result = precision(anchorPosOnPage[1], 12);
+      }
+
+    } else {
+      if(isArray(value)) {
+        var offset = [value[0] - anchorPosOnPage[0], value[1] - anchorPosOnPage[1]];
+        transform(pItem, "translate", offset);
+        return value;
+      } else {
+        result = [precision(anchorPosOnPage[0], 12), precision(anchorPosOnPage[1], 12)];
+      }
+    }
+
+  } else {
+    error("transform(), invalid transform type. Use \"translate\", \"rotate\", \"scale\", \"shear\", \"size\", \"width\", \"height\", \"position\", \"x\" or \"y\".");
+  }
+
+  app.transformPreferences.adjustStrokeWeightWhenScaling = true;
+  app.transformPreferences.whenScaling = WhenScalingOptions.APPLY_TO_CONTENT;
+
+  if(result === null) {
+    result = value;
+  }
+  return result;
+
+}
+
+var printMatrixHelper = function(elements) {
+  var big = 0;
+  for (var i = 0; i < elements.length; i++) {
+    if (i !== 0) {
+      big = Math.max(big, Math.abs(elements[i]));
+
+    } else {
+      big = Math.abs(elements[i]);
+    }
+  }
+  var digits = (big + "").indexOf(".");
+  if (digits === 0) {
+    digits = 1;
+  } else if (digits === -1) {
+    digits = (big + "").length;
+  }
+  return digits;
+};
+
+// ----------------------------------------
+// private matrix functions
+
+var Matrix2D = function() {
+  if (arguments.length === 0) {
+    this.reset();
+  } else if (arguments.length === 1 && arguments[0] instanceof Matrix2D) {
+    this.set(arguments[0].array());
+  } else if (arguments.length === 6) {
+    this.set(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5]);
+  }
+};
+
+Matrix2D.prototype = {
+
+  // Set a Matrix.
+  set: function() {
+    if (arguments.length === 6) {
+      var a = arguments;
+      this.set([a[0], a[1], a[2], a[3], a[4], a[5]]);
+    } else if (arguments.length === 1 && arguments[0] instanceof Matrix2D) {
+      this.elements = arguments[0].array();
+    } else if (arguments.length === 1 && arguments[0] instanceof Array) {
+      this.elements = arguments[0].slice();
+    }
+  },
+
+  // Get a Matrix.
+  get: function() {
+    var outgoing = new Matrix2D();
+    outgoing.set(this.elements);
+    return outgoing;
+  },
+
+  // Reset the Matrix.
+  reset: function() {
+    this.set([1, 0, 0, 0, 1, 0]);
+  },
+
+  // Slice the Matrix into an array.
+  array: function array() {
+    return this.elements.slice();
+  },
+
+  adobeMatrix: function array(x, y) {
+    // this seems to work:
+    // it's important to know the position of the object around which it will be rotated and scaled.
+
+    // 1. making a copy of this matrix
+    var tmpMatrix = this.get();
+
+    // 2. pre-applying a translation as if the object was starting from the origin
+    tmpMatrix.preApply([1, 0, -x, 0, 1, -y]);
+
+    // 3. move to object to its given coordinates
+    tmpMatrix.apply([1, 0, x, 0, 1, y]);
+
+    var uVX = new UnitValue(tmpMatrix.elements[2], currUnits);
+    var uVY = new UnitValue(tmpMatrix.elements[5], currUnits);
+
+    return [
+      tmpMatrix.elements[0],
+      tmpMatrix.elements[3],
+      tmpMatrix.elements[1],
+      tmpMatrix.elements[4],
+      uVX.as("pt"),
+      uVY.as("pt")
+    ];
+  },
+
+  translate: function(tx, ty) {
+    this.elements[2] = tx * this.elements[0] + ty * this.elements[1] + this.elements[2];
+    this.elements[5] = tx * this.elements[3] + ty * this.elements[4] + this.elements[5];
+  },
+
+  scale: function(sx, sy) {
+    if (sx && !sy) {
+      sy = sx;
+    }
+    if (sx && sy) {
+      this.elements[0] *= sx;
+      this.elements[1] *= sy;
+      this.elements[3] *= sx;
+      this.elements[4] *= sy;
+    }
+  },
+
+  apply: function() {
+    var source;
+    if (arguments.length === 1 && arguments[0] instanceof Matrix2D) {
+      source = arguments[0].array();
+    } else if (arguments.length === 6) {
+      source = Array.prototype.slice.call(arguments);
+    } else if (arguments.length === 1 && arguments[0] instanceof Array) {
+      source = arguments[0];
+    }
+    var result = [0, 0, this.elements[2], 0, 0, this.elements[5]];
+    var e = 0;
+    for (var row = 0; row < 2; row++) {
+      for (var col = 0; col < 3; col++, e++) {
+        result[e] += this.elements[row * 3 + 0] * source[col + 0] + this.elements[row * 3 + 1] * source[col + 3];
+      }
+    }
+    this.elements = result.slice();
+  },
+
+  preApply: function() {
+    var source;
+    if (arguments.length === 1 && arguments[0] instanceof Matrix2D) {
+      source = arguments[0].array();
+    } else if (arguments.length === 6) {
+      source = Array.prototype.slice.call(arguments);
+    } else if (arguments.length === 1 && arguments[0] instanceof Array) {
+      source = arguments[0];
+    }
+    var result = [0, 0, source[2], 0, 0, source[5]];
+    result[2] = source[2] + this.elements[2] * source[0] + this.elements[5] * source[1];
+    result[5] = source[5] + this.elements[2] * source[3] + this.elements[5] * source[4];
+    result[0] = this.elements[0] * source[0] + this.elements[3] * source[1];
+    result[3] = this.elements[0] * source[3] + this.elements[3] * source[4];
+    result[1] = this.elements[1] * source[0] + this.elements[4] * source[1];
+    result[4] = this.elements[1] * source[3] + this.elements[4] * source[4];
+    this.elements = result.slice();
+  },
+
+  rotate: function(angle) {
+    var c = Math.cos(angle);
+    var s = Math.sin(angle);
+    var temp1 = this.elements[0];
+    var temp2 = this.elements[1];
+    this.elements[0] = c * temp1 + s * temp2;
+    this.elements[1] = -s * temp1 + c * temp2;
+    temp1 = this.elements[3];
+    temp2 = this.elements[4];
+    this.elements[3] = c * temp1 + s * temp2;
+    this.elements[4] = -s * temp1 + c * temp2;
+  },
+
+  print: function() {
+    var digits = printMatrixHelper(this.elements);
+    var output = "" + pub.nfs(this.elements[0], digits, 4) + " " + pub.nfs(this.elements[1], digits, 4) + " " + pub.nfs(this.elements[2], digits, 4) + "\n" + pub.nfs(this.elements[3], digits, 4) + " " + pub.nfs(this.elements[4], digits, 4) + " " + pub.nfs(this.elements[5], digits, 4) + "\n\n";
+    pub.println(output);
+  }
+};
+
+/**
+ * @description Multiplies the current matrix by the one specified through the parameters.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method applyMatrix
+ * @param  {Matrix2D} matrix The matrix to be applied.
+ */
+pub.applyMatrix = function (matrix) {
+  currMatrix.apply(matrix);
+};
+
+/**
+ * @description Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method popMatrix
+ */
+pub.popMatrix = function () {
+  if (matrixStack.length > 0) {
+    currMatrix.set(matrixStack.pop());
+  } else {
+    error("popMatrix(), missing a pushMatrix() to go with that popMatrix()");
+  }
+};
+
+/**
+ * @description Prints the current matrix to the console window.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method printMatrix
+ */
+pub.printMatrix = function () {
+  currMatrix.print();
+};
+
+/**
+ * @description Pushes the current transformation matrix onto the matrix stack. Understanding `pushMatrix()` and `popMatrix()` requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method pushMatrix
+ */
+pub.pushMatrix = function () {
+  matrixStack.push(currMatrix.array());
+};
+
+/**
+ * @description Replaces the current matrix with the identity matrix.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method resetMatrix
+ */
+pub.resetMatrix = function () {
+  matrixStack = [];
+  currMatrix = new Matrix2D();
+
+  pub.translate(currOriginX, currOriginY);
+};
+
+/**
+ * @description Rotates an object the amount specified by the angle parameter. Angles should be specified in radians (values from 0 to `PI`*2) or converted to radians with the `radians()` function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a clockwise direction with 0 radians or degrees being up and `HALF_PI` being to the right etc. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `rotate(PI/2)` and then `rotate(PI/2)` is the same as `rotate(PI)`. If `rotate()` is called within the `draw()`, the transformation is reset when the loop begins again. Technically, `rotate()` multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method rotate
+ * @param  {Number} angle The angle specified in radians
+ */
+pub.rotate = function (angle) {
+  if(typeof arguments[0] === "undefined") {
+    error("Please provide an angle for rotation.");
+  }
+  currMatrix.rotate(angle);
+};
+
+/**
+ * @description Increasing and decreasing the size of an object by expanding and contracting vertices. Scale values are specified as decimal percentages. The function call `scale(2.0)` increases the dimension of a shape by 200%. Objects always scale from their relative origin to the coordinate system. Transformations apply to everything that happens after and subsequent calls to the function multiply the effect. For example, calling `scale(2.0)` and then `scale(1.5)` is the same as `scale(3.0)`. If `scale()` is called within `draw()`, the transformation is reset when the loop begins again. This function can be further controlled by `pushMatrix()` and `popMatrix()`.
+ * If only one parameter is given, it is applied on X and Y axis.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method scale
+ * @param  {Number} scaleX The amount to scale the X axis.
+ * @param  {Number} scaleY The amount to scale the Y axis.
+ */
+pub.scale = function (scaleX, scaleY) {
+  if(typeof arguments[0] != "number" || (arguments.length === 2 && typeof arguments[1] != "number")) {
+    error("Please provide valid x and/or y factors for scaling.");
+  }
+  currMatrix.scale(scaleX, scaleY);
+};
+
+/**
+ * @description Specifies an amount to displace objects within the page. The x parameter specifies left/right translation, the y parameter specifies up/down translation. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `translate(50, 0)` and then `translate(20, 0)` is the same as `translate(70, 0)`. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
+ *
+ * @cat    Document
+ * @subcat Transformation
+ * @method translate
+ * @param  {Number} tx The amount of offset on the X axis.
+ * @param  {Number} ty The amount of offset on the Y axis.
+ */
+pub.translate = function (tx, ty) {
+  if(typeof arguments[0] === "undefined" || typeof arguments[1] === "undefined") {
+    error("Please provide x and y coordinates for translation.");
+  }
+  currMatrix.translate(tx, ty);
+};
+
+// clearing global space if it is still populated from previous run of a loop script
+// ----------------------------------------
+// src/includes/ui.js
+// ----------------------------------------
+
+// Hey Ken, this is your new home...
+// to ensure basil methods work properly
+
+if($.engineName === "loop" && $.global.basilGlobal) {
+init();
+
+})();
+  for (var i = basilGlobal.length - 1; i >= 0; i--) {
+    if($.global.hasOwnProperty(basilGlobal[i])) {
+      try{
+        delete $.global[basilGlobal[i]];
+      } catch(e) {
+        // could not delete
+      }
+    }
+  }
+  delete $.global.basilGlobal;
+}
+
+if(!$.global.hasOwnProperty("basilTest")) {
+  // load global vars of the user script
+  var sourceScript;
+  try {
+    app.nonExistingProperty;
+  } catch(e) {
+    sourceScript = e.source;
+  }
+
+  var userScript = sourceScript.replace(/[\s\S]*[#@]\s*[i]nclude\s+.+basil\.js["']*[\s;)}]*/, "");
+  app.doScript(userScript);
+}
+
+
+(function() {
+
+var pub = {};
+
+/**
+ * The basil version
+ * @property VERSION {String}
+ * @cat Environment
+ */
+pub.VERSION = "1.1.0";
+
+// ----------------------------------------
+// src/includes/constants.js
+// ----------------------------------------
+
+/**
+ * Used with units() to set the coordinate system to points.
+ * @property PT {String}
+ * @cat Document
+ * @subcat Units
+ */
+pub.PT = "pt";
+
+/**
+ * Used with units() to set the coordinate system to pixels.
+ * @property PX {String}
+ * @cat Document
+ * @subcat Units
+ */
+pub.PX = "px";
+
+/**
+ * Used with units() to set the coordinate system to centimeters.
+ * @property CM {String}
+ * @cat Document
+ * @subcat Units
+ */
+
+pub.CM = "cm";
+
+/**
+ * Used with units() to set the coordinate system to millimeters.
+ * @property MM {String}
+ * @cat Document
+ * @subcat Units
+ */
+pub.MM = "mm";
+
+/**
+ * Used with units() to set the coordinate system to inches.
+ * @property IN {String}
+ * @cat Document
+ * @subcat Units
+ */
+pub.IN = "inch";
+
+/**
+ * Used with colorMode() to set the color space.
+ * @property RGB {String}
+ * @cat Color
+ */
+pub.RGB = "rgb";
+
+/**
+ * Used with colorMode() to set the color space.
+ * @property CMYK {String}
+ * @cat Color
+ */
+pub.CMYK = "cmyk";
+
+/**
+ * Used with gradientMode() to set the gradient mode.
+ * @property LINEAR {String}
+ * @cat Color
+ */
+pub.LINEAR = "linear";
+
+/**
+ * Used with gradientMode() to set the gradient mode.
+ * @property RADIAL {String}
+ * @cat Color
+ */
+pub.RADIAL = "radial";
+
+/**
+ * Corner, used for drawing modes.
+ * @property CORNER {String}
+ * @cat Document
+ * @subcat Primitives
+ */
+pub.CORNER = "corner";
+
+/**
+ * Corners, used for drawing modes.
+ * @property CORNERS {String}
+ * @cat Document
+ * @subcat Primitives
+ */
+pub.CORNERS = "corners";
+
+/**
+ * Center, used for drawing modes or used with referencePoint() to set the reference point of transformations to the center of the page item.
+ * @property CENTER {String}
+ * @cat Document
+ * @subcat Primitives
+ */
+pub.CENTER = "center";
+pub.CENTER_CENTER = "center";
+
+/**
+ * Radius, used for drawing modes.
+ * @property RADIUS {String}
+ * @cat Document
+ * @subcat Primitives
+ */
+pub.RADIUS = "radius";
+
+/**
+ * Used with referencePoint() to set the reference point of transformations to the top left of the page item.
+ * @property TOP_LEFT {String}
+ * @cat Document
+ * @subcat Transformation
+ */
+pub.TOP_LEFT = "topLeft";
+
+/**
+ * Used with referencePoint() to set the reference point of transformations to the top center of the page item.
+ * @property TOP_CENTER {String}
+ * @cat Document
+ * @subcat Transformation
+ */
+pub.TOP_CENTER = "topCenter";
+
+/**
+ * Used with referencePoint() to set the reference point of transformations to the top right of the page item.
+ * @property TOP_RIGHT {String}
+ * @cat Document
+ * @subcat Transformation
+ */
+pub.TOP_RIGHT = "topRight";
+
+/**
+ * Used with referencePoint() to set the reference point of transformations to the center left of the page item.
+ * @property CENTER_LEFT {String}
+ * @cat Document
+ * @subcat Transformation
+ */
+pub.CENTER_LEFT = "centerLeft";
+
+/**
+ * Used with referencePoint() to set the reference point of transformations to the center right of the page item.
+ * @property CENTER_RIGHT {String}
+ * @cat Document
+ * @subcat Transformation
+ */
+pub.CENTER_RIGHT = "centerRight";
+
+/**
+ * Used with referencePoint() to set the reference point of transformations to the bottom left of the page item.
+ * @property BOTTOM_LEFT {String}
+ * @cat Document
+ * @subcat Transformation
+ */
+pub.BOTTOM_LEFT = "bottomLeft";
+
+/**
+ * Used with referencePoint() to set the reference point of transformations to the bottom center of the page item.
+ * @property BOTTOM_CENTER {String}
+ * @cat Document
+ * @subcat Transformation
+ */
+pub.BOTTOM_CENTER = "bottomCenter";
+
+/**
+ * Used with referencePoint() to set the reference point of transformations to the bottom right of the page item.
+ * @property BOTTOM_RIGHT {String}
+ * @cat Document
+ * @subcat Transformation
+ */
+pub.BOTTOM_RIGHT = "bottomRight";
+
+/**
+ * Close, used for endShape() modes.
+ * @property CLOSE {String}
+ * @cat Document
+ * @subcat Primitives
+ */
+pub.CLOSE = "close";
+
+/**
+ * Open, used for arc() modes.
+ * @property OPEN {String}
+ * @cat Document
+ * @subcat Primitives
+ */
+pub.OPEN = "open";
+
+/**
+ * Chord, used for arc() modes.
+ * @property CHORD {String}
+ * @cat Document
+ * @subcat Primitives
+ */
+pub.CHORD = "chord";
+
+/**
+ * Pie, used for arc() modes.
+ * @property PIE {String}
+ * @cat Document
+ * @subcat Primitives
+ */
+pub.PIE = "pie";
+
+/**
+ * Two Pi
+ * @property TWO_PI {Number}
+ * @cat Math
+ * @subcat Constants
+ */
+pub.TWO_PI = Math.PI * 2;
+
+/**
+ * Pi
+ * @property PI {Number}
+ * @cat Math
+ * @subcat Constants
+ */
+pub.PI = Math.PI;
+
+/**
+ * Half Pi
+ * @property HALF_PI {Number}
+ * @cat Math
+ * @subcat Constants
+ */
+pub.HALF_PI = Math.PI / 2;
+
+/**
+ * Quarter Pi
+ * @property QUARTER_PI {Number}
+ * @cat Math
+ * @subcat Constants
+ */
+pub.QUARTER_PI = Math.PI / 4;
+
+/**
+ * Sin Cos Length
+ * @property SINCOS_LENGTH {Number}
+ * @cat Math
+ * @subcat Constants
+ */
+pub.SINCOS_LENGTH = 720;
+
+/**
+ * Epsilon
+ * @property EPSILON {Number}
+ * @cat Math
+ * @subcat Constants
+ */
+pub.EPSILON = 10e-12;
+
+/**
+ * Kappa
+ * @property KAPPA {Number}
+ * @cat Math
+ * @subcat Constants
+ */
+// Kappa, see: http://www.whizkidtech.redprince.net/bezier/circle/kappa/
+pub.KAPPA = (4.0 * (Math.sqrt(2.0) - 1.0) / 3.0);
+
+/**
+ * Used with canvasMode() to set the canvas to the full current page.
+ * @property PAGE {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.PAGE = "page";
+
+/**
+ * Used with canvasMode() to set the canvas to the full current page minus the margins.
+ * @property MARGIN {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.MARGIN = "margin";
+
+/**
+ * Used with canvasMode() to set the canvas to the full current page plus the bleed.
+ * @property BLEED {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.BLEED = "bleed";
+
+/**
+ * Used with canvasMode() to set the canvas to use the current facing pages.
+ * @property FACING_PAGES {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.FACING_PAGES = "facing_pages";
+
+/**
+ * Used with canvasMode() to set the canvas to use the current facing pages plus bleeds.
+ * @property FACING_BLEEDS {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.FACING_BLEEDS = "facing_bleeds";
+
+/**
+ * Used with canvasMode() to set the canvas to use the current facing pages minus margins.
+ * @property FACING_MARGINS {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.FACING_MARGINS = "facing_margins";
+
+/**
+ * Used with addPage() to set the position of the new page in the book.
+ * @property AT_BEGINNING {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.AT_BEGINNING = LocationOptions.AT_BEGINNING;
+
+/**
+ * Used with addPage() to set the position of the new page in the book.
+ * @property AT_END {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.AT_END = LocationOptions.AT_END;
+
+/**
+ * Used with addPage() to set the position of the new page in the book.
+ * @property BEFORE {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.BEFORE = LocationOptions.BEFORE;
+
+/**
+ * Used with addPage() to set the position of the new page in the book.
+ * @property AFTER {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.AFTER = LocationOptions.AFTER;
+
+/**
+ * Used with arrange() to bring a page item to the front or to bring it in front of a given reference object.
+ * @property FRONT {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.FRONT = "front";
+
+/**
+ * Used with arrange() to send a page item to the back or to send it behind a given reference object.
+ * @property BACK {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.BACK = "back";
+
+/**
+ * Used with arrange() to bring a page item one level forward in its layer.
+ * @property FORWARD {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.FORWARD = "forward";
+
+/**
+ * Used with arrange() to send a page item one level backward in its layer.
+ * @property BACKWARD {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.BACKWARD = "backward";
+
+/**
+ * Used with size() to set the orientation of a given page size to portrait.
+ * @property PORTRAIT {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.PORTRAIT = PageOrientation.PORTRAIT;
+
+/**
+ * Used with size() to set the orientation of a given page size to landscape.
+ * @property LANDSCAPE {String}
+ * @cat Document
+ * @subcat Page
+ */
+pub.LANDSCAPE = PageOrientation.LANDSCAPE;
+
+/**
+ * Returns a Lorem ipsum string that can be used for testing.
+ * @property LOREM {String}
+ * @cat Typography
+ */
+pub.LOREM = "Lorem ipsum is dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
+
+/**
+* The name of the current script.
+* @property SCRIPTNAME {String}
+* @cat Environment
+*/
+var stackArray = $.stack.
+            replace(/[\n]toString\(\)[\n]$/,'').
+            replace(/[\[\]']+/g,'').
+            split(/[\n]/);
+pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1] : stackArray[0];
+
+/**
+* Used with `mode()` to set performance mode. Disables screen redraw during processing.
+* @property SILENT {String}
+* @cat Environment
+* @subcat modes
+*/
+pub.SILENT = "silent";
+
+/**
+ * Used with `mode()` to set performance mode. Processes the document in background mode. The document will not be visible until the script is done or until the mode is changed back to `VISIBLE`. The document will be removed from the display list and added again after the script is done. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use `println("yourMessage")` in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.
+ * @property HIDDEN {String}
+ * @cat Environment
+ * @subcat modes
+ */
+pub.HIDDEN = "hidden";
+
+/**
+ * Default mode. Used with `mode()` to set performance mode. Processes the document with screen redraw, use this option to see direct results during the process. This will slow down the process in terms of processing time.
  * @property VISIBLE {String}
  * @cat Environment
  * @subcat modes
@@ -654,7 +8388,7 @@ if (!Array.prototype.map) {
 }
 
 /**
-* @description Used to run a function on all elements of an array. Please note the existance of the convenience methods <code>stories()</code>, <code>paragraphs()</code>, <code>lines()</code>, <code>words()</code> and <code>characters()</code> that are used to iterate through all instances of the given type in the given document.
+* @description Used to run a function on all elements of an array. Please note the existance of the convenience methods `stories()`, `paragraphs()`, `lines()`, `words()` and `characters()` that are used to iterate through all instances of the given type in the given document.
 *
 * @cat    Data
 * @subcat Array
@@ -1066,10 +8800,10 @@ pub.noLoop = function(printFinished) {
 };
 
 /**
- * @description Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, <code>mode()</code> should be placed in the beginning of the script. In basil there are three different performance modes:<br>
- * <code>VISIBLE</code> is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.<br>
- * <code>HIDDEN</code> allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use <code>println("yourMessage")</code> in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.<br>
- * <code>SILENT</code> processes the document without redrawing the screen. The document will stay visible and only update once the script is finished or once the mode is changed back to <code>VISIBLE</code>.
+ * @description Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, `mode()` should be placed in the beginning of the script. In basil there are three different performance modes:<br>
+ * `VISIBLE` is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.<br>
+ * `HIDDEN` allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use `println("yourMessage")` in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.<br>
+ * `SILENT` processes the document without redrawing the screen. The document will stay visible and only update once the script is finished or once the mode is changed back to `VISIBLE`.
  *
  * @cat    Environment
  * @method mode
@@ -1805,7 +9539,7 @@ pub.doc = function(doc) {
  * @method size
  * @param  {Number|String} [widthOrPageSize] The desired width of the current document or the name of a page size preset.
  * @param  {Number|String} [heightOrOrientation] The desired height of the current document. If not provided the width will be used as the height. If the first argument is a page size preset, the second argument can be used to set the orientation.
- * @return {Object} Object containing the current <code>width</code> and <code>height</code> of the document.
+ * @return {Object} Object containing the current `width` and `height` of the document.
  *
  * @example <caption>Sets the document size to 70 x 100 units</caption>
  * size(70, 100);
@@ -2259,13 +9993,13 @@ pub.layer = function(layer) {
 
 
 /**
- * @description Arranges a page item or a layer before or behind other page items or layers. If using the constants <code>FORWARD</code> or <code>BACKWARD</code> the object is sent forward or back one step. The constants <code>FRONT</code> or <code>BACK</code> send the object to the very front or very back. Using <code>FRONT</code> or <code>BACK</code> together with the optional reference object, sends the object in front or behind this reference object.
+ * @description Arranges a page item or a layer before or behind other page items or layers. If using the constants `FORWARD` or `BACKWARD` the object is sent forward or back one step. The constants `FRONT` or `BACK` send the object to the very front or very back. Using `FRONT` or `BACK` together with the optional reference object, sends the object in front or behind this reference object.
  *
  * @cat    Document
  * @subcat Page
  * @method arrange
  * @param  {PageItem|Layer} pItemOrLayer The page item or layer to be moved to a new position.
- * @param  {String} positionOrDirection The position or direction to move the page item or layer. Can be <code>FRONT</code>, <code>BACK</code>, <code>FORWARD</code> or <code>BACKWARD</code>.
+ * @param  {String} positionOrDirection The position or direction to move the page item or layer. Can be `FRONT`, `BACK`, `FORWARD` or `BACKWARD`.
  * @param  {PageItem|Layer} [reference] A reference object to move the page item or layer behind or in front of.
  * @return {PageItem|Layer} The newly arranged page item or layer.
  */
@@ -2414,7 +10148,7 @@ pub.labels = function(label, cb) {
 
 
 /**
- * @description Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of <code>labels()</code>, when you know you just have one thing with that label and don't want to deal with a single-element array.
+ * @description Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of `labels()`, when you know you just have one thing with that label and don't want to deal with a single-element array.
  *
  * @cat    Document
  * @subcat Multi-Getters
@@ -2655,22 +10389,22 @@ pub.bleeds = function(top, right, bottom, left) {
 
 /**
  * @description Inspects a given object or any other data item and prints the result to the console. This is useful for inspecting or debugging any kind of variable or data item. The optional settings object allows to control the function's output. The following parameters can be set in the settings object:<br>
- * <code>showProps</code>: Show or hide properties. Default: <code>true</code><br>
- * <code>showValues</code>: Show or hide values. Default: <code>true</code><br>
- * <code>showMethods</code>: Show or hide methods. Default: <code>false</code><br>
- * <code>maxLevel</code>: Chooses how many levels of properties should be inspected recursively. Default: <code>1</code><br>
- * <code>propList</code>: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: <code>[]</code> (no propList)<br>
+ * `showProps`: Show or hide properties. Default: `true`<br>
+ * `showValues`: Show or hide values. Default: `true`<br>
+ * `showMethods`: Show or hide methods. Default: `false`<br>
+ * `maxLevel`: Chooses how many levels of properties should be inspected recursively. Default: `1`<br>
+ * `propList`: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: `[]` (no propList)<br>
  * If no settings object is set, the default values will be used.
  *
  * @cat    Output
  * @method inspect
  * @param  {Object} obj An object or any other data item to be inspected.
  * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {Boolean} [settings.showProps] Show or hide properties. Default: <code>true</code>
- * @param  {Boolean} [settings.showValues] Show or hide values. Default: <code>true</code>
- * @param  {Boolean} [settings.showMethods] Show or hide methods. Default: <code>false</code>
- * @param  {Number} [settings.maxLevel] How many levels of properties should be inspected recursively. Default: <code>1</code>
- * @param  {Array} [settings.propList] Array of properties to show. Default: <code>[]</code> (no propList)
+ * @param  {Boolean} [settings.showProps] Show or hide properties. Default: `true`
+ * @param  {Boolean} [settings.showValues] Show or hide values. Default: `true`
+ * @param  {Boolean} [settings.showMethods] Show or hide methods. Default: `false`
+ * @param  {Number} [settings.maxLevel] How many levels of properties should be inspected recursively. Default: `1`
+ * @param  {Array} [settings.propList] Array of properties to show. Default: `[]` (no propList)
  *
  * @example <caption>Inspecting a string</caption>
  * inspect("foo");
@@ -2935,9 +10669,9 @@ pub.folder = function(folderPath) {
  * @method files
  * @param  {Folder|String} [folder] The folder that holds the files or a string describing the path to that folder.
  * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String|Array} [settings.filter] Suffix(es) of file types to include. Default: <code>"*"</code> (include all file types)
- * @param  {Boolean} [settings.hidden] Hidden files will be included. Default: <code>false</code>
- * @param  {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: <code>false</code>
+ * @param  {String|Array} [settings.filter] Suffix(es) of file types to include. Default: `"*"` (include all file types)
+ * @param  {Boolean} [settings.hidden] Hidden files will be included. Default: `false`
+ * @param  {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: `false`
  * @return {Array} Array of the resulting file(s). If no files are found, an empty array will be returned.
  *
  * @example <caption>Get a folder from the desktop and load all its JPEG files</caption>
@@ -3013,10 +10747,10 @@ pub.files = function(folder, settings, collectedFiles) {
  * @cat    Files
  * @method selectFile
  * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
- * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
+ * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
+ * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
  * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {File|Null} The selected file. If the user cancels, <code>null</code> will be returned.
+ * @return {File|Null} The selected file. If the user cancels, `null` will be returned.
  *
  * @example <caption>Open file selection dialog with a prompt text</caption>
  * selectFile({prompt: "Please select a file."});
@@ -3034,8 +10768,8 @@ pub.selectFile = function(settings) {
  * @cat    Files
  * @method selectFiles
  * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
- * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
+ * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
+ * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
  * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
  * @return {Array} Array of the selected file(s). If the user cancels, an empty array will be returned.
  *
@@ -3060,9 +10794,9 @@ pub.selectFiles = function(settings) {
  * @cat    Files
  * @method selectFolder
  * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: <code>""</code> (no prompt)
+ * @param  {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: `""` (no prompt)
  * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {Folder|Null} The selected folder. If the user cancels, <code>null</code> will be returned.
+ * @return {Folder|Null} The selected folder. If the user cancels, `null` will be returned.
  *
  * @example <caption>Open folder selection dialog with a prompt text</caption>
  * selectFolder({prompt: "Please select a folder."});
@@ -4856,14 +12590,14 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
 /**
  * @description Modifies the location from which rectangles or text frames draw. The default
  * mode is rectMode(CORNER), which specifies the location to be the upper left
- * corner of the shape and uses the <code>w</code> and <code>h</code> parameters to specify the
- * width and height. The syntax rectMode(CORNERS) uses the <code>x</code> and <code>y</code>
- * parameters of <code>rect()</code> or <code>text()</code> to set the location of one corner
- * and uses the <code>w</code> and <code>h</code> parameters to set the opposite corner.
- * The syntax <code>rectMode(CENTER)</code> draws the shape from its center point and
- * uses the <code>w</code> and <code>h</code> parameters to specify the shape's
- * width and height. The syntax <code>rectMode(RADIUS)</code> draws the shape from its
- * center point and uses the <code>w</code> and <code>h</code> parameters to specify
+ * corner of the shape and uses the `w` and `h` parameters to specify the
+ * width and height. The syntax rectMode(CORNERS) uses the `x` and `y`
+ * parameters of `rect()` or `text()` to set the location of one corner
+ * and uses the `w` and `h` parameters to set the opposite corner.
+ * The syntax `rectMode(CENTER)` draws the shape from its center point and
+ * uses the `w` and `h` parameters to specify the shape's
+ * width and height. The syntax `rectMode(RADIUS)` draws the shape from its
+ * center point and uses the `w` and `h` parameters to specify
  * half of the shape's width and height.
  *
  * @cat    Document
@@ -4883,13 +12617,13 @@ pub.rectMode = function (mode) {
 };
 
 /**
- * @description The origin of new ellipses is modified by the <code>ellipseMode()</code> function.
- * The default configuration is <code>ellipseMode(CENTER)</code>, which specifies the
+ * @description The origin of new ellipses is modified by the `ellipseMode()` function.
+ * The default configuration is `ellipseMode(CENTER)`, which specifies the
  * location of the ellipse as the center of the shape. The RADIUS mode is
- * the same, but the <code>w</code> and <code>h</code> parameters to <code>ellipse()</code> specify the
+ * the same, but the `w` and `h` parameters to `ellipse()` specify the
  * radius of the ellipse, rather than the diameter. The CORNER mode draws
  * the shape from the upper-left corner of its bounding box. The CORNERS
- * mode uses the four parameters to <code>ellipse()</code> to set two opposing corners
+ * mode uses the four parameters to `ellipse()` to set two opposing corners
  * of the ellipse's bounding box.
  *
  * @cat    Document
@@ -4997,7 +12731,7 @@ pub.applyObjectStyle = function(item, style) {
 };
 
 /**
- * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use <code>rectMode()</code> to set center point.
+ * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use `rectMode()` to set center point.
  *
  * @cat    Document
  * @subcat Transformation
@@ -5498,22 +13232,22 @@ pub.opacity = function(obj, opacity) {
  * @method blendMode
  * @param  {Object} obj The object to set blendMode of.
  * @param  {Number} blendMode The blendMode must be one of the InDesign BlendMode enum values:
- *                           BlendMode.NORMAL<br>
- *                           BlendMode.MULTIPLY<br>
- *                           BlendMode.SCREEN<br>
- *                           BlendMode.OVERLAY<br>
- *                           BlendMode.SOFT_LIGHT<br>
- *                           BlendMode.HARD_LIGHT<br>
- *                           BlendMode.COLOR_DODGE<br>
- *                           BlendMode.COLOR_BURN<br>
- *                           BlendMode.DARKEN<br>
- *                           BlendMode.LIGHTEN<br>
- *                           BlendMode.DIFFERENCE<br>
- *                           BlendMode.EXCLUSION<br>
- *                           BlendMode.HUE<br>
- *                           BlendMode.SATURATION<br>
- *                           BlendMode.COLOR<br>
- *                           BlendMode.LUMINOSITY<br>
+ *    - `BlendMode.NORMAL`
+ *    - `BlendMode.MULTIPLY`
+ *    - `BlendMode.SCREEN`
+ *    - `BlendMode.OVERLAY`
+ *    - `BlendMode.SOFT_LIGHT`
+ *    - `BlendMode.HARD_LIGHT`
+ *    - `BlendMode.COLOR_DODGE`
+ *    - `BlendMode.COLOR_BURN`
+ *    - `BlendMode.DARKEN`
+ *    - `BlendMode.LIGHTEN`
+ *    - `BlendMode.DIFFERENCE`
+ *    - `BlendMode.EXCLUSION`
+ *    - `BlendMode.HUE`
+ *    - `BlendMode.SATURATION`
+ *    - `BlendMode.COLOR`
+ *    - `BlendMode.LUMINOSITY`
  */
 pub.blendMode = function(obj, blendMode) {
   checkNull(obj);
@@ -7123,7 +14857,7 @@ var precision = function(num, dec) {
 };
 
 /**
- * @description The function calculates the geometric bounds of any given page item or text. Use the <code>transforms()</code> function to modify page items.
+ * @description The function calculates the geometric bounds of any given page item or text. Use the `transforms()` function to modify page items.
  * In case the object is any kind of text, additional typographic information baseline and xHeight are calculated.
  *
  * @cat    Document

--- a/basil.js
+++ b/basil.js
@@ -85,7740 +85,6 @@ var pub = {};
  */
 pub.VERSION = "1.1.0";
 
-/*
-  ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
-// ----------------------------------------
-// src/includes/constants.js
-// ----------------------------------------
-
-/**
- * Used with units() to set the coordinate system to points.
- * @property PT {String}
- * @cat Document
- * @subcat Units
- */
-pub.PT = "pt";
-
-/**
- * Used with units() to set the coordinate system to pixels.
- * @property PX {String}
- * @cat Document
- * @subcat Units
- */
-pub.PX = "px";
-
-/**
- * Used with units() to set the coordinate system to centimeters.
- * @property CM {String}
- * @cat Document
- * @subcat Units
- */
-
-pub.CM = "cm";
-
-/**
- * Used with units() to set the coordinate system to millimeters.
- * @property MM {String}
- * @cat Document
- * @subcat Units
- */
-pub.MM = "mm";
-
-/**
- * Used with units() to set the coordinate system to inches.
- * @property IN {String}
- * @cat Document
- * @subcat Units
- */
-pub.IN = "inch";
-
-/**
- * Used with colorMode() to set the color space.
- * @property RGB {String}
- * @cat Color
- */
-pub.RGB = "rgb";
-
-/**
- * Used with colorMode() to set the color space.
- * @property CMYK {String}
- * @cat Color
- */
-pub.CMYK = "cmyk";
-
-/**
- * Used with gradientMode() to set the gradient mode.
- * @property LINEAR {String}
- * @cat Color
- */
-pub.LINEAR = "linear";
-
-/**
- * Used with gradientMode() to set the gradient mode.
- * @property RADIAL {String}
- * @cat Color
- */
-pub.RADIAL = "radial";
-
-/**
- * Corner, used for drawing modes.
- * @property CORNER {String}
- * @cat Document
- * @subcat Primitives
- */
-pub.CORNER = "corner";
-
-/**
- * Corners, used for drawing modes.
- * @property CORNERS {String}
- * @cat Document
- * @subcat Primitives
- */
-pub.CORNERS = "corners";
-
-/**
- * Center, used for drawing modes or used with referencePoint() to set the reference point of transformations to the center of the page item.
- * @property CENTER {String}
- * @cat Document
- * @subcat Primitives
- */
-pub.CENTER = "center";
-pub.CENTER_CENTER = "center";
-
-/**
- * Radius, used for drawing modes.
- * @property RADIUS {String}
- * @cat Document
- * @subcat Primitives
- */
-pub.RADIUS = "radius";
-
-/**
- * Used with referencePoint() to set the reference point of transformations to the top left of the page item.
- * @property TOP_LEFT {String}
- * @cat Document
- * @subcat Transformation
- */
-pub.TOP_LEFT = "topLeft";
-
-/**
- * Used with referencePoint() to set the reference point of transformations to the top center of the page item.
- * @property TOP_CENTER {String}
- * @cat Document
- * @subcat Transformation
- */
-pub.TOP_CENTER = "topCenter";
-
-/**
- * Used with referencePoint() to set the reference point of transformations to the top right of the page item.
- * @property TOP_RIGHT {String}
- * @cat Document
- * @subcat Transformation
- */
-pub.TOP_RIGHT = "topRight";
-
-/**
- * Used with referencePoint() to set the reference point of transformations to the center left of the page item.
- * @property CENTER_LEFT {String}
- * @cat Document
- * @subcat Transformation
- */
-pub.CENTER_LEFT = "centerLeft";
-
-/**
- * Used with referencePoint() to set the reference point of transformations to the center right of the page item.
- * @property CENTER_RIGHT {String}
- * @cat Document
- * @subcat Transformation
- */
-pub.CENTER_RIGHT = "centerRight";
-
-/**
- * Used with referencePoint() to set the reference point of transformations to the bottom left of the page item.
- * @property BOTTOM_LEFT {String}
- * @cat Document
- * @subcat Transformation
- */
-pub.BOTTOM_LEFT = "bottomLeft";
-
-/**
- * Used with referencePoint() to set the reference point of transformations to the bottom center of the page item.
- * @property BOTTOM_CENTER {String}
- * @cat Document
- * @subcat Transformation
- */
-pub.BOTTOM_CENTER = "bottomCenter";
-
-/**
- * Used with referencePoint() to set the reference point of transformations to the bottom right of the page item.
- * @property BOTTOM_RIGHT {String}
- * @cat Document
- * @subcat Transformation
- */
-pub.BOTTOM_RIGHT = "bottomRight";
-
-/**
- * Close, used for endShape() modes.
- * @property CLOSE {String}
- * @cat Document
- * @subcat Primitives
- */
-pub.CLOSE = "close";
-
-/**
- * Open, used for arc() modes.
- * @property OPEN {String}
- * @cat Document
- * @subcat Primitives
- */
-pub.OPEN = "open";
-
-/**
- * Chord, used for arc() modes.
- * @property CHORD {String}
- * @cat Document
- * @subcat Primitives
- */
-pub.CHORD = "chord";
-
-/**
- * Pie, used for arc() modes.
- * @property PIE {String}
- * @cat Document
- * @subcat Primitives
- */
-pub.PIE = "pie";
-
-/**
- * Two Pi
- * @property TWO_PI {Number}
- * @cat Math
- * @subcat Constants
- */
-pub.TWO_PI = Math.PI * 2;
-
-/**
- * Pi
- * @property PI {Number}
- * @cat Math
- * @subcat Constants
- */
-pub.PI = Math.PI;
-
-/**
- * Half Pi
- * @property HALF_PI {Number}
- * @cat Math
- * @subcat Constants
- */
-pub.HALF_PI = Math.PI / 2;
-
-/**
- * Quarter Pi
- * @property QUARTER_PI {Number}
- * @cat Math
- * @subcat Constants
- */
-pub.QUARTER_PI = Math.PI / 4;
-
-/**
- * Sin Cos Length
- * @property SINCOS_LENGTH {Number}
- * @cat Math
- * @subcat Constants
- */
-pub.SINCOS_LENGTH = 720;
-
-/**
- * Epsilon
- * @property EPSILON {Number}
- * @cat Math
- * @subcat Constants
- */
-pub.EPSILON = 10e-12;
-
-/**
- * Kappa
- * @property KAPPA {Number}
- * @cat Math
- * @subcat Constants
- */
-// Kappa, see: http://www.whizkidtech.redprince.net/bezier/circle/kappa/
-pub.KAPPA = (4.0 * (Math.sqrt(2.0) - 1.0) / 3.0);
-
-/**
- * Used with canvasMode() to set the canvas to the full current page.
- * @property PAGE {String}
- * @cat Document
- * @subcat Page
- */
-pub.PAGE = "page";
-
-/**
- * Used with canvasMode() to set the canvas to the full current page minus the margins.
- * @property MARGIN {String}
- * @cat Document
- * @subcat Page
- */
-pub.MARGIN = "margin";
-
-/**
- * Used with canvasMode() to set the canvas to the full current page plus the bleed.
- * @property BLEED {String}
- * @cat Document
- * @subcat Page
- */
-pub.BLEED = "bleed";
-
-/**
- * Used with canvasMode() to set the canvas to use the current facing pages.
- * @property FACING_PAGES {String}
- * @cat Document
- * @subcat Page
- */
-pub.FACING_PAGES = "facing_pages";
-
-/**
- * Used with canvasMode() to set the canvas to use the current facing pages plus bleeds.
- * @property FACING_BLEEDS {String}
- * @cat Document
- * @subcat Page
- */
-pub.FACING_BLEEDS = "facing_bleeds";
-
-/**
- * Used with canvasMode() to set the canvas to use the current facing pages minus margins.
- * @property FACING_MARGINS {String}
- * @cat Document
- * @subcat Page
- */
-pub.FACING_MARGINS = "facing_margins";
-
-/**
- * Used with addPage() to set the position of the new page in the book.
- * @property AT_BEGINNING {String}
- * @cat Document
- * @subcat Page
- */
-pub.AT_BEGINNING = LocationOptions.AT_BEGINNING;
-
-/**
- * Used with addPage() to set the position of the new page in the book.
- * @property AT_END {String}
- * @cat Document
- * @subcat Page
- */
-pub.AT_END = LocationOptions.AT_END;
-
-/**
- * Used with addPage() to set the position of the new page in the book.
- * @property BEFORE {String}
- * @cat Document
- * @subcat Page
- */
-pub.BEFORE = LocationOptions.BEFORE;
-
-/**
- * Used with addPage() to set the position of the new page in the book.
- * @property AFTER {String}
- * @cat Document
- * @subcat Page
- */
-pub.AFTER = LocationOptions.AFTER;
-
-/**
- * Used with arrange() to bring a page item to the front or to bring it in front of a given reference object.
- * @property FRONT {String}
- * @cat Document
- * @subcat Page
- */
-pub.FRONT = "front";
-
-/**
- * Used with arrange() to send a page item to the back or to send it behind a given reference object.
- * @property BACK {String}
- * @cat Document
- * @subcat Page
- */
-pub.BACK = "back";
-
-/**
- * Used with arrange() to bring a page item one level forward in its layer.
- * @property FORWARD {String}
- * @cat Document
- * @subcat Page
- */
-pub.FORWARD = "forward";
-
-/**
- * Used with arrange() to send a page item one level backward in its layer.
- * @property BACKWARD {String}
- * @cat Document
- * @subcat Page
- */
-pub.BACKWARD = "backward";
-
-/**
- * Used with size() to set the orientation of a given page size to portrait.
- * @property PORTRAIT {String}
- * @cat Document
- * @subcat Page
- */
-pub.PORTRAIT = PageOrientation.PORTRAIT;
-
-/**
- * Used with size() to set the orientation of a given page size to landscape.
- * @property LANDSCAPE {String}
- * @cat Document
- * @subcat Page
- */
-pub.LANDSCAPE = PageOrientation.LANDSCAPE;
-
-/**
- * Returns a Lorem ipsum string that can be used for testing.
- * @property LOREM {String}
- * @cat Typography
- */
-pub.LOREM = "Lorem ipsum is dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
-
-/**
-* The name of the current script.
-* @property SCRIPTNAME {String}
-* @cat Environment
-*/
-var stackArray = $.stack.
-            replace(/[\n]toString\(\)[\n]$/,'').
-            replace(/[\[\]']+/g,'').
-            split(/[\n]/);
-pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1] : stackArray[0];
-
-/**
-* Used with `mode()` to set performance mode. Disables screen redraw during processing.
-* @property SILENT {String}
-* @cat Environment
-* @subcat modes
-*/
-pub.SILENT = "silent";
-
-/**
- * Used with `mode()` to set performance mode. Processes the document in background mode. The document will not be visible until the script is done or until the mode is changed back to `VISIBLE`. The document will be removed from the display list and added again after the script is done. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use `println("yourMessage")` in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.
- * @property HIDDEN {String}
- * @cat Environment
- * @subcat modes
- */
-pub.HIDDEN = "hidden";
-
-/**
- * Default mode. Used with `mode()` to set performance mode. Processes the document with screen redraw, use this option to see direct results during the process. This will slow down the process in terms of processing time.
- * @property VISIBLE {String}
- * @cat Environment
- * @subcat modes
- */
-pub.VISIBLE = "visible";
-
-
-var ERROR_PREFIX = "\nBasil.js Error -> ",
-  WARNING_PREFIX = "### Basil Warning -> ";
-
-
-// ----------------------------------------
-// src/includes/public-vars.js
-// ----------------------------------------
-
-/**
- * @description System variable which stores the width of the current page.
- *
- * @cat Environment
- * @property {Number} width Width of the current page.
- */
-pub.width = null;
-
-/**
- * @description System variable which stores the height of the current page.
- *
- * @cat Environment
- * @property {Number} height Height of the current page.
- */
-pub.height = null;
-
-  B A S I L . J S
-// ----------------------------------------
-// src/includes/private-vars.js
-// ----------------------------------------
-
-var addToStoryCache = null, /* tmp cache, see addToStroy(), via InDesign external library file*/
-  appSettings = null,
-  currAlign = null,
-  currCanvasMode = null,
-  currColorMode = null,
-  currDialogFolder = null,
-  currDoc = null,
-  currDocSettings = null,
-  currEllipseMode = null,
-  currFillColor = null,
-  currFillTint = null,
-  currFont = null,
-  currFontSize = null,
-  currGradientMode = null,
-  currImageMode = null,
-  currKerning = null,
-  currLayer = null,
-  currLeading = null,
-  currMatrix = null,
-  currMode = null,
-  currOriginX = null,
-  currOriginY = null,
-  currPage = null,
-  currPathPointer = null,
-  currPolygon = null,
-  currRefPoint = null,
-  currRectMode = null,
-  currShapeMode = null,
-  currStrokeColor = null,
-  currStrokeTint = null,
-  currStrokeWeight = null,
-  currTracking = null,
-  currUnits = null,
-  currVertexPoints = null,
-  currYAlign = null,
-  currFrameRate = null,
-  currIdleTask = null,
-  matrixStack = null,
-  noneSwatchColor = null,
-  progressPanel = null,
-  startTime = null;
-
-  Bringing the spirit of the Processing visualization language to Adobe InDesign.
-
-// ----------------------------------------
-// src/includes/global-functions.js
-// ----------------------------------------
-
-/**
- * @description The <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/filter">filter()</a> method creates a new array with all elements that pass the test implemented by the provided function.
- *
- * @cat    Data
- * @subcat Array
- * @method Array.filter
- * @param  {Function} callback The Function is a predicate, to test each element of the array. Return true to keep the element, false otherwise.
- * @return {Array} The new array with the elements that pass the test.
- */
-if (!Array.prototype.filter) {
-  Array.prototype.filter = function(fun) {
-    if (this === null) throw new TypeError();
-    var t = Object(this);
-    var len = t.length >>> 0;
-    if (typeof fun != "function") throw new TypeError();
-    var res = [];
-    var thisp = arguments[1];
-    for (var i = 0; i < len; i++) {
-      if (i in t) {
-        var val = t[i]; // in case fun mutates this
-        if (fun.call(thisp, val, i, t)) res.push(val);
-      }
-    }
-    return res;
-  };
-}
-
-/**
- * @description The <a href="https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array/map">map()</a> method creates a new array with the results of calling a provided function on every element in this array.
- *
- * @cat    Data
- * @subcat Array
- * @method Array.map
- * @param  {Function} callback Function that produces an element of the new Array.
- * @return {Array} The new array with each element being the result of the callback function.
- */
-if (!Array.prototype.map) {
-  Array.prototype.map = function(callback, thisArg) {
-    var T, A, k;
-    if (this == null) {
-      throw new TypeError(" this is null or not defined");
-    }
-    var O = Object(this);
-    var len = O.length >>> 0;
-    if (typeof callback !== "function") {
-      throw new TypeError(callback + " is not a function");
-    }
-    if (thisArg) {
-      T = thisArg;
-    }
-    A = new Array(len);
-    k = 0;
-    while(k < len) {
-      var kValue, mappedValue;
-      if (k in O) {
-        kValue = O[ k ];
-        mappedValue = callback.call(T, kValue, k, O);
-        A[ k ] = mappedValue;
-      }
-      k++;
-    }
-    return A;
-  };
-}
-
-/**
-* @description Used to run a function on all elements of an array. Please note the existance of the convenience methods `stories()`, `paragraphs()`, `lines()`, `words()` and `characters()` that are used to iterate through all instances of the given type in the given document.
-*
-* @cat    Data
-* @subcat Array
-* @method Array.forEach
-* @param  {Array} collection The array to be processed.
-* @param  {Function} cb The function that will be called on each element. The call will be like function(item,i) where i is the current index of the item within the array.
-*/
-forEach = function(collection, cb) {
-  for (var i = 0, len = collection.length; i < len; i++) {
-
-    if(!isValid(collection[i])) {
-      warning("forEach(), invalid object processed.");
-      continue;
-    }
-
-    if(cb(collection[i], i) === false) {
-      return false;
-    }
-  }
-  return true;
-};
-
-/**
- * @description HashList is a data container that allows you to store information as key - value pairs. As usual in JavaScript mixed types of keys and values are accepted in one HashList instance.
- *
- * @cat    Data
- * @subcat HashList
- * @method HashList
- * @constructor
- */
-// taken from http://pbrajkumar.wordpress.com/2011/01/17/hashmap-in-javascript/
-HashList = function () {
-  var that = {};
-  that.length = 0;
-  that.items = {};
-
-  for (var key in that.items) {
-    pub.println(key);
-  }
-
-  // Please note: this is removing Object fields, but has to be done to have an empty "bucket"
-  function checkKey(key) {
-    if(that.items[key] instanceof Function) {
-      that.items[key] = undefined;
-    }
-  }
-
-  /**
-   *
-   * @description This removes a key - value pair by its key.
-   *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.remove
-   * @param  {String} key The key to delete.
-   * @return {Object} The value before deletion.
-   */
-  that.remove = function(key) {
-    var tmp_previous;
-    if (typeof that.items[key] != "undefined") {
-      var tmp_previous = that.items[key];
-      delete that.items[key];
-      that.length--;
-    }
-    return tmp_previous;
-  };
-
-  /**
-   * @description This gets a value by its key.
-   *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.get
-   * @param  {String} key The key to look for.
-   * @return {Object} The value.
-   */
-  that.get = function(key) {
-    return that.items[key];
-  };
-
-  /**
-   * @description This sets a key - value pair. If a key is already existing, the value will be updated. Please note that Functions are currently not supported as values.
-   *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.set
-   * @param  {String} key The key to use.
-   * @param  {Object|String|Number|Boolean} value The value to set.
-   * @return {Object} The value after setting.
-   */
-  that.set = function(key, value) {
-
-    if(value instanceof Function) error("HashList does not support storing Functions as values.");
-    checkKey(key);
-    if (typeof value != "undefined") {
-      if (typeof that.items[key] === "undefined") {
-        that.length++;
-      }
-      that.items[key] = value;
-    }
-    return that.items[key];
-  };
-
-  /**
-   * @description Checks for the existence of a given key.
-   *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.hasKey
-   * @param  {String} key The key to check.
-   * @return {Boolean} Returns true or false.
-   */
-  that.hasKey = function(key) {
-    checkKey(key);
-    return typeof that.items[key] != "undefined";
-  };
-
-  /**
-   * @description Checks if a certain value exists at least once in all of the key - value pairs.
-   *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.hasValue
-   * @param  {Object|String|Number|Boolean} value The value to check.
-   * @return {Boolean} Returns true or false.
-   */
-  that.hasValue = function(value) {
-    var obj = that.items;
-    var found = false;
-    for(var key in obj) {
-      if (obj[key] === value) {
-        found = true;
-        break;
-      }
-    }
-    return found;
-  };
-
-  /**
-   * @description Returns an array of all keys that are sorted by their values from highest to lowest. Please note that this only works if you have conistently used Numbers for values.
-   *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getKeysByValues
-   * @return {Array} An array with all the keys.
-   */
-  that.getKeysByValues = function() {
-    var obj = that.items;
-    var keys = [];
-    for(var key in obj)
-        {
-      if(typeof obj[key] != "number") error("HashList.getKeysByValues(), only works with Numbers as values. ");
-      keys.push(key);
-    }
-    return keys.sort(function(a, b) {return obj[b] - obj[a];});
-  };
-
-  /**
-   * @description Returns an array with all keys in a sorted order from higher to lower magnitude.
-   *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getSortedKeys
-   * @return {Array} An array with all the keys sorted.
-   */
-  that.getSortedKeys = function () {
-    return that.getKeys().sort(); // ["a", "b", "z"]
-  };
-
-  /**
-   * @description Returns an array with all keys.
-   *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getKeys
-   * @return {Array} An array with all the keys.
-   */
-  that.getKeys = function () {
-    var keys = [];
-
-    for(var key in that.items)
-      {
-      if(that.items.hasOwnProperty(key))
-          {
-        keys.push(key);
-      }
-    }
-    return keys;
-  };
-
-  /**
-   * @description Returns an array with all values.
-   *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getValues
-   * @return {Array} An array with all the values.
-   */
-  that.getValues = function () {
-
-    var obj = that.items;
-    var values = [];
-
-    for(var key in obj) {
-      values.push(obj[key]);
-    }
-    return values;
-
-  };
-
-  /**
-   * @description Deletes all the key - value pairs in this HashList.
-   *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.clear
-   */
-  that.clear = function() {
-    for (var i in that.items) {
-      delete that.items[i];
-    }
-    that.length = 0;
-  };
-  return that;
-};
-
-  License        - MIT
-
-
-  Core
-                 - Ted Davis http://teddavis.org
-                 - Benedikt Groß http://benedikt-gross.de
-                 - Ludwig Zeller http://ludwigzeller.de
-  Members
-                 - Philipp Adrian http://www.philippadrian.com/
-                 - be:screen GmbH http://bescreen.de
-                 - Stefan Landsbek http://47nord.de
-// ----------------------------------------
-// src/includes/core.js
-// ----------------------------------------
-
-// all initialisations should go here
-var init = function() {
-
-  welcome();
-  populateGlobal();
-
-  // -- init internal state vars --
-  startTime = Date.now();
-  currStrokeWeight = 1;
-  currStrokeTint = 100;
-  currFillTint = 100;
-  currOriginX = 0;
-  currOriginY = 0;
-  currCanvasMode = pub.PAGE;
-  currColorMode = pub.RGB;
-  currGradientMode = pub.LINEAR;
-  currDocSettings = {};
-  currDialogFolder = Folder("~");
-  currMode = pub.VISIBLE;
-
-  appSettings = {
-    enableRedraw: app.scriptPreferences.enableRedraw,
-    preflightOff: app.preflightOptions.preflightOff,
-    adjustStrokeWeight: app.transformPreferences.adjustStrokeWeightWhenScaling,
-    whenScaling: app.transformPreferences.whenScaling
-  };
-
-  app.doScript(runScript, ScriptLanguage.JAVASCRIPT, undefined, UndoModes.ENTIRE_SCRIPT, pub.SCRIPTNAME);
-
-  if($.global.hasOwnProperty("basilTest")) {
-    return;
-  }
-
-  exit(); // quit program execution
-};
-
-
-// ----------------------------------------
-// execution
-
-var runScript = function() {
-
-  var execTime;
-
-  try {
-
-    if($.global.loop instanceof Function) {
-      if ($.engineName !== "loop") {
-        error("function loop(), no target engine! To use basil's loop function, add the code line\n\n #targetengine \"loop\";\n\n at the very top of your script.");
-      } else {
-        prepareLoop();
-      }
-    }
-
-    // app settings
-    app.scriptPreferences.enableRedraw = true;
-    app.preflightOptions.preflightOff = true;
-    app.transformPreferences.adjustStrokeWeightWhenScaling = true;
-    app.transformPreferences.whenScaling = WhenScalingOptions.APPLY_TO_CONTENT;
-
-    currentDoc();
-
-    appSettings.refPoint = app.activeWindow.transformReferencePoint;
-    currRefPoint = pub.referencePoint(app.activeWindow.transformReferencePoint);
-
-    if ($.global.setup instanceof Function) {
-      setup();
-    }
-
-    if ($.global.draw instanceof Function) {
-      draw();
-    } else if ($.global.loop instanceof Function) {
-      var sleep = null;
-      if (arguments.length === 0) sleep = Math.round(1000 / currFrameRate);
-      else sleep = Math.round(1000 / framerate);
-
-      currIdleTask = app.idleTasks.add({name: "basil_idle_task", sleep: sleep});
-      currIdleTask.addEventListener(IdleEvent.ON_IDLE, function() {
-        loop();
-      }, false);
-      println("Run the script lib/stop.jsx to end the loop, clean up and quit the script!");
-    }
-
-  } catch (e) {
-    execTime = executionDuration();
-
-    if(e.userCancel) {
-      println("[Cancelled by user after " + execTime + "]");
-    } else {
-      println("[Cancelled after " + execTime + "]");
-      alert(e);
-    }
-
-  } finally {
-
-    if((!execTime) && !($.global.loop instanceof Function)) {
-      println("[Finished in " + executionDuration() + "]");
-    }
-
-    if(currDoc && !currDoc.windows.length) {
-      currDoc.windows.add(); // open the hidden doc
-    }
-    closeHiddenDocs();
-    if (progressPanel) {
-      progressPanel.closePanel();
-    }
-    if (addToStoryCache) {
-      addToStoryCache.close();
-    }
-
-    if (!($.global.loop instanceof Function) || $.global.draw instanceof Function) {
-      resetUserSettings();
-    }
-  }
-
-}
-
-var prepareLoop = function() {
-  // before running the loop we need to check if the stop script exists
-  // the script looks for the lib folder next to itself
-  var currentBasilFolderPath = File($.fileName).parent.fsName;
-  var scriptPath = currentBasilFolderPath + "/lib/stop.jsx";
-
-  var stopScriptFile = pub.file(scriptPath);
-  if(stopScriptFile.exists !== true) {
-    // the script is not there, let's create it
-    var scriptContent = [
-      "#targetengine \"loop\"",
-      "noLoop(true);",
-      "if (typeof cleanUp === \"function\") {",
-      "  cleanUp();",
-      "  cleanUp = null;",
-      "}"
-    ];
-    pub.saveStrings(stopScriptFile, scriptContent);
-  }
-  currFrameRate = 25;
-}
-
-/**
- * @description Sets the framerate per second to determine how often loop() is called per second. If the processor is not fast enough to maintain the specified rate, the frame rate will not be achieved. Setting the frame rate within setup() is recommended. The default rate is 25 frames per second. Calling frameRate() with no arguments returns the currently set framerate.
- *
- * @cat    Environment
- * @method frameRate
- * @param  {Number} [fps] Frames per second.
- * @return {Number} Currently set frame rate.
- */
-pub.frameRate = function(fps) {
-  if(arguments.length) {
-    if(!isNumber(fps) || fps <= 0) {
-      error("frameRate(), invalid argument. Use a number greater than 0.")
-    }
-
-    currFrameRate = fps;
-    if(currIdleTask) {
-      currIdleTask.sleep = Math.ceil(1000 / fps);
-    }
-  }
-  return currFrameRate;
-};
-
-/**
- * @description Stops basil from continuously executing the code within loop() and quits the script.
- *
- * @cat    Environment
- * @method noLoop
- */
-pub.noLoop = function(printFinished) {
-  var allIdleTasks = app.idleTasks;
-  for (var i = app.idleTasks.length - 1; i >= 0; i--) {
-    allIdleTasks[i].remove();
-  }
-  if(printFinished) {
-    println("Basil.js -> Stopped looping.");
-    println("[Finished in " + executionDuration() + "]");
-  };
-  resetUserSettings();
-};
-
-/**
- * @description Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, `mode()` should be placed in the beginning of the script. In basil there are three different performance modes:<br>
- * `VISIBLE` is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.<br>
- * `HIDDEN` allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use `println("yourMessage")` in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.<br>
- * `SILENT` processes the document without redrawing the screen. The document will stay visible and only update once the script is finished or once the mode is changed back to `VISIBLE`.
- *
- * @cat    Environment
- * @method mode
- * @param  {String} mode The performance mode to switch to.
- */
-pub.mode = function(mode) {
-
-  if(!(mode === pub.VISIBLE || mode === pub.HIDDEN || mode === pub.SILENT)) {
-    error("mode(), invalid argument. Use VISIBLE, HIDDEN or SILENT.");
-  }
-
-  app.scriptPreferences.enableRedraw = (mode === pub.VISIBLE || mode === pub.HIDDEN);
-
-  if(!currDoc) {
-    // initiate new document in given mode
-    currentDoc(mode);
-  } else {
-
-    if (!currDoc.saved && !currDoc.modified && pub.HIDDEN) {
-      // unsaved, unmodified doc at the beginning of the script that needs to be hidden
-      // -> will be closed without saving, fresh hidden document will be opened
-      currDoc.close(SaveOptions.NO);
-      currDoc = app.documents.add(false);
-      setCurrDoc(currDoc);
-    } else if (mode === pub.HIDDEN && currMode !== pub.HIDDEN) {
-      // existing document needs to be hidden
-      if (!currDoc.saved && currDoc.modified) {
-        try {
-          currDoc.save();
-        } catch(e) {
-          throw {userCancel: true};
-        }
-        warning("Document was not saved and has now been saved to your hard drive in order to enter HIDDEN.");
-      } else if (currDoc.modified) {
-        currDoc.save(File(currDoc.fullName));
-        warning("Document was modified and has now been saved to your hard drive in order to enter HIDDEN.");
-      }
-      var docPath = currDoc.fullName;
-      currDoc.close(); // close the doc and reopen it without adding to the display list
-      currDoc = app.open(File(docPath), false);
-
-      setCurrDoc(currDoc);
-    } else if (mode !== pub.HIDDEN && currMode === pub.HIDDEN) {
-      // existing document needs to be unhidden
-      currDoc.windows.add();
-    }
-  }
-
-  if (!progressPanel && (mode === pub.HIDDEN || mode === pub.SILENT)) {
-    // turn on progress panel
-    progressPanel = new Progress();
-  } else if (progressPanel && mode === pub.VISIBLE) {
-    // turn off progress panel
-    progressPanel.closePanel();
-    progressPanel = null;
-  }
-
-  currMode = mode;
-};
-
-
-// ----------------------------------------
-// all private from here
-
-var welcome = function() {
-  clearConsole();
-  println("Running "
-      + pub.SCRIPTNAME
-      + " using basil.js "
-      + pub.VERSION
-      + " ...");
-};
-
-var populateGlobal = function() {
-  // inject all functions of pub into global space
-  // to make them available to the user
-
-  $.global.basilGlobal = [];
-  for(var key in pub) {
-    if(pub.hasOwnProperty(key)) {
-      if($.global.hasOwnProperty(key)) {
-        // the user created a function or variable
-        // with the same name as a basil has
-        var pubFuncVar = pub[key] instanceof Function ? "function \"" : "variable \"";
-        var globFuncVar = $.global[key] instanceof Function ? "function" : "variable";
-        error("basil had problems creating the global " + pubFuncVar + key + "\", possibly because your code is already using that name as a " + globFuncVar + ". You may want to rename your " + globFuncVar + " to something else.");
-      } else {
-        $.global[key] = pub[key];
-        $.global.basilGlobal.push(key);
-      }
-    }
-  }
-}
-
-var currentDoc = function(mode) {
-  if (!currDoc) {
-    var doc = null;
-    if (app.documents.length && app.windows.length) {
-      doc = app.activeDocument;
-      if (mode === pub.HIDDEN) {
-        if (!doc.saved) {
-          try {
-            doc.save();
-          } catch(e) {
-            throw {userCancel: true};
-          }
-          warning("Document was not saved and has now been saved to your hard drive in order to enter HIDDEN.");
-        } else if (doc.modified) {
-          doc.save(File(doc.fullName));
-          warning("Document was modified and has now been saved to your hard drive in order to enter HIDDEN.");
-        }
-        var docPath = doc.fullName;
-        doc.close(); // Close the doc and reopen it without adding to the display list
-        doc = app.open(File(docPath), false);
-      }
-    } else {
-      doc = app.documents.add(mode !== pub.HIDDEN);
-    }
-    if(!doc.saved && !doc.modified) {
-      setCurrDoc(doc, true);
-    } else {
-      setCurrDoc(doc);
-    }
-  }
-  return currDoc;
-};
-
-var closeHiddenDocs = function () {
-    // in Case we break the Script during execution in HIDDEN we might have documents open that are not on the display list. Close them.
-  for (var i = app.documents.length - 1; i >= 0; i -= 1) {
-    var d = app.documents[i];
-    if (!d.windows.length) {
-      d.close(SaveOptions.NO);
-    }
-  }
-};
-
-var setCurrDoc = function(doc, skipStyles) {
-  resetCurrDoc();
-  currDoc = doc;
-  // -- setup document --
-  // save initial doc settings for later resetting
-  currDocSettings.rulerOrigin = currDoc.viewPreferences.rulerOrigin;
-  currDocSettings.hUnits = currDoc.viewPreferences.horizontalMeasurementUnits;
-  currDocSettings.vUnits = currDoc.viewPreferences.verticalMeasurementUnits;
-
-  currDocSettings.pStyle = currDoc.textDefaults.appliedParagraphStyle;
-  currDocSettings.cStyle = currDoc.textDefaults.appliedCharacterStyle;
-  currDocSettings.otxtStyle = currDoc.pageItemDefaults.appliedTextObjectStyle;
-  currDocSettings.ograStyle = currDoc.pageItemDefaults.appliedGraphicObjectStyle;
-  currDocSettings.ogriStyle = currDoc.pageItemDefaults.appliedGridObjectStyle;
-
-  // set document to default values
-  pub.units(currDoc.viewPreferences.horizontalMeasurementUnits);
-
-  if(!skipStyles) {
-    // in a fresh, unsaved document, those styles should not be set
-    // in order not to modify the doc and be able to enter mode(HIDDEN) without saving
-    currDoc.textDefaults.appliedParagraphStyle = currDoc.paragraphStyles.firstItem();
-    currDoc.textDefaults.appliedCharacterStyle = currDoc.characterStyles.firstItem();
-    currDoc.pageItemDefaults.appliedTextObjectStyle = currDoc.objectStyles.firstItem();
-    currDoc.pageItemDefaults.appliedGraphicObjectStyle = currDoc.objectStyles.firstItem();
-    currDoc.pageItemDefaults.appliedGridObjectStyle = currDoc.objectStyles.firstItem();
-  }
-
-  currAlign = currDoc.textDefaults.justification;
-  currFont = currDoc.textDefaults.appliedFont;
-  currFontSize = currDoc.textDefaults.pointSize;
-  currKerning = 0;
-  currLeading = currDoc.textDefaults.leading;
-  currTracking = currDoc.textDefaults.tracking;
-
-  updatePublicPageSizeVars();
-};
-
-var Progress = function () {
-  this.init = function () {
-    this.panel = Window.find("window", "processing...");
-    if (this.panel === null) {
-      this.panel = new Window("window", "processing...");
-      var logo = (Folder.fs == "Macintosh") ? new File("~/Documents/basiljs/bundle/lib/basil.png") : new File("%USERPROFILE%Documents/basiljs/bundle/lib/basil.png");
-      if (logo.exists) {
-        this.panel.add("image", undefined, logo);
-      }
-      this.panel.statusbar = this.panel.add("edittext", [0, 0, 400, 300], "", {multiline: true, scrolling: false, readonly: true});
-    }
-    this.panel.statusbar.text = "Using basil.js " + pub.VERSION + " ... \nEntering background render mode ...";
-    this.panel.show();
-  };
-  this.closePanel = function () {
-    if (this.panel) {
-      this.panel.hide();
-      this.panel.close();
-    }
-  };
-  this.writeMessage = function (msg) {
-    if (Folder.fs == "Macintosh") { // Indesign Bug on Mac: Need to set app.scriptPreferences.enableRedraw = true to redraw window....
-      var rd = app.scriptPreferences.enableRedraw;
-      app.scriptPreferences.enableRedraw = true;
-    }
-    var lines = this.panel.statusbar.text.split(/\n/);
-    if (lines.length > 17)
-      lines.shift();
-    lines.push(msg);
-    this.panel.statusbar.text = lines.join("\n");
-    this.panel.layout.layout();
-    if (Folder.fs == "Macintosh") {
-      app.scriptPreferences.enableRedraw = rd;
-    }
-  };
-  this.init();
-};
-
-var resetCurrDoc = function() {
-  // resets doc and doc specific vars
-  currDoc = null;
-  currPage = null;
-  currLayer = null;
-  currFillColor = "Black";
-  noneSwatchColor = "None";
-  currStrokeColor = "Black";
-  currRectMode = pub.CORNER;
-  currEllipseMode = pub.CENTER;
-  currYAlign = VerticalJustification.TOP_ALIGN;
-  currFont = null;
-  currImageMode = pub.CORNER;
-
-  pub.resetMatrix();
-};
-
-var currentLayer = function() {
-  if (currLayer === null || !currLayer) {
-    currentDoc();
-    if (currDoc.windows.length) {
-      currLayer = app.activeDocument.activeLayer;
-    } else {
-      currLayer = currDoc.layers[0];
-    }
-  }
-  return currLayer;
-};
-
-var currentPage = function() {
-  if (currPage === null || !currPage) {
-    currentDoc();
-    if (currDoc.windows.length) {
-      currPage = app.activeWindow.activePage;
-    } else {
-      currPage = currDoc.pages[0];
-    }
-  }
-  return currPage;
-};
-
-var updatePublicPageSizeVars = function () {
-  var w, h;
-  var cm = currCanvasMode;
-  var p = currentPage();
-  var spread = p.parent;
-  var docPrefs = currentDoc().documentPreferences;
-  currOriginX = 0;
-  currOriginY = 0;
-
-  if(cm === pub.PAGE || cm === pub.MARGIN || cm === pub.BLEED) {
-    currDoc.viewPreferences.rulerOrigin = RulerOrigin.PAGE_ORIGIN;
-    pub.resetMatrix();
-
-    var leftHand = (p.side === PageSideOptions.LEFT_HAND);
-    w = p.bounds[3] - p.bounds[1];
-    h = p.bounds[2] - p.bounds[0];
-
-    if (cm === pub.MARGIN) {
-      w -= (p.marginPreferences.left + p.marginPreferences.right);
-      h -= (p.marginPreferences.top + p.marginPreferences.bottom);
-      currOriginX = leftHand ? p.marginPreferences.right : p.marginPreferences.left;
-      currOriginY = p.marginPreferences.top;
-    } else if (cm === pub.BLEED) {
-      // pub.BLEED
-      var leftBleed = 0;
-      var rightBleed = 0;
-      if(p === spread.pages.firstItem()) {
-        leftBleed = leftHand ? docPrefs.documentBleedOutsideOrRightOffset : docPrefs.documentBleedInsideOrLeftOffset;
-      }
-      if(p === spread.pages.lastItem()) {
-        rightBleed = leftHand ? docPrefs.documentBleedInsideOrLeftOffset : docPrefs.documentBleedOutsideOrRightOffset;
-      }
-      w += leftBleed + rightBleed;
-      h += docPrefs.documentBleedTopOffset + docPrefs.documentBleedBottomOffset;
-      currOriginX = -leftBleed;
-      currOriginY = -docPrefs.documentBleedTopOffset;
-    }
-
-  } else {
-    // FACING_MODES
-    currDoc.viewPreferences.rulerOrigin = RulerOrigin.SPREAD_ORIGIN;
-    pub.resetMatrix();
-    var firstPage = spread.pages.firstItem();
-    var lastPage = spread.pages.lastItem();
-    var firstPageLeftHand = (firstPage.side === PageSideOptions.LEFT_HAND);
-    var lastPageLeftHand = (lastPage.side === PageSideOptions.LEFT_HAND);
-    w = lastPage.bounds[3] - firstPage.bounds[1];
-    h = p.bounds[2] - p.bounds[0];
-
-    if(cm === pub.FACING_MARGINS) {
-      var leftMargin = firstPageLeftHand ? firstPage.marginPreferences.right : firstPage.marginPreferences.left;
-      var rightMargin = lastPageLeftHand ? lastPage.marginPreferences.left : lastPage.marginPreferences.right;
-      w -= (leftMargin + rightMargin);
-      h -= (p.marginPreferences.top + p.marginPreferences.bottom);
-      currOriginX = leftMargin;
-      currOriginY = p.marginPreferences.top;
-    } else if (cm === pub.FACING_BLEEDS) {
-      var leftBleed = firstPageLeftHand ? docPrefs.documentBleedOutsideOrRightOffset : docPrefs.documentBleedInsideOrLeftOffset;
-      var rightBleed = lastPageLeftHand ? docPrefs.documentBleedInsideOrLeftOffset : docPrefs.documentBleedOutsideOrRightOffset;
-      w += leftBleed + rightBleed;
-      h += docPrefs.documentBleedTopOffset + docPrefs.documentBleedBottomOffset;
-      currOriginX = -leftBleed;
-      currOriginY = -docPrefs.documentBleedTopOffset;
-    }
-
-  }
-
-  pub.translate(currOriginX, currOriginY);
-  pub.width = $.global.width = w;
-  pub.height = $.global.height = h;
-
-};
-
-var resetUserSettings = function() {
-  // app settings
-  app.scriptPreferences.enableRedraw = appSettings.enableRedraw;
-  app.preflightOptions.preflightOff  = appSettings.preflightOff;
-  app.transformPreferences.adjustStrokeWeightWhenScaling = appSettings.adjustStrokeWeight;
-  app.transformPreferences.whenScaling = appSettings.whenScaling;
-
-  if(app.properties.activeWindow instanceof LayoutWindow ) {
-    app.activeWindow.transformReferencePoint = appSettings.refPoint;
-  }
-
-  // doc settings
-  if(currDoc && currDocSettings) {
-    resetDocSettings();
-  }
-}
-
-var resetDocSettings = function() {
-  try {
-    currDoc.viewPreferences.rulerOrigin = currDocSettings.rulerOrigin;
-    currDoc.viewPreferences.horizontalMeasurementUnits = currDocSettings.hUnits;
-    currDoc.viewPreferences.verticalMeasurementUnits = currDocSettings.vUnits;
-
-    currDoc.textDefaults.appliedParagraphStyle = currDocSettings.pStyle;
-    currDoc.textDefaults.appliedCharacterStyle = currDocSettings.cStyle;
-    currDoc.pageItemDefaults.appliedTextObjectStyle = currDocSettings.otxtStyle;
-    currDoc.pageItemDefaults.appliedGraphicObjectStyle = currDocSettings.ograStyle;
-    currDoc.pageItemDefaults.appliedGridObjectStyle = currDocSettings.ogriStyle;
-  } catch (e) {
-    // document was closed via non-basil methods
-    currDoc = null;
-  }
-}
-
-var createSelectionDialog = function(settings) {
-  var result;
-  if(!settings) {
-    settings = {};
-  }
-
-  // set settings object to given values or defaults
-  settings.prompt = settings.hasOwnProperty("prompt") ? settings.prompt : "";
-  settings.filter = settings.hasOwnProperty("filter") ? settings.filter : [""];
-  settings.folder = settings.hasOwnProperty("folder") ? settings.folder : currDialogFolder;
-  settings.multiFile = settings.hasOwnProperty("multiFile") ? true : false;
-  settings.folderSelect = settings.hasOwnProperty("folderSelect") ? true : false;
-
-  if(!isString(settings.prompt)) {
-    settings.prompt = "";
-  }
-  if(!isString(settings.filter) && !isArray(settings.filter)) {
-    settings.filter = [""];
-  }
-  if(isString(settings.filter)) {
-    settings.filter = [settings.filter];
-  }
-  if(isString(settings.folder)) {
-    settings.folder = pub.folder(settings.folder);
-  }
-  if(!(settings.folder instanceof Folder) || !settings.folder.exists) {
-    settings.folder = currDialogFolder;
-  }
-
-  if(settings.folderSelect) {
-    result = Folder(settings.folder).selectDlg(settings.prompt);
-  } else {
-    function filterFiles(file){
-      if (file instanceof Folder) { return true }
-      for (var i = settings.filter.length - 1; i >= 0; i--) {
-        if (isString(settings.filter[i]) && endsWith(file.name.toLowerCase(), settings.filter[i].toLowerCase())) { return true }
-      }
-      return false;
-    }
-
-    result = File(settings.folder).openDlg(settings.prompt, filterFiles, settings.multiFile);
-  }
-
-  if(result instanceof File) {
-    currDialogFolder = result.parent;
-  } else if (isArray(result)) {
-    currDialogFolder = result[0].parent;
-  } else if (result instanceof Folder) {
-    currDialogFolder = result;
-  }
-
-  if(result === null && settings.multiFile) {
-    result = [];
-  }
-
-  return result;
-}
-
-// internal helper to get a style by name, wether it is nested in a stlye group or not
-var findInStylesByName = function(allStylesCollection, name) {
-  for (var i = 0; i < allStylesCollection.length; i++) {
-    if (allStylesCollection[i].name === name) {
-      return allStylesCollection[i];
-    }
-  }
-  return null;
-};
-
-// get the name of parent functions; helpful for more meaningful error messages
-// level describes how many levels above to find the function whose function name is returned
-var getParentFunctionName = function(level) {
-    var stackArray = $.stack.
-          replace(/\((.+?)\)/g, "").
-          split(/[\n]/);
-    return stackArray[stackArray.length - 2 - level];
-}
-
-var checkNull = function (obj) {
-  if(obj === null || typeof obj === undefined) error("Received null object.");
-};
-
-var isEnum = function(base, value) {
-  var props = base.reflect.properties;
-  for (var i = 0; i < props.length; i++) {
-    if (base[props[i].name] == value) return true;
-  }
-  return false;
-}
-
-var executionDuration = function() {
-  var duration = pub.millis();
-  return duration < 1000 ? duration + "ms" : (duration / 1000).toPrecision(3) + "s";
-}
-
-var error = function(msg) {
-  println(ERROR_PREFIX + msg);
-  throw new Error(ERROR_PREFIX + msg);
-};
-
-var warning = function(msg) {
-  println(WARNING_PREFIX + msg);
-};
-
-var clearConsole = function() {
-  var bt = new BridgeTalk();
-  bt.target = "estoolkit";
-  bt.body = "app.clc()"; // works just with cs6
-  bt.onError = function(errObj) {};
-  bt.onResult = function(resObj) {};
-  bt.send();
-};
-
-                 - Ken Frederick http://kennethfrederick.de/
-
-                 - Timo Rychert http://timorychert.de/
-                 - Fabian Morón Zirfas http://fabianmoronzirfas.me/
-// ----------------------------------------
-// src/includes/structure.js
-// ----------------------------------------
-
-var forEachTextCollection = function(container, collection, cb) {
-  // var collection;
-  if(container instanceof Document) {
-    collection = container.stories.everyItem()[collection];
-  } else {
-    collection = container.textFrames.everyItem()[collection];
-  }
-
-  for (var i = 0; i < collection.length; i++) {
-    if(cb(collection[i], i) === false) {
-      return false;
-    }
-  }
-  return true;
-};
-
-
-var textCollection = function(collection, legalContainers, container, cb) {
-
-  checkNull(container);
-
-  if(!(container.hasOwnProperty("contents") || container instanceof Document || container instanceof Page)) {
-    error(collection + "(), wrong object type. Use: " + legalContainers);
-  }
-
-  if(cb instanceof Function) {
-    // callback function is passed
-    if (container instanceof Document || container instanceof Page) {
-      return forEachTextCollection(container, collection, cb);
-    }
-    return forEach(container[collection], cb);
-
-  }
-    // no callback function is passed
-  if(container instanceof Document) {
-    return container.stories.everyItem()[collection];
-  } else if (container instanceof Page) {
-    return container.textFrames.everyItem()[collection];
-  }
-  return container[collection];
-
-
-};
-/**
- * @description Suspends the calling thread for a number of milliseconds.<br>
- * During a sleep period, checks at 100 millisecond intervals to see whether the sleep should be terminated.
- *
- * @cat    Environment
- * @method delay
- * @param  {Number} milliseconds  The delay time in milliseconds.
- */
-pub.delay = function (milliseconds) {
-  $.sleep(milliseconds);
-};
-
-/**
- * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function with each story of the given document.
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method stories
- * @param  {Document} doc The document instance to iterate the stories in
- * @param  {Function} [cb] The callback function to call with each story. When this function returns false the loop stops. Passed arguments: story, loopCount.
- * @return {Stories} A collection of Story objects.
- *
- * @example
- * stories(doc(), function(story, loopCount){
- *   println("Number of words in each Story:");
- *   println(story.words.length);
- * });
- */
-pub.stories = function(doc, cb) {
-
-  checkNull(doc);
-
-  if(arguments.length === 1 && doc instanceof Document) {
-    return doc.stories;
-  } else if (cb instanceof Function) {
-    return forEach(doc.stories, cb);
-  }
-  error("stories(), incorrect call. Wrong parameters!");
-  return null;
-};
-
-/**
- * @description If no callback function is given it returns a Collection of paragraphs in the container otherwise calls the given callback function with each paragraph of the given document, page, story or textFrame.
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method paragraphs
- * @param  {Document|Page|Story|TextFrame} container The document, story, page or textFrame instance to iterate the paragraphs in.
- * @param  {Function} [cb]  Optional: The callback function to call with each paragraph. When this function returns false the loop stops. Passed arguments: para, loopCount.
- * @return {Paragraphs} A collection of Paragraph objects.
- */
-pub.paragraphs = function(container, cb) {
-
-  var legalContainers = "Document, Story, Page or TextFrame.";
-  return textCollection("paragraphs", legalContainers, container, cb);
-
-};
-
-/**
- * @description If no callback function is given it returns a Collection of lines in the container otherwise calls the given callback function with each line of the given document, page, story, textFrame or paragraph.
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method lines
- * @param  {Document|Page|Story|TextFrame|Paragraph} container The document, page, story, textFrame or paragraph instance to iterate the lines in.
- * @param  {Function} [cb] Optional: The callback function to call with each line. When this function returns false the loop stops. Passed arguments: line, loopCount.
- * @return {Lines} A collection of Line objects.
- */
-pub.lines = function(container, cb) {
-
-  var legalContainers = "Document, Story, Page, TextFrame or Paragraph.";
-  return textCollection("lines", legalContainers, container, cb);
-
-};
-
-/**
- * @description If no callback function is given it returns a Collection of words in the container otherwise calls the given callback function with each word of the given document, page, story, textFrame, paragraph or line.
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method words
- * @param  {Document|Page|Story|TextFrame|Paragraph|Line} container The document, page, story, textFrame, paragraph or line instance to iterate the words in.
- * @param  {Function} [cb] The callback function to call with each word. When this function returns false the loop stops. Passed arguments: word, loopCount.
- * @return {Words} A collection of Word objects.
- */
-pub.words = function(container, cb) {
-
-  var legalContainers = "Document, Story, Page, TextFrame, Paragraph or Line.";
-  return textCollection("words", legalContainers, container, cb);
-
-};
-
-/**
- * @description If no callback function is given it returns a Collection of characters in the container otherwise calls the given callback function with each character of the given document, page, story, textFrame, paragraph, line or word.
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method characters
- * @param  {Document|Page|Story|TextFrame|Paragraph|Line|Word} container The document, page, story, textFrame, paragraph, line or word instance to  iterate the characters in.
- * @param  {Function} [cb] Optional: The callback function to call with each character. When this function returns false the loop stops. Passed arguments: character, loopCount
- * @return {Characters} A collection of Character objects.
- */
-pub.characters = function(container, cb) {
-
-  var legalContainers = "Document, Story, Page, TextFrame, Paragraph, Line or Word.";
-  return textCollection("characters", legalContainers, container, cb);
-
-};
-
-
-/**
- * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function for each of the PageItems in the given Document, Page, Layer or Group.
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method items
- * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in
- * @param  {Function|Boolean} [cb] Optional: The callback function to call for each PageItem. When this function returns false the loop stops. Passed arguments: item, loopCount.
- * @return {PageItems} A collection of PageItem objects.
- */
-pub.items = function(container, cb) {
-
-  if (container instanceof Document
-    || container instanceof Page
-    || container instanceof Layer
-    || container instanceof Group) {
-
-    if(arguments.length === 1 || cb === false) {
-      return container.allPageItems;
-    } else if(cb instanceof Function) {
-      return forEach(container.allPageItems, cb);
-    }
-  }
-  error("items(), Not a valid PageItem container, should be Document, Page, Layer or Group");
-  return null;
-};
-
-
-/**
- * @description Removes all PageItems (including locked ones) in the given Document, Page, Layer or Group. If the selected container is a Group, the Group itself will be removed as well.
- *
- * @cat    Document
- * @method clear
- * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in.
- */
-pub.clear = function(container) {
-
-  if (container instanceof Document
-    || container instanceof Page
-    || container instanceof Layer) {
-
-    container.pageItems.everyItem().locked = false;
-    container.pageItems.everyItem().remove();
-
-  } else if (container instanceof Group) {
-
-    container.locked = false;
-    container.remove();
-
-  } else {
-    error("clear(), not a valid container! Use: Document, Page, Layer or Group.");
-  }
-};
-
-/**
- * @description Removes the provided Page, Layer, PageItem, Swatch, etc.
- *
- * @cat    Document
- * @method remove
- * @param  {PageItem} obj The object to be removed.
- */
-pub.remove = function(obj) {
-
-  if(obj.hasOwnProperty("remove")) {
-    obj.remove();
-  } else {
-    error("remove(), provided object cannot be removed.");
-  }
-};
-
-
-  Web Site       - http://basiljs.ch
-  Github Repo.   - https://github.com/basiljs/basil.js
-  Processing     - http://processing.org
-  Processing.js  - http://processingjs.org
-// ----------------------------------------
-// src/includes/environment.js
-// ----------------------------------------
-
-/**
- * @description Sets or possibly creates the current document and returns it.
- * If the param doc is not given the current document gets set to the active document
- * in the application. If no document at all is open, a new document gets created.
- *
- * @cat    Document
- * @method doc
- * @param  {Document} [doc] The document to set the current document to.
- * @return {Document} The current document instance.
- */
-pub.doc = function(doc) {
-  if (doc instanceof Document) {
-    // reset the settings of the old doc, before activating the new doc
-    resetDocSettings();
-    setCurrDoc(doc);
-  }
-  return currentDoc();
-};
-
-/**
- * @description Sets the size of the current document, if arguments are given.
- * If only one argument is given, both the width and the height are set to this value.
- * Alternatively, a string can be given as the first argument to apply an existing page size preset ("A4", "Letter" etc.).
- * In this case, either PORTRAIT or LANDSCAPE can be used as a second argument to determine the orientation of the page.
- * If no argument is given, an object containing the current document's width and height is returned.
- *
- * @cat    Document
- * @method size
- * @param  {Number|String} [widthOrPageSize] The desired width of the current document or the name of a page size preset.
- * @param  {Number|String} [heightOrOrientation] The desired height of the current document. If not provided the width will be used as the height. If the first argument is a page size preset, the second argument can be used to set the orientation.
- * @return {Object} Object containing the current `width` and `height` of the document.
- *
- * @example <caption>Sets the document size to 70 x 100 units</caption>
- * size(70, 100);
- *
- * @example <caption>Sets the document size to 70 x 70</caption>
- * size(70);
- *
- * @example <caption>Sets the document size to A4, keeps the current orientation in place</caption>
- * size("A4");
- *
- * @example <caption>Sets the document size to A4, set the orientation to landscape</caption>
- * size("A4", LANDSCAPE);
- */
-pub.size = function(widthOrPageSize, heightOrOrientation) {
-  if(app.documents.length === 0) {
-    // there are no documents
-    warning("size()", "You have no open document.");
-    return;
-  }
-  if (arguments.length === 0) {
-    // no arguments given
-    // return the current values
-    return {width: pub.width, height: pub.height};
-  }
-
-  var doc = currentDoc();
-
-  if(isString(widthOrPageSize)) {
-    try {
-      doc.documentPreferences.pageSize = widthOrPageSize;
-    } catch (e) {
-      error("size(), could not find a page size preset named \"" + widthOrPageSize + "\".");
-    }
-    if(heightOrOrientation === pub.PORTRAIT || heightOrOrientation === pub.LANDSCAPE) {
-      doc.documentPreferences.pageOrientation = heightOrOrientation;
-    }
-    pub.width = $.global.width = doc.documentPreferences.pageWidth;
-    pub.height = $.global.height = doc.documentPreferences.pageHeight;
-    return {width: pub.width, height: pub.height};
-  } else if(arguments.length === 1) {
-    // only one argument set the first to the secound
-    heightOrOrientation = widthOrPageSize;
-  }
-  // set the document's pageHeight and pageWidth
-  doc.properties = {
-    documentPreferences: {
-      pageHeight: heightOrOrientation,
-      pageWidth: widthOrPageSize
-    }
-  };
-  // set height and width
-  pub.width = $.global.width = widthOrPageSize;
-  pub.height = $.global.height = heightOrOrientation;
-
-  return {width: pub.width, height: pub.height};
-
-};
-
-/**
- * @description Closes the current document. If no saveOptions argument is used, the user will be asked if they want to save or not.
- *
- * @cat    Document
- * @method close
- * @param  {Object|Boolean} [saveOptions] The InDesign SaveOptions constant or either true for triggering saving before closing or false for closing without saving.
- * @param  {File} [file] The InDesign file instance to save the document to.
- */
-pub.close = function(saveOptions, file) {
-  if (currDoc) {
-    if(saveOptions === false) {
-      saveOptions = SaveOptions.NO;
-    } else if(saveOptions === true) {
-      saveOptions = SaveOptions.YES;
-    } else if(saveOptions === undefined) {
-      saveOptions = SaveOptions.ASK;
-    } else {
-      if(!isEnum(SaveOptions, saveOptions)) {
-        error("close(), wrong saveOptions argument. Use True, False, InDesign SaveOptions constant or leave empty.");
-      }
-    }
-
-    resetDocSettings();
-
-    try {
-      currDoc.close(saveOptions, file);
-    } catch (e) {
-      // the user has cancelled a save dialog, the doc will not be saved
-      currDoc.close(saveOptions.NO);
-    }
-    resetCurrDoc();
-  }
-};
-
-/**
- * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
- *
- * @cat    Document
- * @method revert
- * @return {Document} The reverted document.
- */
-pub.revert = function() {
-
-  if(currDoc.saved && currDoc.modified) {
-    var currFile = currDoc.fullName;
-    currDoc.close(SaveOptions.NO);
-    currDoc = null;
-    app.open(File(currFile));
-    currentDoc();
-  } else if(!currDoc.saved) {
-    currDoc.close(SaveOptions.NO);
-    currDoc = null;
-    app.documents.add();
-    currentDoc();
-  }
-
-  return currDoc;
-};
-
-/**
- * @description Use this to set the dimensions of the canvas. Choose between PAGE (default), MARGIN, BLEED resp. FACING_PAGES, FACING_MARGINS and FACING_BLEEDS for book setups with facing page. Please note: Setups with more than two facing pages are not yet supported.<br>
- * Please note that you will loose your current MatrixTransformation. You should set the canvasMode before you attempt to use translate(), rotate() and scale();
- *
- * @cat    Document
- * @subcat Page
- * @method canvasMode
- * @param  {String} mode The canvas mode to set.
- * @return {String} The current canvas mode.
- */
-pub.canvasMode = function (m) {
-  if(arguments.length === 0) {
-    return currCanvasMode;
-  } else if (m === pub.PAGE ||
-             m === pub.MARGIN ||
-             m === pub.BLEED ||
-             m === pub.FACING_PAGES ||
-             m === pub.FACING_MARGINS ||
-             m === pub.FACING_BLEEDS) {
-    currCanvasMode = m;
-    updatePublicPageSizeVars();
-  } else {
-    error("canvasMode(), there is a problem setting the canvasMode. Please check the reference for details.");
-  }
-  return currCanvasMode;
-};
-
-
-/**
- * @description Returns the current horizontal and vertical pasteboard margins and sets them if both arguements are given.
- *
- * @cat    Document
- * @subcat Page
- * @method pasteboard
- * @param  {Number} h The desired horizontal pasteboard margin.
- * @param  {Number} v The desired vertical pasteboard margin.
- * @return {Array} The current horizontal, vertical pasteboard margins.
- */
-pub.pasteboard = function (h, v) {
-  if(arguments.length == 0) {
-    return currentDoc().pasteboardPreferences.pasteboardMargins;
-  } else if(arguments.length == 1) {
-    error("pasteboard() requires both a horizontal and vertical value. Please check the reference for details.");
-  }else if (typeof h === "number" && typeof v === "number") {
-    currentDoc().pasteboardPreferences.pasteboardMargins = [h, v];
-    return currentDoc().pasteboardPreferences.pasteboardMargins;
-  }else {
-    error("pasteboard(), there is a problem setting the pasteboard. Please check the reference for details.");
-  }
-};
-
-/**
- * @description Returns the current page and sets it if argument page is given. Numbering starts with 1.
- *
- * @cat    Document
- * @subcat Page
- * @method page
- * @param  {Page|Number|PageItem} [page] The page object or page number to set the current page to. If you pass a PageItem the current page will be set to it's containing page.
- * @return {Page} The current page instance.
- */
-pub.page = function(page) {
-  if (page instanceof Page) {
-    currPage = page;
-  } else if (typeof page !== "undefined" && page.hasOwnProperty("parentPage")) {
-    currPage = page.parentPage; // page is actually a PageItem
-  } else if (typeof page === "number") {
-    if(page < 1) {
-      p = 0;
-    } else {
-      p = page - 1;
-    }
-    var tempPage = currentDoc().pages[p];
-    try {
-      tempPage.id;
-    } catch (e) {
-      error("page(), " + page + " does not exist.");
-    }
-    currPage = tempPage;
-  } else if (typeof page !== "undefined") {
-    error("page(), bad type for page().");
-  }
-  updatePublicPageSizeVars();
-  if (currentDoc().windows.length) {
-    app.activeWindow.activePage = currPage;
-  } // focus in GUI if not in HIDDEN
-  return currentPage();
-};
-
-/**
- * @description Adds a new page to the document. Set the optional location parameter to either AT_END (default), AT_BEGINNING, AFTER or BEFORE. AFTER and BEFORE will use the current page as insertion point.
- *
- * @cat    Document
- * @subcat Page
- * @method addPage
- * @param  {String} [location] The location placement mode.
- * @return {Page} The new page.
- */
-pub.addPage = function(location) {
-
-  checkNull(location);
-
-  if(arguments.length === 0) {
-    location = pub.AT_END;
-  } // default
-
-  var nP;
-  try {
-
-    switch (location) {
-
-      case pub.AT_END:
-        nP = currentDoc().pages.add(location);
-        break;
-
-      case pub.AT_BEGINNING:
-        nP = currentDoc().pages.add(location);
-        break;
-
-      case pub.AFTER:
-        nP = currentDoc().pages.add(location, pub.page());
-        break;
-
-      case pub.BEFORE:
-        nP = currentDoc().pages.add(location, pub.page());
-        break;
-
-      default:
-        throw new Error();
-        break;
-    }
-
-    pub.page(nP);
-    return nP;
-
-  } catch (e) {
-    error("addPage(), invalid location argument passed to addPage()");
-  }
-};
-
-
-/**
- * @description Removes a page from the current document. This will either be the current Page if the parameter page is left empty, or the given Page object or page number.
- *
- * @cat    Document
- * @subcat Page
- * @method removePage
- * @param  {Page|Number} [page] The page to be removed as Page object or page number.
- */
-pub.removePage = function (page) {
-  checkNull(page);
-  if(typeof page === "number" || arguments.length === 0 || page instanceof Page) {
-    var p = pub.page(page);
-    p.remove();
-    currPage = null; // reset!
-    currentPage();
-  } else {
-    error("removePage(), invalid call. Wrong parameter!");
-  }
-};
-
-/**
- * @description Returns the current page number of either the current page or the given Page object.
- *
- * @cat    Document
- * @subcat Page
- * @method pageNumber
- * @param  {Page} [pageObj] The page you want to know the number of.
- * @return {Number} The page number within the document.
- */
-pub.pageNumber = function (pageObj) {
-  checkNull(pageObj);
-  if (typeof pageObj === "number") {
-    error("pageNumber(), cannot be called with a Number argument.");
-  }
-  if (pageObj instanceof Page) {
-    return parseInt(pageObj.name); // current number of given page
-  }
-  return parseInt(pub.page().name); // number of current page
-};
-
-/**
- * @description Set the next page of the document to be the active one. Returns new active page.
- *
- * @cat    Document
- * @subcat Page
- * @method nextPage
- * @return {Page} The active page.
- */
-pub.nextPage = function () {
-  var p = pub.doc().pages.nextItem(currentPage());
-  return pub.page(p);
-};
-
-
-/**
- * @description Set the previous page of the document to be the active one. Returns new active page.
- *
- * @cat    Document
- * @subcat Page
- * @method previousPage
- * @return {Page} The active page.
- */
-pub.previousPage = function () {
-  var p = pub.doc().pages.previousItem(currentPage());
-  return pub.page(p);
-};
-
-
-/**
- * @description Returns the number of all pages in the current document. If a number is given as an argument,
- * it will set the document's page count to the given number by either adding pages or removing
- * pages until the number is reached. If pages are added, the master page of the document's last
- * page will be applied to the new pages.
- *
- * @cat    Document
- * @subcat Page
- * @method pageCount
- * @param  {Number} [pageCount] New page count of the document (integer between 1 and 9999).
- * @return {Number} The amount of pages.
- */
-pub.pageCount = function(pageCount) {
-  if(arguments.length) {
-    if(pub.isInteger(pageCount) && pageCount > 0 && pageCount < 10000) {
-      currentDoc().documentPreferences.pagesPerDocument = pageCount;
-    } else {
-      error("pageCount(), wrong arguments! Use an integer between 1 and 9999 to set page count.");
-    }
-  }
-  return currentDoc().pages.count();
-};
-
-
-/**
- * @description The number of all stories in the current document.
- *
- * @cat    Document
- * @subcat Story
- * @method storyCount
- * @return {Number} count The amount of stories.
- */
-pub.storyCount = function() {
-  return currentDoc().stories.count();
-};
-
-/**
- * @description Adds a page item or a string to an existing story. You can control the position of the insert via the last parameter. It accepts either an InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
- *
- * @cat    Document
- * @subcat Story
- * @method addToStory
- * @param  {Story} story The story.
- * @param  {PageItem|String} itemOrString The itemOrString either a PageItem, a String or one the following constants: AT_BEGINNING and AT_END.
- * @param  {InsertionPoint|String} insertionPointOrMode InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
- */
-pub.addToStory = function(story, itemOrString, insertionPointorMode) {
-
-  checkNull(story);
-  checkNull(itemOrString);
-
-  // init
-  var libFileName = "addToStoryLib.indl";
-
-  var libFile = new File(Folder.temp + "/" + libFileName);
-  addToStoryCache = app.libraries.itemByName(libFileName);
-  // if and a cache is existing from previous executions, remove it
-  if (addToStoryCache.isValid) {
-    addToStoryCache.close();
-    libFile.remove();
-  }
-  // create an InDesign library for caching the page items
-  addToStoryCache = app.libraries.add(libFile);
-
-
-  if (story instanceof Story && arguments.length >= 2) {
-    // add string
-    if (isString(itemOrString)) {
-      if (insertionPointorMode instanceof InsertionPoint) {
-        insertionPointorMode.contents = itemOrString;
-      } else if (insertionPointorMode === pub.AT_BEGINNING) {
-        story.insertionPoints.firstItem().contents = itemOrString;
-      } else {
-        story.insertionPoints.lastItem().contents = itemOrString;
-      }
-    } else {
-      // store the item as first asset in cache
-      addToStoryCache.store(itemOrString);
-
-      var insertionPoint = null;
-      if (insertionPointorMode instanceof InsertionPoint) {
-        insertionPoint = insertionPointorMode;
-      } else if (insertionPointorMode === pub.AT_BEGINNING) {
-        insertionPoint = story.insertionPoints.firstItem();
-      } else {
-        insertionPoint = story.insertionPoints.lastItem();
-      }
-
-      // place & remove from cache
-      addToStoryCache.assets.firstItem().placeAsset(insertionPoint);
-      addToStoryCache.assets.firstItem().remove();
-    }
-  } else {
-    error("addToStory(), wrong arguments! Please use: addToStory(story, itemOrString, insertionPointorMode). Parameter insertionPointorMode is optional.");
-  }
-};
-
-
-/**
- * @description Returns the current layer if no argument is given. Sets active layer if layer object or name of existing layer is given. Newly creates layer and sets it to active if new name is given.
- *
- * @cat    Document
- * @subcat Page
- * @method layer
- * @param  {Layer|String} [layer] The layer or layer name to set the current layer to.
- * @return {Layer} The current layer instance.
- */
-pub.layer = function(layer) {
-  checkNull(layer);
-  if (layer instanceof Layer) {
-    currLayer = layer;
-    currentDoc().activeLayer = currLayer;
-  } else if (typeof layer === "string") {
-    var layers = currentDoc().layers;
-    currLayer = layers.item(layer);
-    if (!currLayer.isValid) {
-      currLayer = layers.add({name: layer});
-    } else {
-      currentDoc().activeLayer = currLayer;
-    }
-  } else if (arguments.length > 0) {
-    error("layer(), wrong arguments. Use layer object or string instead.");
-  }
-  return currentLayer();
-};
-
-
-/**
- * @description Arranges a page item or a layer before or behind other page items or layers. If using the constants `FORWARD` or `BACKWARD` the object is sent forward or back one step. The constants `FRONT` or `BACK` send the object to the very front or very back. Using `FRONT` or `BACK` together with the optional reference object, sends the object in front or behind this reference object.
- *
- * @cat    Document
- * @subcat Page
- * @method arrange
- * @param  {PageItem|Layer} pItemOrLayer The page item or layer to be moved to a new position.
- * @param  {String} positionOrDirection The position or direction to move the page item or layer. Can be `FRONT`, `BACK`, `FORWARD` or `BACKWARD`.
- * @param  {PageItem|Layer} [reference] A reference object to move the page item or layer behind or in front of.
- * @return {PageItem|Layer} The newly arranged page item or layer.
- */
-pub.arrange = function(pItemOrLayer, positionOrDirection, reference) {
-  checkNull(pItemOrLayer);
-
-  if(pItemOrLayer.hasOwnProperty("parentPage")) {
-    if(positionOrDirection === pub.BACKWARD) {
-      pItemOrLayer.sendBackward();
-    } else if (positionOrDirection === pub.FORWARD) {
-      pItemOrLayer.bringForward();
-    } else if (positionOrDirection === pub.BACK) {
-      pItemOrLayer.sendToBack(reference);
-    } else if (positionOrDirection === pub.FRONT) {
-      pItemOrLayer.bringToFront(reference);
-    } else {
-      error("arrange(), not a valid position or direction. Please use FRONT, BACK, FORWARD or BACKWARD.");
-    }
-  } else if (pItemOrLayer instanceof Layer) {
-    if(positionOrDirection === pub.BACKWARD) {
-      if(pItemOrLayer.index === currentDoc().layers.length - 1) return;
-      pItemOrLayer.move(LocationOptions.AFTER, currentDoc().layers[pItemOrLayer.index + 1]);
-    } else if (positionOrDirection === pub.FORWARD) {
-      if(pItemOrLayer.index === 0) return;
-      pItemOrLayer.move(LocationOptions.BEFORE, currentDoc().layers[pItemOrLayer.index - 1]);
-    } else if (positionOrDirection === pub.BACK) {
-      if(!(reference instanceof Layer)) {
-        pItemOrLayer.move(LocationOptions.AT_END);
-      } else {
-        pItemOrLayer.move(LocationOptions.AFTER, reference);
-      }
-    } else if (positionOrDirection === pub.FRONT) {
-      if(!(reference instanceof Layer)) {
-        pItemOrLayer.move(LocationOptions.AT_BEGINNING);
-      } else {
-        pItemOrLayer.move(LocationOptions.BEFORE, reference);
-      }
-    } else {
-      error("arrange(), not a valid position or direction. Please use FRONT, BACK, FORWARD or BACKWARD.");
-    }
-  } else {
-    error("arrange(), invalid first parameter. Use page item or layer.");
-  }
-
-  return pItemOrLayer;
-};
-
-
-/**
- *  @description Returns the Group instance and sets it if argument Group is given.
- *  Groups items to a new group. Returns the resulting group instance. If a string is given as the only
- *  argument, the group by the given name will be returned.
- *
- *  @cat    Document
- *  @subCat Page
- *  @method group
- *  @param  {Array} pItems An array of page items (must contain at least two items) or name of group instance.
- *  @param  {String} [name] The name of the group, only when creating a group from page items.
- *  @return {Group} The group instance.
- */
-pub.group = function (pItems, name) {
-  checkNull(pItems);
-  var group;
-  if(pItems instanceof Array) {
-    if(pItems.length < 2) {
-      error("group(), the array passed to group() must at least contain two page items.");
-    }
-    // creates a group from Page Items
-    group = currentDoc().groups.add(pItems);
-    if(typeof name !== "undefined") {
-      group.name = name;
-    }
-  } else if(typeof pItems === "string") {
-    // get the Group of the given name
-    group = currentDoc().groups.item(pItems);
-    if (!group.isValid) {
-      error("group(), a group with the provided name doesn't exist.");
-    }
-  } else {
-    error("group(), not a valid argument. Use an array of page items to group or a name of an existing group.");
-  }
-
-  return group;
-};
-
-
-/**
- *  @description Ungroups an existing group. Returns an array of the items that were within the group before ungroup() was called.
- *
- *  @cat    Document
- *  @subCat Page
- *  @method ungroup
- *  @param  {Group|String} group The group instance or name of the group to ungroup.
- *  @return {Array} An array of the ungrouped page items.
- */
-pub.ungroup = function(group) {
-  checkNull(group);
-  var ungroupedItems = null;
-  if(group instanceof Group) {
-    ungroupedItems = pub.items(group);
-    group.ungroup();
-  } else if(typeof group === "string") {
-    // get the Group of the given name
-    group = currentDoc().groups.item(group);
-    if (!group.isValid) {
-      error("ungroup(), a group with the provided name doesn't exist.");
-    }
-    ungroupedItems = pub.items(group);
-    group.ungroup();
-  } else {
-    error("ungroup(), not a valid group. Please select a valid group.");
-  }
-  return ungroupedItems;
-};
-
-
-/**
- * @description Returns items tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label).
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method labels
- * @param  {String} label The label identifier.
- * @param  {Function} [cb] The callback function to call with each item in the search result. When this function returns false the loop stops. Passed arguments: item, loopCount.
- * @return {Array} Array of concrete PageItem instances, e.g. TextFrame or SplineItem.
- */
-pub.labels = function(label, cb) {
-  checkNull(label);
-  var result = [];
-  var doc = currentDoc();
-  for (var i = 0, len = doc.pageItems.length; i < len; i++) {
-    var pageItem = doc.pageItems[i];
-    if (pageItem.label === label) {
-      // push pageItem's 1st element to get the concrete PageItem instance, e.g. a TextFrame
-      result.push(pageItem.getElements()[0]);
-    }
-  }
-  if (arguments.length === 2 && cb instanceof Function) {
-    return forEach(result, cb);
-  }
-  if(result.length === 0) {
-    error("labels(), no item found with the given label '" + label + "'. Check for line breaks and whitespaces in the script label panel.");
-  }
-  return result;
-};
-
-
-/**
- * @description Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of `labels()`, when you know you just have one thing with that label and don't want to deal with a single-element array.
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method label
- * @param  {String} label The label identifier.
- * @return {PageItem} The first PageItem with the given label.
- */
-pub.label = function(label) {
-  checkNull(label);
-  var doc = currentDoc();
-  for (var i = 0, len = doc.pageItems.length; i < len; i++) {
-    var pageItem = doc.pageItems[i];
-    if (pageItem.label === label) {
-      return pageItem;
-    }
-  }
-  error("label(), no item found with the given label '" + label + "'. Check for line breaks and whitespaces in the script label panel.");
-};
-
-
-/**
- * @description Returns the first currently selected object. Use this if you know you only have one selected item and don't want to deal with an array.
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method selection
- * @return {Object} The first selected object.
- */
-pub.selection = function() {
-  if(app.selection.length === 0) {
-    error("selection(), selection is empty. Please select something.");
-  }
-  return app.selection[0];
-};
-
-/**
- * @description Returns the currently selected object(s)
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method selections
- * @param  {Function} [cb] The callback function to call with each item in the selection. When this function returns false the loop stops. Passed arguments: item, loopCount.
- * @return {Array} Array of selected object(s).
- */
-pub.selections = function(cb) {
-  if(app.selection.length === 0) {
-    error("selections(), selection is empty. Please select something.");
-  }
-  if (arguments.length === 1 && cb instanceof Function) {
-    return forEach(app.selection, cb);
-  }
-  return app.selection;
-};
-
-/**
- * @description Returns the first item on the active page that is named by the given name in the Layers pane (Window -> Layer).
- *
- * @cat    Document
- * @subcat Multi-Getters
- * @method nameOnPage
- * @return {Object} The first object on the active page with the given name.
- */
-pub.nameOnPage = function(name) {
-  checkNull(name);
-  var result = null;
-  var page = currentPage();
-  for (var i = 0, len = page.allPageItems.length; i < len; i++) {
-    var pageItem = page.allPageItems[i];
-    if (pageItem.name === name) {
-      result = pageItem.getElements()[0];
-      break;
-    }
-  }
-  if(result === null) {
-    error("nameOnPage(), no item found with the name '" + name + "' on page " + pub.pageNumber());
-  }
-  return result;
-};
-
-
-/**
- * @description Sets the units of the document (like right clicking the rulers). By default basil uses the units of the user's document or the user's default units.
- *
- * @cat    Document
- * @method units
- * @param  {String} [units] Supported units: PT, PX, CM, MM or IN.
- * @return {String} Current unit setting.
- */
-var unitsCalledCounter = 0;
-pub.units = function (units) {
-  checkNull(units);
-  if (arguments.length === 0) {
-    return currUnits;
-  }
-
-  if (units === pub.PT || units === 2054188905) {
-    units = pub.PT;
-    unitType = MeasurementUnits.points;
-  } else if(units === pub.MM || units === 2053991795) {
-    units = pub.MM;
-    unitType = MeasurementUnits.millimeters;
-  } else if(units === pub.CM || units === 2053336435) {
-    units = pub.CM;
-    unitType = MeasurementUnits.centimeters;
-  } else if(units === pub.IN || units === 2053729891) {
-    units = pub.IN;
-    unitType = MeasurementUnits.inches;
-  } else if(units === pub.PX || units === 2054187384) {
-    units = pub.PX;
-    unitType = MeasurementUnits.pixels;
-  } else if(isEnum(MeasurementUnits, units)) {
-    // valid enumerator with invalid basil.js unit (from documents that are set to PICAS, CICEROS etc.)
-    warning("The document's current units are not supported by basil.js. Units will be set to Points.");
-    units = pub.PT;
-    unitType = MeasurementUnits.points;
-  } else {
-    error("units(), invalid unit. Use: PT, MM, CM, IN or PX.");
-  }
-
-  currentDoc().viewPreferences.horizontalMeasurementUnits = unitType;
-  currentDoc().viewPreferences.verticalMeasurementUnits = unitType;
-  currUnits = units;
-
-  updatePublicPageSizeVars();
-
-  if (unitsCalledCounter === 1) {
-    warning("Please note that units() will reset the current transformation matrix.");
-  }
-  unitsCalledCounter++;
-  return currUnits;
-};
-
-/**
- * @description Creates a vertical guide line at the current spread and current layer.
- *
- * @cat    Document
- * @method guideX
- * @param  {Number} x Position of the new guide line.
- * @return {Guide} New guide line.
- */
-pub.guideX = function (x) {
-  checkNull(x);
-  var guides = currentPage().guides;
-  var guide = guides.add(currentLayer());
-  guide.fitToPage = true;
-  guide.orientation = HorizontalOrVertical.VERTICAL;
-  guide.location = x;
-  return guide;
-};
-
-
-/**
- * @description Creates a horizontal guide line at the current spread and current layer.
- *
- * @cat    Document
- * @method guideY
- * @param  {Number} y Position of the new guide line.
- * @return {Guide} New guide line.
- */
-pub.guideY = function (y) {
-  checkNull(y);
-  var guides = currentPage().guides;
-  var guide = guides.add(currentLayer());
-  guide.fitToPage = true;
-  guide.orientation = HorizontalOrVertical.HORIZONTAL;
-  guide.location = y;
-  return guide;
-};
-
-
-/**
- * @description Sets the margins of a given page. If 1 value is given, all 4 sides are set equally. If 4 values are given, the current page will be adjusted. Adding a 5th value will set the margin of a given page. Calling the function without any values, will return the margins for the current page.
- *
- * @cat    Document
- * @subcat Page
- * @method margins
- * @param  {Number} [top] Top margin or all if only one.
- * @param  {Number} [right] Right margin.
- * @param  {Number} [bottom] Bottom margin.
- * @param  {Number} [left] Left margin.
- * @param  {Number} [pageNumber] Sets margins to selected page, currentPage() if left blank.
- * @return {Object} Current page margins with the properties: top, right, bottom, left.
- */
-pub.margins = function(top, right, bottom, left, pageNumber) {
-  if (arguments.length === 0) {
-    return {top: pub.page(pageNumber).marginPreferences.top,
-      right: pub.page(pageNumber).marginPreferences.right,
-      bottom: pub.page(pageNumber).marginPreferences.bottom,
-      left: pub.page(pageNumber).marginPreferences.left
-    };
-  } else if (arguments.length === 1) {
-    right = bottom = left = top;
-  }
-  if(pageNumber !== undefined) {
-    pub.page(pageNumber).marginPreferences.top = top;
-    pub.page(pageNumber).marginPreferences.right = right;
-    pub.page(pageNumber).marginPreferences.bottom = bottom;
-    pub.page(pageNumber).marginPreferences.left = left;
-  }else{
-    currentPage().marginPreferences.top = top;
-    currentPage().marginPreferences.right = right;
-    currentPage().marginPreferences.bottom = bottom;
-    currentPage().marginPreferences.left = left;
-  }
-};
-
-
-/**
- * @description Sets the document bleeds. If one value is given, all 4 are set equally. If 4 values are given, the top/right/bottom/left document bleeds will be adjusted. Calling the function without any values, will return the document bleed settings.
- *
- * @cat    Document
- * @subcat Page
- * @method bleeds
- * @param  {Number} [top] Top bleed or all if only one.
- * @param  {Number} [right] Right bleed.
- * @param  {Number} [bottom] Bottom bleed.
- * @param  {Number} [left] Left bleed.
- * @return {Object} Current document bleeds settings.
- */
-pub.bleeds = function(top, right, bottom, left) {
-  if (arguments.length === 0) {
-    return {top: currentDoc().documentPreferences.documentBleedTopOffset,
-      right: currentDoc().documentPreferences.documentBleedOutsideOrRightOffset,
-      bottom: currentDoc().documentPreferences.documentBleedBottomOffset,
-      left: currentDoc().documentPreferences.documentBleedInsideOrLeftOffset
-    };
-  } else if (arguments.length === 1) {
-    right = bottom = left = top;
-  }else{
-    currentDoc().documentPreferences.documentBleedUniformSize = false;
-  }
-  currentDoc().documentPreferences.documentBleedTopOffset = top;
-  currentDoc().documentPreferences.documentBleedOutsideOrRightOffset = right;
-  currentDoc().documentPreferences.documentBleedBottomOffset = bottom;
-  currentDoc().documentPreferences.documentBleedInsideOrLeftOffset = left;
-};
-
-
-/**
- * @description Inspects a given object or any other data item and prints the result to the console. This is useful for inspecting or debugging any kind of variable or data item. The optional settings object allows to control the function's output. The following parameters can be set in the settings object:<br>
- * `showProps`: Show or hide properties. Default: `true`<br>
- * `showValues`: Show or hide values. Default: `true`<br>
- * `showMethods`: Show or hide methods. Default: `false`<br>
- * `maxLevel`: Chooses how many levels of properties should be inspected recursively. Default: `1`<br>
- * `propList`: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: `[]` (no propList)<br>
- * If no settings object is set, the default values will be used.
- *
- * @cat    Output
- * @method inspect
- * @param  {Object} obj An object or any other data item to be inspected.
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {Boolean} [settings.showProps] Show or hide properties. Default: `true`
- * @param  {Boolean} [settings.showValues] Show or hide values. Default: `true`
- * @param  {Boolean} [settings.showMethods] Show or hide methods. Default: `false`
- * @param  {Number} [settings.maxLevel] How many levels of properties should be inspected recursively. Default: `1`
- * @param  {Array} [settings.propList] Array of properties to show. Default: `[]` (no propList)
- *
- * @example <caption>Inspecting a string</caption>
- * inspect("foo");
- *
- * @example <caption>Inspecting the current page, its methods and an additional level of properties</caption>
- * inspect(page(), {showMethods: true, maxLevel: 2})
- *
- * @example <caption>Inspecting an ellipse, listing only the properties "geometricBounds" and "strokeWeight"</caption>
- * var myEllipse = ellipse(0, 0, 10, 10);
- * inspect(myEllipse, {maxLevel: 2, propList: ["geometricBounds, strokeWeight"]});
- */
-pub.inspect = function (obj, settings, level, branchArray, branchEnd) {
-
-  var output, indent;
-  output = indent = "";
-
-  if (!level) {
-    level = 0;
-    branchArray = [];
-
-    if(!settings) {
-      settings = {};
-    }
-
-    // set settings object to given values or defaults
-    settings.showProps = settings.hasOwnProperty("showProps") ? settings.showProps : true;
-    settings.showValues = settings.hasOwnProperty("showValues") ? settings.showValues : true;
-    settings.showMethods = settings.hasOwnProperty("showMethods") ? settings.showMethods : false;
-    settings.maxLevel = settings.hasOwnProperty("maxLevel") ? settings.maxLevel : 1;
-    settings.propList = settings.hasOwnProperty("propList") ? settings.propList : [];
-
-    if(obj === null || obj === undefined) {
-      println(obj + "");
-      return;
-    }
-
-    if(obj.constructor.name === "Array") {
-      if(obj.length > 0 && obj.reflect.properties.length < 3) {
-        // fixing InDesign's buggy implementation of certain arrays
-        // see: https://forums.adobe.com/message/9408120#9408120
-        obj = Array.prototype.slice.call(obj, 0);
-      }
-      output += "[" + obj.join(", ") + "] (Array)";
-    } else if (obj.constructor.name === "String") {
-      output += "\"" + obj + "\" (String)";
-    } else {
-      output += obj + " (" + obj.constructor.name + ")";
-    }
-  } else {
-    // setting up tree structure indent
-    if(branchArray.length < level) {
-      branchArray.push(branchEnd);
-    } else if (branchArray.length > level) {
-      branchArray.pop();
-    }
-    if(branchEnd) {
-      if(!(level === 1 && settings.showMethods)) {
-        branchArray[branchArray.length - 1] = true;
-      }
-    }
-    for (var i = 0; i < level; i++) {
-      if(branchArray[i]) {
-        indent += "    ";
-      } else {
-        indent += "|   ";
-      }
-    }
-  }
-
-  if(settings.showProps) {
-    var propArray, value, usePropList;
-
-    if(level === 0 && settings.propList.length > 0 && settings.propList.constructor.name === "Array") {
-      usePropList = true;
-      propArray = settings.propList.reverse();
-    } else if (obj.constructor.name === "Array") {
-      // correct sorting for Array number properties (0, 1, 2 etc.)
-      propArray = obj.reflect.properties.sort(function(a, b) {return a - b}).reverse();
-    } else {
-      propArray = obj.reflect.properties.sort().reverse();
-    }
-
-    if(propArray.length > 1 || usePropList) {
-      output += "\n" + indent + "|";
-
-      for (var i = propArray.length - 1; i >= 0; i--) {
-        if(propArray[i] == "__proto__" || propArray[i] == "__count__" || propArray[i] == "__class__"|| propArray[i] == "reflect") {
-          if(!i) {
-            output += "\n" + indent;
-          }
-          continue;
-        }
-
-        if(settings.showValues) {
-
-          try {
-            var propValue = obj[propArray[i]];
-            if (usePropList && !obj.hasOwnProperty(propArray[i]) && propArray[i] != "length") {
-              // in case a non-existing prop is passed via propList
-              // "length" needs special handling as it is not correctly recognized as a property
-              value = ": The inspected item has no such property.";
-            } else if (propValue === null || propValue === undefined) {
-              value = ": " + propValue;
-            } else if (propValue.constructor.name === "Array") {
-              if(propValue.length > 0 && propValue.reflect.properties.length < 3) {
-                propValue = Array.prototype.slice.call(propValue, 0);
-              }
-              value = ": Array (" + propValue.length + ")";
-              if(propValue.length && level < settings.maxLevel - 1) {
-                // recursive inspecting of Array properties
-                value += pub.inspect(propValue, settings, level + 1, branchArray, !i);
-              }
-            } else if (typeof propValue === "object" && propValue.constructor.name !== "Enumerator"  && propValue.constructor.name !== "Date") {
-              value = ": " + propValue;
-              if(level < settings.maxLevel - 1) {
-                // recursive inspecting of Object properties
-                value += pub.inspect(propValue, settings, level + 1, branchArray, !i);
-              }
-            } else {
-              value = ": " + propValue.toString();
-            }
-          } catch (e) {
-            if(e.number === 30615) {
-              value = ": The property is not applicable in the current state.";
-            } else if (e.number === 55) {
-              value = ": Object does not support the property '" + propArray[i] + "'.";
-            } else {
-              // other InDesign specific error messages
-              value = ": " + e.message;
-            }
-          }
-
-        } else {
-          value = "";
-        }
-
-        output += "\n" + indent + "|-- " + propArray[i] + value;
-
-
-        if(!i && !branchEnd && level !== 0) {
-          // separation space when a sub-branch ends
-          output += "\n" + indent;
-        }
-      } // end for-loop
-    } // end if(propArray.length > 1 || usePropList)
-  } // end if(settings.showProps)
-
-  if(level === 0 && settings.showMethods) {
-
-    var methodArray = settings.showMethods ? obj.reflect.methods.sort().reverse() : [];
-
-    if(methodArray.length) {
-      output += "\n|" +
-                "\n|   METHODS";
-    }
-
-    for (var i = methodArray.length - 1; i >= 0; i--) {
-      if(methodArray[i].name.charAt(0) === "=") {continue;}
-      output += "\n|-- " + methodArray[i] + "()";
-    }
-  }
-
-  if(level > 0) {
-    // return for recursive calls
-    return output;
-  }
-  // print for top level call
-  println(output);
-
-};
-
-// ----------------------------------------
-// Files & Folders
-
-/**
- * @description Returns a file object.<br>
- * Note that the resulting file object can either refer to an already existing file or if the file does not exist, it can create a preliminary "virtual" file that refers to a file that could be created later (i.e. by an export command).
- *
- * @cat    Files
- * @method file
- * @param  {String} filePath The file path.
- * @return {File} File at the given path.
- *
- * @example <caption>Get an image file from the desktop and place it in the document</caption>
- * var myImage = file("~/Desktop/myImage.jpg");
- * image(myImage, 0, 0);
- *
- * @example <caption>Create a file and export it to the desktop</caption>
- * var myExportFile = file("~/Desktop/myNewExportFile.pdf");
- * savePDF(myExportFile);
- */
-pub.file = function(filePath) {
-  if(! isString(filePath)) {
-    error("file(), wrong argument. Use a string that describes a file path.");
-  }
-
-  // check if user is referring to a file in the data directory
-  if(currentDoc().saved) {
-    var file = new File(pub.projectFolder() + "/data/" + filePath);
-    if(file.exists) {
-      return file;
-    }
-  }
-
-  // add leading slash to avoid errors on file creation
-  if(filePath[0] !== "~" && filePath[0] !== "/") {
-    filePath = "/" + filePath;
-  }
-
-  return new File(filePath);
-};
-
-/**
- * @description Returns a folder object.<br>
- * Note that the resulting folder object can either refer to an already existing folder or if the folder does not exist, it can create a preliminary "virtual" folder that refers to a folder that could be created later.
- *
- * @cat    Files
- * @method folder
- * @param  {String} [folderPath] The path of the folder.
- * @return {Folder} Folder at the given path. If no path is given, but the document is already saved, the document's data folder will be returned.
- *
- * @example <caption>Get a folder from the desktop and load its files</caption>
- * var myImageFolder = folder("~/Desktop/myImages/");
- * var myImageFiles = files(myImageFolder);
- *
- * @example <caption>Get the data folder, if the document is already saved</caption>
- * var myDataFolder = folder();
- */
-pub.folder = function(folderPath) {
-  if(folderPath === undefined) {
-    if(currentDoc().saved) {
-      return new Folder(pub.projectFolder() + "/data/");
-    } else {
-      error("folder(), no data folder. The document has not been saved yet, so there is no data folder to access.");
-    }
-  }
-  if(! isString(folderPath)) {
-    error("folder(), wrong argument. Use a string that describes the path of a folder.");
-  }
-
-  // check if user is referring to a folder in the data directory
-  if(currentDoc().saved) {
-    var folder = new Folder(pub.projectFolder() + "/data/" + folderPath);
-    if(folder.exists) {
-      return folder;
-    }
-  }
-
-  // add leading slash to avoid errors on folder creation
-  if(folderPath[0] !== "~" && folderPath[0] !== "/") {
-    folderPath = "/" + folderPath;
-  }
-
-  return new Folder(folderPath);
-};
-
-/**
- * @description Gets all files of a folder and returns them in an array of file objects.
- * The settings object can be used to restrict the search to certain file types only, to include hidden files and to include files in subfolders.
- *
- * @cat    Files
- * @method files
- * @param  {Folder|String} [folder] The folder that holds the files or a string describing the path to that folder.
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String|Array} [settings.filter] Suffix(es) of file types to include. Default: `"*"` (include all file types)
- * @param  {Boolean} [settings.hidden] Hidden files will be included. Default: `false`
- * @param  {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: `false`
- * @return {Array} Array of the resulting file(s). If no files are found, an empty array will be returned.
- *
- * @example <caption>Get a folder from the desktop and load all its JPEG files</caption>
- * var myImageFolder = folder("~/Desktop/myImages/");
- * var myImageFiles = files(myImageFolder, {filter: ["jpeg", "jpg"]});
- *
- * @example <caption>If the document is saved, load all files from its data folder, including from its subfolders</caption>
- * var myDataFolder = folder();
- * var allMyDataFiles = files(myDataFolder, {recursive: true});
- */
-pub.files = function(folder, settings, collectedFiles) {
-  var topLevel;
-  if (collectedFiles === undefined) {
-    if(folder === undefined && currentDoc().saved) {
-      folder = pub.folder();
-    } else if (folder === undefined) {
-      error("files(), missing first argument. Use folder or a string to describe a folder path or save your document to access the data folder.");
-    }
-    if(isString(folder)) {
-      folder = pub.folder(folder);
-    }
-    if(!(folder instanceof Folder)) {
-      error("files(), wrong first argument. Use folder or a string to describe a folder path.");
-    } else if (!folder.exists) {
-      error("files(), the folder \"" + folder + "\" does not exist.");
-    }
-
-    topLevel = true;
-    collectedFiles = [];
-
-    if(!settings) {
-      settings = {};
-    }
-
-    // set settings object to given values or defaults
-    settings.filter = settings.hasOwnProperty("filter") ? settings.filter : "*";
-    settings.hidden = settings.hasOwnProperty("hidden") ? settings.hidden : false;
-    settings.recursive = settings.hasOwnProperty("recursive") ? settings.recursive : false;
-
-    if(!(settings.filter instanceof Array)) {
-      settings.filter = [settings.filter];
-    }
-  } else {
-    topLevel = false;
-  }
-
-  if(settings.recursive) {
-    var folderItems = folder.getFiles();
-    for (var i = folderItems.length - 1; i >= 0; i--) {
-      if (folderItems[i] instanceof Folder) {
-        if(!settings.hidden && folderItems[i].displayName[0] === ".") continue;
-        collectedFiles = pub.files(folderItems[i], settings, collectedFiles);
-      }
-    }
-  }
-
-  for (var i = settings.filter.length - 1; i >= 0; i--) {
-    var mask = "*." + settings.filter[i];
-    var fileItems = folder.getFiles(mask);
-    for (var j = fileItems.length - 1; j >= 0; j--) {
-      if(!settings.hidden && fileItems[j].displayName[0] === ".") continue;
-      if(!(fileItems[j] instanceof File)) continue;
-      collectedFiles.push(fileItems[j]);
-    }
-  }
-
-  return topLevel ? collectedFiles.reverse() : collectedFiles;
-};
-
-/**
- * @description Opens a selection dialog that allows to select one file. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
- *
- * @cat    Files
- * @method selectFile
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
- * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
- * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {File|Null} The selected file. If the user cancels, `null` will be returned.
- *
- * @example <caption>Open file selection dialog with a prompt text</caption>
- * selectFile({prompt: "Please select a file."});
- *
- * @example <caption>Open selection dialog starting at the user's desktop, allowing to only select PNG or JPEG files</caption>
- * selectFile({folder: "~/Desktop/", filter: ["jpeg", "jpg", "png"]});
- */
-pub.selectFile = function(settings) {
-  return createSelectionDialog(settings);
-};
-
-/**
- * @description Opens a selection dialog that allows to select one or multiple files. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
- *
- * @cat    Files
- * @method selectFiles
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
- * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
- * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {Array} Array of the selected file(s). If the user cancels, an empty array will be returned.
- *
- * @example <caption>Open file selection dialog with a prompt text</caption>
- * selectFiles({prompt: "Please select your files."});
- *
- * @example <caption>Open selection dialog starting at the user's desktop, allowing to only select PNG or JPEG files</caption>
- * selectFiles({folder: "~/Desktop/", filter: ["jpeg", "jpg", "png"]});
- */
-pub.selectFiles = function(settings) {
-  if(!settings) {
-    settings = {};
-  }
-  settings.multiFile = true;
-
-  return createSelectionDialog(settings);
-};
-
-/**
- * @description Opens a selection dialog that allows to select a folder. The settings object can be used to add a prompt text at the top of the dialog and to set the dialog's starting folder.
- *
- * @cat    Files
- * @method selectFolder
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: `""` (no prompt)
- * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {Folder|Null} The selected folder. If the user cancels, `null` will be returned.
- *
- * @example <caption>Open folder selection dialog with a prompt text</caption>
- * selectFolder({prompt: "Please select a folder."});
- *
- * @example <caption>Open folder selection dialog starting at the user's desktop</caption>
- * selectFolder({folder: "~/Desktop/"});
- */
-pub.selectFolder = function(settings) {
-  if(!settings) {
-    settings = {};
-  }
-  settings.folderSelect = true;
-
-  return createSelectionDialog(settings);
-};
-
-
-// ----------------------------------------
-// Date
-
-/**
- * @description The year() function returns the current year as an integer (2012, 2013 etc).
- *
- * @cat    Environment
- * @subcat Date
- * @method year
- * @return {Number} The current year.
- */
-pub.year = function() {
-  return (new Date()).getFullYear();
-};
-
-
-/**
- * @description The month() function returns the current month as a value from 1 - 12.
- *
- * @cat    Environment
- * @subcat Date
- * @method month
- * @return {Number} The current month number.
- */
-pub.month = function() {
-  return (new Date()).getMonth() + 1;
-};
-
-
-/**
- * @description The day() function returns the current day as a value from 1 - 31.
- *
- * @cat    Environment
- * @subcat Date
- * @method day
- * @return {Number} The current day number.
- */
-pub.day = function() {
-  return (new Date()).getDate();
-};
-
-
-/**
- * @description The weekday() function returns the current weekday as a string from Sunday, Monday, Tuesday...
- *
- * @cat    Environment
- * @subcat Date
- * @method weekday
- * @return {String} The current weekday name.
- */
-pub.weekday = function() {
-  var weekdays = new Array("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday");
-  return weekdays[(new Date()).getDay()];
-};
-
-
-/**
- * @description The hour() function returns the current hour as a value from 0 - 23.
- *
- * @cat    Environment
- * @subcat Date
- * @method hour
- * @return {Number} The current hour.
- */
-pub.hour = function() {
-  return (new Date()).getHours();
-};
-
-
-/**
- * @description The minute() function returns the current minute as a value from 0 - 59.
- *
- * @cat    Environment
- * @subcat Date
- * @method minute
- * @return {Number} The current minute.
- */
-pub.minute = function() {
-  return (new Date()).getMinutes();
-};
-
-
-/**
- * @description The second() function returns the current second as a value from 0 - 59.
- *
- * @cat    Environment
- * @subcat Date
- * @method second
- * @return {Number} The current second.
- */
-pub.second = function() {
-  return (new Date()).getSeconds();
-};
-
-
-/**
- * @description Returns the number of milliseconds (thousandths of a second) since starting an applet.
- *
- * @cat    Environment
- * @subcat Date
- * @method millis
- * @return {Number} The current milli.
- */
-pub.millis = function() {
-  return Date.now() - startTime;
-};
-
-
-/**
- * @description The millisecond() function differs from millis(), in that it returns the exact millisecond (thousandths of a second) of the current time.
- *
- * @cat    Environment
- * @subcat Date
- * @method millisecond
- * @return {Number} The current millisecond.
- */
-pub.millisecond = function() {
-  return (new Date()).getMilliseconds();
-};
-
-
-/**
- * @description The timestamp() function returns the current date formatted as YYYYMMDD_HHMMSS for useful unique filenaming.
- *
- * @cat    Environment
- * @subcat Date
- * @method timestamp
- * @return {String} The current time in YYYYMMDD_HHMMSS.
- */
-pub.timestamp = function() {
-  var dt = new Date();
-  var dtf = dt.getFullYear();
-  dtf += pub.nf(dt.getMonth() + 1, 2);
-  dtf += pub.nf(dt.getDate(), 2);
-  dtf += "_";
-  dtf += pub.nf(dt.getHours(), 2);
-  dtf += pub.nf(dt.getMinutes(), 2);
-  dtf += pub.nf(dt.getSeconds(), 2);
-  return dtf;
-};
-
-
-  basil.js was conceived and is generously supported by
-  The Visual Communication Institute / The Basel School of Design
-  Department of the Academy of Art and Design Basel (HGK FHNW)
-
-  http://thebaselschoolofdesign.ch
-
-  Please note: Big general parts e.g. random() of the basil.js source code are copied
-  from processing.js by the Processing.js team. We would have had a hard time
-  to figure all of that out on our own!
-// ----------------------------------------
-// src/includes/data.js
-// ----------------------------------------
-
-pub.JSON = {
-  /**
-   * @description Function parses and validates a string as JSON-object. Usage:<br>
-   * var obj = JSON.decode(str);
-   * var str = JSON.encode(obj);
-   *
-   * @cat    Data
-   * @subcat JSON
-   * @method JSON.decode
-   * @param  {String} String to be parsed as JSON-object.
-   * @return {Object} Returns JSON-object or throws an error if invalid JSON has been provided.
-  */
-  // From: jQuery JavaScript Library v1.7.1 http://jquery.com/
-  decode: function(data) {
-    if (typeof data !== "string" || !data) {
-      return null;
-    }
-    var rvalidchars = /^[\],:{}\s]*$/,
-      rvalidescape = /\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g,
-      rvalidtokens = /"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g,
-      rvalidbraces = /(?:^|:|,)(?:\s*\[)+/g;
-
-    // Make sure the incoming data is actual JSON
-    // Logic borrowed from http://json.org/json2.js
-    if (rvalidchars.test(data.replace(rvalidescape, "@")
-      .replace(rvalidtokens, "]")
-      .replace(rvalidbraces, ""))) {
-      return (new Function("return " + data))();
-    }
-    error("JSON.decode(), invalid JSON: " + data);
-  },
-  /**
-   * Function convert an javascript object to a JSON-string. Usage:<br>
-   * var str = JSON.encode(obj);
-   * var obj = JSON.decode(str);
-   *
-   * @cat    Data
-   * @subcat JSON
-   * @method JSON.encode
-   * @param  {Object} Object to be converted to a JSON-string
-   * @return {String} Returns JSON-string
-   */
-  // From: https://gist.github.com/754454
-  encode: function(obj) {
-    var t = typeof (obj);
-    if (t !== "object" || obj === null) {
-      // simple data type
-      if (t === "string") obj = "\"" + obj + "\"";
-      return String(obj);
-    } else {
-      // recurse array or object
-      var n, v, json = [], arr = (obj && obj.constructor === Array);
-
-      for (n in obj) {
-        v = obj[n];
-        t = typeof (v);
-        if (obj.hasOwnProperty(n)) {
-          if (t === "string") v = "\"" + v + "\""; else if (t === "object" && v !== null) v = pub.JSON.encode(v);
-          json.push((arr ? "" : "\"" + n + "\":") + String(v));
-        }
-      }
-      return (arr ? "[" : "{") + String(json) + (arr ? "]" : "}");
-    }
-  }
-};
-
-// Taken and hijacked from d3.js robust csv parser. Hopefully Michael Bostock won't mind.
-// https://github.com/mbostock/d3/tree/master/src/dsv
-pub.CSV = new CSV();
-function CSV() {
-  var reParse = null,
-    reFormat = null,
-    delimiterStr = null,
-    delimiterCode = null;
-
-  initDelimiter(",");
-  function initDelimiter(delimiter) {
-    reParse = new RegExp("\r\n|[" + delimiter + "\r\n]", "g"), // field separator regex
-    reFormat = new RegExp("[\"" + delimiter + "\n]"),
-    delimiterCode = delimiter.charCodeAt(0);
-    delimiterStr = delimiter;
-  }
-
-  /**
-   * @description Sets the delimiter of the CSV decode and encode function.
-   *
-   * @cat    Data
-   * @subcat CSV
-   * @method CSV.delimiter
-   * @param  {String} [delimiter] Optional Sets the delimiter for CSV parsing
-   * @return {String} Returns the current delimiter if called without argument
-  */
-  this.delimiter = function(delimiter) {
-    if (arguments.length === 0) return delimiterStr;
-    if (typeof delimiter === "string") {
-      initDelimiter(delimiter);
-    } else {
-      error("CSV.delimiter, separator has to be a character or string");
-    }
-  };
-
-  /**
-   * @description Function parses a string as CSV-object Array. Usage:<br>
-   * var arr = CSV.decode(str);
-   * var str = CSV.encode(arr);
-   *
-   * @cat    Data
-   * @subcat CSV
-   * @method CSV.decode
-   * @param  {String} String to be parsed as CSV-object.
-   * @return {Array} Returns CSV-object Array
-  */
-  this.decode = function(text) {
-    var header;
-    return parseRows(text, function(row, i) {
-      if (i) {
-        var o = {}, j = -1, m = header.length;
-        while (++j < m) o[header[j]] = row[j];
-        return o;
-      } else {
-        header = row;
-        return null;
-      }
-    });
-  };
-
-  /**
-   * @description Function convert an javascript array of objects to a CSV-string. Usage:<br>
-   * var str = CSV.encode(arr);
-   * var arr = CSV.decode(str);
-   *
-   * @cat    Data
-   * @subcat CSV
-   * @method CSV.encode
-   * @param  {Array} Array to be converted to a CSV-string
-   * @return {String} Returns CSV-string
-   */
-  this.encode = function(rows) {
-    var csvStrings = [];
-    var header = [];
-    var firstRow = rows[0]; // all rows have to have the same properties keys
-    // gather infos for the header
-    for (var propname in firstRow) {
-      if (firstRow.hasOwnProperty(propname)) {
-        header.push(propname);
-      }
-    }
-    csvStrings.push(formatRow(header));
-    for (var i = 0; i < rows.length; i++) {
-      var row = rows[i];
-      var tokens = [];
-      for (var ii = 0; ii < header.length; ii++) {
-        tokens.push(row[header[ii]]);
-      }
-      csvStrings.push(formatRow(tokens));
-    }
-    return csvStrings.join("\n");
-  };
-
-  function formatRow(row) {
-    return row.map(formatValue).join(delimiterStr);
-  }
-
-  function formatValue(text) {
-    return reFormat.test(text) ? "\"" + text.replace(/\"/g, "\"\"") + "\"" : text;
-  }
-
-  function parseRows(text, f) {
-    var EOL = {}, // sentinel value for end-of-line
-      EOF = {}, // sentinel value for end-of-file
-      rows = [], // output rows
-      n = 0, // the current line number
-      t, // the current token
-      eol; // is the current token followed by EOL?
-
-    reParse.lastIndex = 0; // work-around bug in FF 3.6
-
-    function token() {
-      if (reParse.lastIndex >= text.length) return EOF; // special case: end of file
-      if (eol) { eol = false; return EOL; } // special case: end of line
-
-      // special case: quotes
-      var j = reParse.lastIndex;
-      if (text.charCodeAt(j) === 34) {
-        var i = j;
-        while (i++ < text.length) {
-          if (text.charCodeAt(i) === 34) {
-            if (text.charCodeAt(i + 1) !== 34) break;
-            i++;
-          }
-        }
-        reParse.lastIndex = i + 2;
-        var c = text.charCodeAt(i + 1);
-        if (c === 13) {
-          eol = true;
-          if (text.charCodeAt(i + 2) === 10) reParse.lastIndex++;
-        } else if (c === 10) {
-          eol = true;
-        }
-        return text.substring(j + 1, i).replace(/""/g, "\"");
-      }
-
-      // common case
-      var m = reParse.exec(text);
-      if (m) {
-        eol = m[0].charCodeAt(0) !== delimiterCode;
-        return text.substring(j, m.index);
-      }
-      reParse.lastIndex = text.length;
-      return text.substring(j);
-    }
-
-    while ((t = token()) !== EOF) {
-      var a = [];
-      while (t !== EOL && t !== EOF) {
-        a.push(t);
-        t = token();
-      }
-      if (f && !(a = f(a, n++))) continue;
-      rows.push(a);
-    }
-
-    return rows;
-  }
-}
-
-// -- Conversion --
-
-
-/**
- * @description Converts a byte, char, int, or color to a String containing the
- * equivalent binary notation. For example color(0, 102, 153, 255)
- * will convert to the String "11111111000000000110011010011001". This
- * function can help make your geeky debugging sessions much happier.
- *
-
- * @cat    Data
- * @subcat Conversion
- * @method binary
- * @param  {Number} num value to convert
- * @param  {Number} [numBits] number of digits to return
- * @return {String} A formatted string
- */
- // From: http://processingjs.org/reference/binary_/
-pub.binary = function(num, numBits) {
-  var bit;
-  if (numBits > 0) bit = numBits;
-  else if (num instanceof Char) {
-    bit = 16;
-    num |= 0;
-  } else {
-    bit = 32;
-    while (bit > 1 && !(num >>> bit - 1 & 1)) bit--;
-  }
-  var result = "";
-  while (bit > 0) result += num >>> --bit & 1 ? "1" : "0";
-  return result;
-};
-
-/**
- * @description Converts a String representation of a binary number to its
- * equivalent integer value. For example, unbinary("00001000") will
- * return 8.
- *
- * @cat    Data
- * @subcat Conversion
- * @method unbinary
- * @param  {String} binaryString value to convert
- * @return {Number} The integer representation
- */
- // From: http://processingjs.org/reference/unbinary_/
-pub.unbinary = function(binaryString) {
-  var i = binaryString.length - 1,
-    mask = 1,
-    result = 0;
-  while (i >= 0) {
-    var ch = binaryString[i--];
-    if (ch !== "0" && ch !== "1") throw "the value passed into unbinary was not an 8 bit binary number";
-    if (ch === "1") result += mask;
-    mask <<= 1;
-  }
-  return result;
-};
-
-
-var decimalToHex = function(d, padding) {
-  padding = padding === undefined || padding === null ? padding = 8 : padding;
-  if (d < 0) d = 4294967295 + d + 1;
-  var hex = Number(d).toString(16).toUpperCase();
-  while (hex.length < padding) hex = "0" + hex;
-  if (hex.length >= padding) hex = hex.substring(hex.length - padding, hex.length);
-  return hex;
-};
-
-/**
- * @description Convert a number to a hex representation.
- *
- * @cat    Data
- * @subcat Conversion
- * @method hex
- * @param  {Number} value The number to convert
- * @param  {Number} [len] The length of the hex number to be created, default: 8
- * @return {String} The hex representation as a string
- */
-pub.hex = function(value, len) {
-  if (arguments.length === 1) len = 8;
-  return decimalToHex(value, len);
-};
-
-var unhexScalar = function(hex) {
-  var value = parseInt("0x" + hex, 16);
-  if (value > 2147483647) value -= 4294967296;
-  return value;
-};
-
-/**
- * @description Convert a hex representation to a number.
- *
- * @cat    Data
- * @subcat Conversion
- * @method unhex
- * @param  {String} hex The hex representation
- * @return {Number} The number
- */
-pub.unhex = function(hex) {
-  if (hex instanceof Array) {
-    var arr = [];
-    for (var i = 0; i < hex.length; i++) arr.push(unhexScalar(hex[i]));
-    return arr;
-  }
-  return unhexScalar(hex);
-};
-
-
-// -- String Functions --
-
-
-
-/**
- * @description Removes multiple, leading or trailing spaces and punctuation from "words". E.g. converts "word!" to "word". Especially useful together with words();
- *
- * @cat    Data
- * @subcat String Functions
- * @method trimWord
- * @param  {String} s The String to trim
- * @return {String} The trimmed string
- */
- // from: https://stackoverflow.com/a/25575009/3399765
-pub.trimWord = function(s) {
-  s = s.replace(/\s*/g, "")
-       .replace(/\n*/g, "")
-       .replace(/(^[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]*)|([\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]*$)/gi, "");
-  return s;
-};
-
-/**
- * @description Combines an array of Strings into one String, each separated by
- * the character(s) used for the separator parameter. To join arrays
- * of ints or floats, it's necessary to first convert them to strings
- * using nf() or nfs().
- *
- * @cat    Data
- * @subcat String Functions
- * @method join
- * @param  {Array} array A string array
- * @param  {String} separator The separator to be inserted
- * @return {String} The joined string
- */
- // http://processingjs.org/reference/join_/
-pub.join = function(array, separator) {
-  return array.join(separator);
-};
-
-/**
- * @description The split() function breaks a string into pieces using a
- * character or string as the divider. The delim parameter specifies the
- * character or characters that mark the boundaries between each piece. A
- * String[] array is returned that contains each of the pieces.
- * <br><br>
- * If the result is a set of numbers, you can convert the String[] array
- * to to a float[] or int[] array using the datatype conversion functions
- * int() and float() (see example above).
- * <br><br>
- * The splitTokens() function works in a similar fashion, except that it
- * splits using a range of characters instead of a specific character or
- * sequence.
- *
- * @cat    Data
- * @subcat String Functions
- * @method split
- * @param  {String} str the String to be split
- * @param  {String} [delim] The string used to separate the data
- * @return {Array} Array of strings
- */
- // http://processingjs.org/reference/split_/
-pub.split = function(str, delim) {
-  return str.split(delim);
-};
-
-/**
- * @description The splitTokens() function splits a String at one or many character
- * "tokens." The tokens parameter specifies the character or characters
- * to be used as a boundary.
- * <br><br>
- * If no tokens character is specified, any whitespace character is used
- * to split. Whitespace characters include tab (\t), line feed (\n),
- * carriage return (\r), form feed (\f), and space. To convert a String
- * to an array of integers or floats, use the datatype conversion functions
- * int() and float() to convert the array of Strings.
- *
- * @cat    Data
- * @subcat String Functions
- * @method splitTokens
- * @param  {String} str the String to be split
- * @param  {String} [tokens] list of individual characters that will be used as separators
- * @return {Array} Array of strings
- */
- // From: http://processingjs.org/reference/splitTokens_/
-pub.splitTokens = function(str, tokens) {
-  if (arguments.length === 1) tokens = "\n\t\r\u000c ";
-  tokens = "[" + tokens + "]";
-  var ary = [];
-  var index = 0;
-  var pos = str.search(tokens);
-  while (pos >= 0) {
-    if (pos === 0) str = str.substring(1);
-    else {
-      ary[index] = str.substring(0, pos);
-      index++;
-      str = str.substring(pos);
-    }
-    pos = str.search(tokens);
-  }
-  if (str.length > 0) ary[index] = str;
-  if (ary.length === 0) ary = undefined;
-  return ary;
-};
-
-
-pub.match = function(str, regexp) {
-  return str.match(regexp);
-};
-
-
-pub.matchAll = function(aString, aRegExp) {
-  var results = [],
-    latest;
-  var regexp = new RegExp(aRegExp, "g");
-  while ((latest = regexp.exec(aString)) !== null) {
-    results.push(latest);
-    if (latest[0].length === 0)++regexp.lastIndex;
-  }
-  return results.length > 0 ? results : null;
-};
-
-function nfCoreScalar(value, plus, minus, leftDigits, rightDigits, group) {
-  var sign = value < 0 ? minus : plus;
-  var autoDetectDecimals = rightDigits === 0;
-  var rightDigitsOfDefault = rightDigits === undefined || rightDigits < 0 ? 0 : rightDigits;
-  var absValue = Math.abs(value);
-  if (autoDetectDecimals) {
-    rightDigitsOfDefault = 1;
-    absValue *= 10;
-    while (Math.abs(Math.round(absValue) - absValue) > 1.0E-6 && rightDigitsOfDefault < 7) {
-      ++rightDigitsOfDefault;
-      absValue *= 10;
-    }
-  } else if (rightDigitsOfDefault !== 0) absValue *= Math.pow(10, rightDigitsOfDefault);
-  var number, doubled = absValue * 2;
-  if (Math.floor(absValue) === absValue) number = absValue;
-  else if (Math.floor(doubled) === doubled) {
-    var floored = Math.floor(absValue);
-    number = floored + floored % 2;
-  } else number = Math.round(absValue);
-  var buffer = "";
-  var totalDigits = leftDigits + rightDigitsOfDefault;
-  while (totalDigits > 0 || number > 0) {
-    totalDigits--;
-    buffer = "" + number % 10 + buffer;
-    number = Math.floor(number / 10);
-  }
-  if (group !== undefined) {
-    var i = buffer.length - 3 - rightDigitsOfDefault;
-    while (i > 0) {
-      buffer = buffer.substring(0, i) + group + buffer.substring(i);
-      i -= 3;
-    }
-  }
-  if (rightDigitsOfDefault > 0) return sign + buffer.substring(0, buffer.length - rightDigitsOfDefault) + "." + buffer.substring(buffer.length - rightDigitsOfDefault, buffer.length);
-  return sign + buffer;
-}
-function nfCore(value, plus, minus, leftDigits, rightDigits, group) {
-  if (value instanceof Array) {
-    var arr = [];
-    for (var i = 0, len = value.length; i < len; i++) arr.push(nfCoreScalar(value[i], plus, minus, leftDigits, rightDigits, group));
-    return arr;
-  }
-  return nfCoreScalar(value, plus, minus, leftDigits, rightDigits, group);
-}
-
-/**
- * @description Utility function for formatting numbers into strings. There
- * are two versions, one for formatting floats and one for formatting
- * ints. The values for the digits, left, and right parameters should
- * always be positive integers.
- * <br><br>
- * As shown in the above example, nf() is used to add zeros to the
- * left and/or right of a number. This is typically for aligning a list
- * of numbers. To remove digits from a floating-point number, use the
- * int(), ceil(), floor(), or round() functions.
- *
- * @cat    Data
- * @subcat String Functions
- * @method nf
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
- */
- // From: http://processingjs.org/reference/nf_/
-pub.nf = function(value, leftDigits, rightDigits) {
-  return nfCore(value, "", "-", leftDigits, rightDigits);
-};
-
-/**
- * @description Utility function for formatting numbers into strings. Similar to nf()
- * but leaves a blank space in front of positive numbers so they align
- * with negative numbers in spite of the minus symbol. There are two
- * versions, one for formatting floats and one for formatting ints. The
- * values for the digits, left, and right parameters should always be
- * positive integers.
- *
- * @cat    Data
- * @subcat String Functions
- * @method nfs
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
- */
- // From: http://processingjs.org/reference/nfs_/
-pub.nfs = function(value, leftDigits, rightDigits) {
-  return nfCore(value, " ", "-", leftDigits, rightDigits);
-};
-
-/**
- * @description Utility function for formatting numbers into strings. Similar to nf()
- * but puts a "+" in front of positive numbers and a "-" in front of
- * negative numbers. There are two versions, one for formatting floats
- * and one for formatting ints. The values for the digits, left, and right
- * parameters should always be positive integers.
- *
- * @cat    Data
- * @subcat String Functions
- * @method nfp
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
- */
- // From: http://processingjs.org/reference/nfp_/
-pub.nfp = function(value, leftDigits, rightDigits) {
-  return nfCore(value, "+", "-", leftDigits, rightDigits);
-};
-
-/**
- * @description Utility function for formatting numbers into strings and placing
- * appropriate commas to mark units of 1000. There are two versions, one
- * for formatting ints and one for formatting an array of ints. The value
- * for the digits parameter should always be a positive integer.
- *
- * @cat    Data
- * @subcat String Functions
- * @method nfc
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
- */
- // From: http://processingjs.org/reference/nfc_/
-pub.nfc = function(value, leftDigits, rightDigits) {
-  return nfCore(value, "", "-", leftDigits, rightDigits, ",");
-};
-
-
-/**
- * @description Removes whitespace characters from the beginning and end of a String.
- * In addition to standard whitespace characters such as space, carriage
- * return, and tab, this function also removes the Unicode "nbsp" character.
- *
- * @cat    Data
- * @subcat String Functions
- * @method trim
- * @param  {String|Array} str A string or an array of strings to be trimmed
- * @return {String|Array} Returns the input in a trimmed way
- */
- // From: http://processingjs.org/reference/trim_/
-pub.trim = function(str) {
-  if (str instanceof Array) {
-    var arr = [];
-    for (var i = 0; i < str.length; i++) arr.push(str[i].replace(/^\s*/, "").replace(/\s*$/, "").replace(/\r*$/, ""));
-    return arr;
-  }
-  return str.replace(/^\s*/, "").replace(/\s*$/, "").replace(/\r*$/, "");
-};
-
-/**
- * @description Checks whether an URL string is valid.
- *
- * @cat    Data
- * @subcat String Functions
- * @method isURL
- * @param  {String} url An url string to be checked
- * @return {Boolean} Returns either true or false
- */
-var isURL = pub.isURL = function(url) {
-  var pattern = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
-  return pattern.test(url);
-};
-
-/**
- * @description Checks whether a string ends with a specific character or string.
- *
- * @cat    Data
- * @subcat String Functions
- * @method endsWith
- * @param  {String} str A string to be checked
- * @param  {String} suffix The string to look for
- * @return {Boolean} Returns either true or false
- */
-var endsWith = pub.endsWith = function(str, suffix) {
-  if(!isString(str) || !isString(suffix)) {
-    error("endsWith() requires two strings, the string to be checked and the suffix to look for.");
-  }
-  return str.indexOf(suffix, str.length - suffix.length) !== -1;
-};
-
-/**
- * @description Checks whether a string starts with a specific character or string.
- *
- * @cat    Data
- * @subcat String Functions
- * @method startsWith
- * @param  {String} str A string to be checked
- * @param  {String} prefix The string to look for
- * @return {Boolean} Returns either true or false
- */
-var startsWith = pub.startsWith = function(str, prefix) {
-  if(!isString(str) || !isString(prefix)) {
-    error("startsWith() requires two strings, the string to be checked and the prefix to look for.");
-  }
-  return str.indexOf(prefix) === 0;
-};
-
-
-/**
- * @description Checks whether a var is an Array, returns true if this is the case
- *
- * @cat    Data
- * @subcat Type-Check
- * @method isArray
- * @param  {Object|String|Number|Boolean} obj The object to check
- * @return {Boolean} returns true if this is the case
- */
-var isArray = pub.isArray = function(obj) {
-  return Object.prototype.toString.call(obj) === "[object Array]";
-};
-
-/**
- * @description Checks whether a var is a number, returns true if this is the case
- *
- * @cat    Data
- * @subcat Type-Check
- * @method isNumber
- * @param  {Object|String|Number|Boolean}  num The number to check
- * @return {Boolean} returns true if this is the case
- */
-var isNumber = pub.isNumber = function(num) {
-  if (num === null) {
-    return false;
-  }
-  if (isNaN(num)) {
-    return false;
-  }
-  return isFinite(num) && num.constructor.name === "Number";
-};
-
-
-/**
- * @description Checks whether a var is an integer, returns true if this is the case.
- *
- * @cat    Data
- * @subcat Type-Check
- * @method isInteger
- * @param  {Object|String|Number|Boolean}  num The number to check.
- * @return {Boolean} Returns true if the given argument is an integer.
- */
-var isInteger = pub.isInteger = function(num) {
-  return Object.prototype.toString.call(num) === "[object Number]" && num % 1 === 0;
-};
-
-/**
- * @description Checks whether a var is a string, returns true if this is the case
- *
- * @cat    Data
- * @subcat Type-Check
- * @method isString
- * @param  {Object|String|Number|Boolean} str The string to check
- * @return {Boolean} returns true if this is the case
- */
-var isString = pub.isString = function(str) {
-  return Object.prototype.toString.call(str) === "[object String]";
-};
-
-/**
- * @description Checks whether a var is an InDesign text object, returns true if this is the case
- * NB: a InDesign TextFrame will return false as it is just a container holding text.
- * So you could say that isText() refers to all the things inside a TextFrame.
- *
- * @cat    Document
- * @subcat Type-Check
- * @method isText
- * @param  {Character|InsertionPoint|Line|Paragraph|TextColumn|TextStyleRange|Word}  obj The object to check
- * @return {Boolean} returns true if this is the case
- */
-var isText = pub.isText = function(obj) {
-
-  return obj instanceof Character ||
-         obj instanceof InsertionPoint ||
-         obj instanceof Word ||
-         obj instanceof Line ||
-         obj instanceof TextStyleRange ||
-         obj instanceof Paragraph ||
-         obj instanceof TextColumn ||
-         obj instanceof Text ||
-         obj.constructor.name === "Characters" ||
-         obj.constructor.name === "InsertionPoints" ||
-         obj.constructor.name === "Words" ||
-         obj.constructor.name === "Lines" ||
-         obj.constructor.name === "TextStyleRanges" ||
-         obj.constructor.name === "Paragraphs" ||
-         obj.constructor.name === "TextColumns";
-};
-
-
-var initDataFile = function(file) {
-
-  if(!(isString(file) || file instanceof File)) {
-    error(getParentFunctionName(1) + "(), invalid first argument. Use File or a String describing a file path.");
-  }
-
-  var result = null;
-  if (file instanceof File) {
-    result = file;
-  } else {
-    result = new File(pub.projectFolder().absoluteURI + "/data/" + file);
-  }
-  if (!result.exists) {
-    error(getParentFunctionName(1) + "(), could not load file. The file \"" + result + "\" does not exist.");
-  }
-  return result;
-};
-
-var initExportFile = function(file) {
-
-  if(!(isString(file) || file instanceof File)) {
-    error(getParentFunctionName(1) + "(), invalid first argument. Use File or a String describing a file path.");
-  }
-
-  var result, tmpPath = null;
-  var isFile = file instanceof File;
-  var filePath = isFile ? file.absoluteURI : file;
-
-  // if parent folder already exists, the rest can be skipped
-  if(isFile && File(filePath).parent.exists) {
-    // remove file as in some circumstances file cannot be overwritten
-    // (if file is on top level outside user folder)
-    // also improves performance considerably
-    File(filePath).remove();
-    return File(filePath);
-  }
-
-  // clean up string path
-  if((!isFile) && filePath[0] !== "~") {
-    if(filePath[0] !== "/") {
-      filePath = "/" + filePath;
-    }
-    // check if file path is a relative URI ( /Users/username/examples/... )
-    // if so, turn it into an absolute URI ( ~/examples/... )
-    var userRelURI = Folder("~").relativeURI;
-    if(startsWith(filePath, userRelURI)) {
-      filePath = "~" + filePath.substring(userRelURI.length);
-    }
-  }
-
-  // clean up path and convert to array
-  var pathNormalized = filePath.split("/");
-  for (var i = 0; i < pathNormalized.length; i++) {
-    if (pathNormalized[i] === "" || pathNormalized[i] === ".") {
-      pathNormalized.splice(i, 1);
-    }
-  }
-
-  if(filePath[0] === "~") {
-    tmpPath = "~";
-    pathNormalized.splice(0, 1);
-  } else if (isFile) {
-    // file objects that are outside the user folder
-    tmpPath = "";
-  } else {
-    // string paths relative to the project folder
-    tmpPath = pub.projectFolder().absoluteURI;
-  }
-  var fileName = pathNormalized[pathNormalized.length - 1];
-
-  // does the path contain folders? if not, create them ...
-  if (pathNormalized.length > 1) {
-    var folders = pathNormalized.slice(0, -1);
-    for (var i = 0; i < folders.length; i++) {
-      tmpPath += "/" + folders[i];
-      var f = new Folder(tmpPath);
-      if (!f.exists) {
-        f.create();
-
-        if(!f.exists) {
-          // in some cases, folder creation does not throw an error, yet folder does not exist
-          error(getParentFunctionName(1) + "(), folder \"" + tmpPath + "\" could not be created.\n\n" +
-            "InDesign cannot create top level folders outside the user folder. If you are trying to write to such a folder, first create it manually.");
-        }
-      }
-    }
-  }
-
-  if(File(tmpPath + "/" + fileName).exists) {
-    // remove existing file to avoid save errors
-    File(tmpPath + "/" + fileName).remove();
-  }
-
-  return File(tmpPath + "/" + fileName);
-};
-
-/**
- * @description Get the folder of the active document as a Folder object. Use .absoluteURI to access a string representation of the folder path.
- *
- * @cat    Document
- * @subcat Misc
- * @method projectFolder
- * @return {Folder} The folder of the the active document
- */
-pub.projectFolder = function() {
-  if(!currentDoc().saved) {
-    error("The current document must be saved before its project directory can be accessed.");
-  }
-  return currentDoc().filePath;
-};
-
-
-/**
- * @description Executes a shell command and returns the result, currently Mac only.
- * <br><br>
- * BE CAREFUL!
- *
- * @cat    Data
- * @subcat Input
- * @method shellExecute
- * @param  {String} cmd The shell command to execute
- * @return {String}
- */
-pub.shellExecute = function(cmd) {
-  if (Folder.fs === "Macintosh") {
-    try {
-      return app.doScript("return do shell script item 1 of arguments", ScriptLanguage.applescriptLanguage, [cmd]);
-    } catch (e) {
-      error("shellExecute(): " + e);
-    }
-  } else {
-    error("shellExecute() is a Mac only feature at the moment. Sorry!");
-  }
-};
-
-/**
- * @description Reads the contents of a file or loads an URL into a String.
- * If the file is specified by name as String, it must be located in the document's data directory.
- *
- * @cat    Data
- * @subcat Input
- * @method loadString
- * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
- * @return {String}  String file or URL content.
- */
-pub.loadString = function(file) {
-  if (isURL(file)) {
-    return getURL(file);
-  } else {
-    var inputFile = initDataFile(file),
-      data = null;
-    inputFile.open("r");
-    data = inputFile.read();
-    inputFile.close();
-    return data;
-  }
-};
-
-var getURL = function(url) {
-  if (isURL(url)) {
-    if (Folder.fs === "Macintosh") {
-      return pub.shellExecute("curl -m 15 -L '" + url + "'");
-    } else {
-      error(getParentFunctionName(1) + "(), loading of strings via an URL is a Mac only feature at the moment. Sorry!");
-    }
-  } else {
-    error(getParentFunctionName(1) + "(), the url " + url + " is invalid. Please double check!");
-  }
-};
-
-/**
- * @description Reads the contents of a file or loads an URL and creates a String array of its individual lines.
- * If the file is specified by name as String, it must be located in the document's data directory.
- *
- * @cat    Data
- * @subcat Input
- * @method loadStrings
- * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
- * @return {Array}  Array of the individual lines in the given File or URL
- */
-pub.loadStrings = function(file) {
-  if (isURL(file)) {
-    var result = getURL(file);
-    return result.match(/[^\r\n]+/g);
-  } else {
-    var inputFile = initDataFile(file),
-      result = [];
-    inputFile.open("r");
-    while (!inputFile.eof) {
-      result.push(inputFile.readln());
-    }
-    inputFile.close();
-    return result;
-  }
-};
-
-
-// ----------------------------------------
-// Output
-
-/**
- * @description Prints a message line to the console output in the ExtendScript editor.
- *
- * @cat Output
- * @method println
- * @param {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
- */
-var println = pub.println = function() {
-  var msg = Array.prototype.slice.call(arguments).join(" ");
-  $.writeln(msg);
-  if (progressPanel)
-    progressPanel.writeMessage(msg + "\n");
-};
-
-/**
- * @description Prints a message to the console output in the ExtendScript editor, but unlike println() it doesn't return the carriage to a new line at the end.
- *
- * @cat    Output
- * @method print
- * @param  {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
- */
-pub.print = function() {
-  var msg = Array.prototype.slice.call(arguments).join(" ");
-  $.write(msg);
-  if (progressPanel)
-    progressPanel.writeMessage(msg);
-};
-
-/**
- * @description Print numerous information about the current environment to the console
- *
- * @cat    Output
- * @method printInfo
- */
-pub.printInfo = function() {
-
-  pub.println("###");
-  pub.println("OS: " + $.os);
-  pub.println("ExtendScript Build: " + $.build);
-  pub.println("ExtendScript Version:" + $.version);
-  pub.println("Engine: " + $.engineName);
-  pub.println("memCache: " + $.memCache + " bytes");
-  pub.println("###");
-
-};
-
-/**
- * @description Writes an array of strings to a file, one line per string.
- * If the given file exists it gets overridden.
- *
- * @cat    Output
- * @method saveStrings
- * @param  {String|File} file The file name or a File instance
- * @param  {Array} strings The string array to be written
- * @return {File} The file the strings were written to.
- */
-pub.saveStrings = function(file, strings) {
-  if(!isArray(strings)) {
-    error("saveStrings(), invalid second argument. Use an array of strings.");
-  }
-  var outputFile = initExportFile(file);
-  outputFile.open("w");
-  outputFile.lineFeed = Folder.fs === "Macintosh" ? "Unix" : "Windows";
-  outputFile.encoding = "UTF-8";
-  forEach(strings, function(s) {
-    outputFile.writeln(s);
-  });
-  outputFile.close();
-  return outputFile;
-};
-
-/**
- * @description Writes a string to a file.
- * If the given file exists it gets overridden.
- *
- * @cat    Output
- * @method saveString
- * @param  {String|File} file The file name or a File instance.
- * @param  {String} string The string to be written.
- * @return {File} The file the string was written to.
- */
-pub.saveString = function(file, string) {
-  if(!isString(string)) {
-    error("saveString(), invalid second argument. Use a string.");
-  }
-  var outputFile = initExportFile(file);
-  outputFile.open("w");
-  outputFile.lineFeed = Folder.fs === "Macintosh" ? "Unix" : "Windows";
-  outputFile.encoding = "UTF-8";
-  outputFile.write(string);
-  outputFile.close();
-  return outputFile;
-};
-
-/**
- * @description Exports the current document as PDF to the documents folder. Please note, that export options default to the last used export settings.
- *
- * @cat    Output
- * @method savePDF
- * @param  {String|File} file The file name or a File instance.
- * @param  {Boolean} [showOptions] Whether to show the export dialog.
- * @return {File} The exported PDF file.
- */
-pub.savePDF = function(file, showOptions) {
-  var outputFile = initExportFile(file);
-  if (showOptions !== true) showOptions = false;
-  try{
-    var myPDF = currentDoc().exportFile(ExportFormat.PDF_TYPE, outputFile, showOptions);
-  } catch(e) {
-    error("savePDF(), PDF could not be saved. Possibly you are trying to save to a write protected location.\n\n" +
-      "InDesign cannot create top level folders outside the user folder. If you are trying to write to such a folder, first create it manually.");
-  }
-  return outputFile;
-};
-
-/**
- * @description Exports the current document as PNG (or sequence of PNG files) to the documents folder. Please note, that export options default to the last used export settings.
- *
- * @cat    Output
- * @method savePNG
- * @param  {String|File} file The file name or a File instance
- * @param  {Boolean} [showOptions] Whether to show the export dialog
- * @return {File} The exported PNG file.
- */
-pub.savePNG = function(file, showOptions) {
-  var outputFile = initExportFile(file);
-  if (showOptions !== true) showOptions = false;
-  try{
-    currentDoc().exportFile(ExportFormat.PNG_FORMAT, outputFile, showOptions);
-  } catch(e) {
-    error("savePNG(), PNG could not be saved. Possibly you are trying to save to a write protected location.\n\n" +
-      "InDesign cannot create top level folders outside the user folder. If you are trying to write to such a folder, first create it manually.");
-  }
-  return outputFile;
-};
-
-/**
- * @description Downloads an URL to a file, currently Mac only.
- *
- * @cat    Output
- * @method download
- * @param  {String} url The download url
- * @param  {String|File} [file] A relative file path in the project folder or a File instance
- */
-pub.download = function(url, file) {
-  var projPath = pub.projectFolder().fsName.replace(" ", "\\ ");
-  // var scriptPath = "~/Documents/basiljs/bundle/lib/download.sh";
-  // This is more portable then a fixed location
-  // the Script looks for the lib folder next to itself
-  var currentBasilFolderPath = File($.fileName).parent.fsName;
-  var scriptPath = currentBasilFolderPath + "/lib/download.sh";
-  if(File(scriptPath).exists === true) {
-    // the script is there. Great
-    scriptPath = File(scriptPath).fsName;
-  } else {
-    // if not lets create it on the fly
-    var scriptContent = [
-      "#!/bin/bash",
-      "mkdir -p \"$1\"",
-      "cd \"$1\"",
-      "if [ -z \"$3\" ]",
-      "  then",
-      "    # echo \"-O\"",
-      "    curl -L -O $2",
-      "  else",
-      "    # echo \"-o\"",
-      "    curl -L -o \"$3\" $2",
-      "fi"];
-    // check if the lib folder is there.
-    if(Folder(currentBasilFolderPath + "/lib").exists !== true) {
-      // no its not lets create ot
-      // should be functionalized
-      // will be needed for loop and stop.jsx as well
-      var res = Folder(currentBasilFolderPath + "/lib").create();
-      if(res === false) {
-        // ! Error creating folder :-(
-        // uh this should never happen
-        error("An error occurred while creating the \"/lib\" folder. Please report this issue");
-        return;
-      }
-    } // end of lib folder check
-    // the folder should be there.
-    // lets get it
-    var libFolder = Folder(currentBasilFolderPath + "/lib");
-    // now create the script file
-    var downloadScript = new File(libFolder.fsName + "/download.sh");
-    downloadScript.open("w", undefined, undefined);
-    // set encoding and linefeeds
-    downloadScript.lineFeed = "Unix";
-    downloadScript.encoding = "UTF-8";
-    downloadScript.write(scriptContent.join("\n"));
-    downloadScript.close();
-  } // end of file and folder creation
-
-  if (isURL(url)) {
-    var cmd = null;
-
-    if (file) {
-      if (file instanceof File) {
-        var downloadFolder = file.parent.fsName;
-        var fileName = file.displayName;
-        downloadFolder = downloadFolder.replace(" ", "\\ ");
-        fileName = fileName.replace(" ", "\\ ");
-        cmd = ["sh", scriptPath, downloadFolder, url, fileName].join(" ");
-
-      } else {
-        var downloadFolder = file.substr(0, file.lastIndexOf("/"));
-        var fileName = file.substr(file.lastIndexOf("/") + 1);
-
-        // get rif of some special cases
-        if(startsWith(downloadFolder, "./")) downloadFolder.substr(2);
-        if(startsWith(downloadFolder, "/")) downloadFolder.substr(1);
-
-        downloadFolder = downloadFolder.replace(" ", "\\ ");
-        fileName = fileName.replace(" ", "\\ ");
-        downloadFolder = projPath + "/data/" + downloadFolder;
-        cmd = ["sh", scriptPath, downloadFolder, url, fileName].join(" ");
-
-      }
-
-    } else {
-      var downloadFolder = projPath + "/data/download";
-      var cmd = ["sh", scriptPath, downloadFolder, url].join(" ");
-    }
-
-    println(cmd);
-    pub.shellExecute(cmd);
-
-  } else {
-    error("The url " + url + " is not a valid one. Please double check!");
-  }
-};
-
-
-
-// ----------------------------------------
-// src/includes/shape.js
-// ----------------------------------------
-
-/**
- * @description Draws an ellipse (oval) in the display window. An ellipse with an equal width and height is a circle.
- * The first two parameters set the location, the third sets the width, and the fourth sets the height.
- *
- * @cat    Document
- * @subcat Primitives
- * @method ellipse
- * @param  {Number} x X-coordinate of the ellipse.
- * @param  {Number} y Y-coordinate of the ellipse.
- * @param  {Number} w Width of the ellipse.
- * @param  {Number} h Height of the ellipse.
- * @return {Oval} New Oval (in InDesign Scripting terms the corresponding type is Oval, not Ellipse).
- */
-pub.ellipse = function(x, y, w, h) {
-  if (arguments.length !== 4) error("ellipse(), not enough parameters to draw an ellipse! Use: x, y, w, h");
-  var ellipseBounds = [];
-  if (currEllipseMode === pub.CORNER) {
-    ellipseBounds[0] = y;
-    ellipseBounds[1] = x;
-    ellipseBounds[2] = y + h;
-    ellipseBounds[3] = x + w;
-  } else if (currEllipseMode === pub.CORNERS) {
-    ellipseBounds[0] = y;
-    ellipseBounds[1] = x;
-    ellipseBounds[2] = h;
-    ellipseBounds[3] = w;
-  } else if (currEllipseMode === pub.CENTER) {
-    ellipseBounds[0] = y - (h / 2);
-    ellipseBounds[1] = x - (w / 2);
-    ellipseBounds[2] = y + (h / 2);
-    ellipseBounds[3] = x + (w / 2);
-  } else if (currEllipseMode === pub.RADIUS) {
-    ellipseBounds[0] = y - h;
-    ellipseBounds[1] = x - w;
-    ellipseBounds[2] = y + h;
-    ellipseBounds[3] = x + w;
-  }
-
-  if(w === 0 || h === 0)
-    {return false;}
-
-  var ovals = currentPage().ovals;
-  var newOval = ovals.add(currentLayer());
-
-  newOval.strokeWeight = currStrokeWeight;
-  newOval.strokeTint = currStrokeTint;
-  newOval.fillColor = currFillColor;
-  newOval.fillTint = currFillTint;
-  newOval.strokeColor = currStrokeColor;
-  newOval.geometricBounds = ellipseBounds;
-
-  if (currEllipseMode === pub.CENTER || currEllipseMode === pub.RADIUS) {
-    newOval.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
-                       AnchorPoint.CENTER_ANCHOR,
-                       currMatrix.adobeMatrix(x, y));
-  } else {
-    newOval.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
-                   AnchorPoint.TOP_LEFT_ANCHOR,
-                   currMatrix.adobeMatrix(x, y));
-  }
-  return newOval;
-};
-
-/**
- * @description Draws a line (a direct path between two points) to the page.
- *
- * @cat    Document
- * @subcat Primitives
- * @method line
- * @param  {Number} x1 X-coordinate of Point 1.
- * @param  {Number} y1 Y-coordinate of Point 1.
- * @param  {Number} x2 X-coordinate of Point 2.
- * @param  {Number} y2 Y-coordinate of Point 2.
- * @return {GraphicLine} New GraphicLine.
- *
- * @example
- * var vec1 = new Vector( x1, y1 );
- * var vec2 = new Vector( x2, y2 );
- * line( vec1, vec2 );
- */
-pub.line = function(x1, y1, x2, y2) {
-  if (arguments.length !== 4) {
-    error("line(), not enough parameters to draw a line! Use: x1, y1, x2, y2");
-  }
-  var lines = currentPage().graphicLines;
-  var newLine = lines.add(currentLayer());
-  newLine.strokeWeight = currStrokeWeight;
-  newLine.strokeTint = currStrokeTint;
-  newLine.fillColor = currFillColor;
-  newLine.fillTint = currFillTint;
-  newLine.strokeColor = currStrokeColor;
-  newLine.paths.item(0).entirePath = [[x1, y1], [x2, y2]];
-  newLine.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
-                   AnchorPoint.CENTER_ANCHOR,
-                   currMatrix.adobeMatrix( (x1 + x2) / 2, (y1 + y2) / 2 ));
-  return newLine;
-};
-
-/**
- * @description Using the beginShape() and endShape() functions allows to create more complex forms.
- * beginShape() begins recording vertices for a shape and endShape() stops recording.
- * After calling the beginShape() function, a series of vertex() commands must follow.
- * To stop drawing the shape, call endShape(). The shapeMode parameter allows to close the shape
- * (to connect the beginning and the end).
- *
- * @cat    Document
- * @subcat Primitives
- * @method beginShape
- * @param  {String} shapeMode Set to CLOSE if the new Path should be auto-closed.
- */
-pub.beginShape = function(shapeMode) {
-  currVertexPoints = [];
-  currPathPointer = 0;
-  currPolygon = null;
-  if(typeof shapeMode != null) {
-    currShapeMode = shapeMode;
-  } else {
-    currShapeMode = null;
-  }
-};
-
-/**
- * @description Shapes are constructed by connecting a series of vertices. vertex() is used to
- * specify the vertex coordinates of lines and polygons. It is used exclusively between
- * the beginShape() and endShape() functions.
- * <br><br>
- * Use either vertex(x, y) for drawing straight corners or
- * vertex(x, y, xLeftHandle, yLeftHandle, xRightHandle, yRightHandle) for drawing bezier shapes.
- * You can also mix the two approaches.
- *
- * @cat    Document
- * @subcat Primitives
- * @method vertex
- * @param  {Number} x X-coordinate of the vertex.
- * @param  {Number} y Y-coordinate of the vertex.
- * @param  {Number} [xLeftHandle] X-coordinate of the left-direction point.
- * @param  {Number} [yLeftHandle] Y-coordinate of the left-direction point.
- * @param  {Number} [xRightHandle] X-coordinate of the right-direction point.
- * @param  {Number} [yRightHandle] Y-coordinate of the right-direction point.
- */
-pub.vertex = function() {
-  if (isArray(currVertexPoints)) {
-    if (arguments.length === 2) {
-      currVertexPoints.push([arguments[0], arguments[1]]);
-    } else if (arguments.length === 6) {
-      // [[xL1, YL1], [x1, y1], [xR1, yR1]]
-      currVertexPoints.push([[arguments[2], arguments[3]],
-                              [arguments[0], arguments[1]],
-                              [arguments[4], arguments[5]]]);
-    } else {
-      error("vertex(), wrong argument count: Please use either vertex(x, y) or vertex(x, y, xLeftHandle, yLeftHandle, xRightHandle, yRightHandle)!");
-    }
-  } else {
-    notCalledBeginShapeError();
-  }
-};
-
-/**
- * @description The arc() function draws an arc. Arcs are drawn along the outer edge of an ellipse
- * defined by the x, y, width and height parameters.
- * The origin or the arc's ellipse may be changed with the ellipseMode() function.
- * The start and stop parameters specify the angles at which to draw the arc.
- *
- * @cat    Document
- * @subcat Primitives
- * @method arc
- * @param  {Number} cx X-coordinate of the arc's center.
- * @param  {Number} cy Y-coordinate of the arc's center.
- * @param  {Number} w Width of the arc's ellipse.
- * @param  {Number} h Height of the arc's ellipse.
- * @param  {Number} startAngle Starting angle of the arc in radians.
- * @param  {Number} endAngle Ending angle of the arc in radians.
- * @param  {String} [mode] Mode to define the rendering technique of the arc: OPEN (default), CHORD, or PIE.
- * @return {GraphicLine|Polygon} The resulting GraphicLine or Polygon object (in InDesign Scripting terms the corresponding type is GraphicLine or Polygon, not Arc).
- *
- */
-pub.arc = function(cx, cy, w, h, startAngle, endAngle, mode) {
-  if (w <= 0 || endAngle < startAngle) {
-    return false;
-  }
-  if (arguments.length < 6) error("arc(), not enough parameters to draw an arc! Use: x, y, w, h, startAngle, endAngle");
-
-  var o = pub.radians(1); // add 1 degree to ensure angles of 360 degrees are drawn
-  startAngle %= pub.TWO_PI + o;
-  endAngle %= pub.TWO_PI + o;
-  w /= 2;
-  h /= 2;
-
-  if (currEllipseMode === pub.CORNER) {
-    cx = (cx - w);
-    cy = (cy + h);
-  }
-  else if (currEllipseMode === pub.CORNERS) {
-    // cx = (cx-w);
-    // cy = (cy-h);
-    // w -= cx;
-    // h -= cy;
-  }
-  else if (currEllipseMode === pub.RADIUS) {
-    w *= 2;
-    h *= 2;
-  }
-
-  var delta = pub.abs(endAngle - startAngle);
-  var direction = (startAngle < endAngle) ? 1 : -1;
-  var thetaStart = startAngle;
-
-  if(mode == pub.CHORD) {
-    pub.beginShape(pub.CLOSE);
-  }
-  else if(mode == pub.PIE) {
-    pub.beginShape(pub.CLOSE);
-    pub.vertex(cx, cy);
-  }
-  else {
-    pub.beginShape();
-  }
-  for (var theta = pub.min(pub.TWO_PI, delta); theta > pub.EPSILON;) {
-    var thetaEnd = thetaStart + direction * pub.min(theta, pub.HALF_PI);
-    var points = calculateEllipticalArc(w, h, thetaEnd, thetaStart);
-
-    pub.vertex(
-      cx + points.startx,
-      cy + points.starty,
-      cx + points.startx,
-      cy + points.starty,
-      cx + points.handle1x,
-      cy + points.handle1y
-    );
-    pub.vertex(
-      cx + points.endx,
-      cy + points.endy,
-      cx + points.handle2x,
-      cy + points.handle2y,
-      cx + points.endx,
-      cy + points.endy
-    );
-
-    theta -= pub.abs(thetaEnd - thetaStart);
-    thetaStart = thetaEnd;
-  }
-  return pub.endShape();
-};
-
-/*
- * Cubic bezier approximation of a eliptical arc
- *
- * intial source code:
- * Golan Levin
- * golan@flong.com
- * http://www.flong.com/blog/2009/bezier-approximation-of-a-circular-arc-in-processing/
- *
- * The solution is taken from this PDF by Richard DeVeneza:
- * http://www.tinaja.com/glib/bezcirc2.pdf
- * linked from this excellent site by Don Lancaster:
- * http://www.tinaja.com/cubic01.asp
- *
- */
-function calculateEllipticalArc(w, h, startAngle, endAngle) {
-  var theta = (endAngle - startAngle);
-
-  var x0 = pub.cos(theta / 2.0);
-  var y0 = pub.sin(theta / 2.0);
-  var x3 = x0;
-  var y3 = 0 - y0;
-  var x1 = (4.0 - x0) / 3.0;
-  var y1 = ((1.0 - x0) * (3.0 - x0)) / (3.0 * y0);
-  var x2 = x1;
-  var y2 = 0 - y1;
-
-  var bezAng = startAngle + theta / 2.0;
-  var cBezAng = pub.cos(bezAng);
-  var sBezAng = pub.sin(bezAng);
-
-  return {
-    startx:   w * (cBezAng * x0 - sBezAng * y0),
-    starty:   h * (sBezAng * x0 + cBezAng * y0),
-    handle1x: w * (cBezAng * x1 - sBezAng * y1),
-    handle1y: h * (sBezAng * x1 + cBezAng * y1),
-
-    handle2x: w * (cBezAng * x2 - sBezAng * y2),
-    handle2y: h * (sBezAng * x2 + cBezAng * y2),
-    endx:     w * (cBezAng * x3 - sBezAng * y3),
-    endy:     h * (sBezAng * x3 + cBezAng * y3)
-  };
-}
-
-/**
- * @description addPath() is used to create multi component paths. Call addPath() to add
- * the vertices drawn so far to a single path. New vertices will then end up in a new path and
- * endShape() will return a multi path object. All component paths will account for
- * the setting (see CLOSE) given in beginShape(shapeMode).
- *
- * @cat    Document
- * @subcat Primitives
- * @method addPath
- */
-pub.addPath = function() {
-  doAddPath();
-  currPathPointer++;
-};
-
-/**
- * @description The endShape() function is the companion to beginShape() and may only be called
- * after beginShape().
- *
- * @cat    Document
- * @subcat Primitives
- * @method endShape
- * @return {GraphicLine|Polygon} The GraphicLine or Polygon object that was created.
- */
-pub.endShape = function() {
-  doAddPath();
-  currPolygon.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
-                   AnchorPoint.TOP_LEFT_ANCHOR,
-                   currMatrix.adobeMatrix(currPolygon.geometricBounds[1], currPolygon.geometricBounds[0]));
-  return currPolygon;
-};
-
-function doAddPath() {
-  if (isArray(currVertexPoints)) {
-    if (currVertexPoints.length > 0) {
-
-      if(currPolygon === null) {
-        addPolygon();
-      } else {
-        currPolygon.paths.add();
-      }
-
-      currPolygon.paths.item(currPathPointer).entirePath = currVertexPoints;
-      currVertexPoints = [];
-    }
-  } else {
-    notCalledBeginShapeError();
-  }
-}
-
-function addPolygon() {
-  if (currShapeMode === pub.CLOSE) {
-    currPolygon = currentPage().polygons.add(currentLayer());
-  } else {
-    currPolygon = currentPage().graphicLines.add(currentLayer());
-  }
-
-  currPolygon.strokeWeight = currStrokeWeight;
-  currPolygon.strokeTint = currStrokeTint;
-  currPolygon.fillColor = currFillColor;
-  currPolygon.fillTint = currFillTint;
-  currPolygon.strokeColor = currStrokeColor;
-}
-
-
-function notCalledBeginShapeError () {
-  error("endShape(), you have to call first beginShape(), before calling vertex() and endShape()");
-}
-
-/**
- * @description Draws a rectangle on the page.<br>
- * By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, however, may be changed with the rectMode() function.<br>
- * The fifth, sixth, seventh and eighth parameters, if specified, determine corner radius for the top-right, top-left, lower-right and lower-left corners, respectively. If only a fifth parameter is provided, all corners will be set to this radius.
- *
- * @cat    Document
- * @subcat Primitives
- * @method rect
- * @param  {Number} x X-coordinate of the rectangle.
- * @param  {Number} y Y-coordinate of the rectangle.
- * @param  {Number} w Width of the rectangle.
- * @param  {Number} h Height of the rectangle.
- * @param  {Number} [tl] Radius of top left corner or radius of all 4 corners (optional).
- * @param  {Number} [tr] Radius of top right corner (optional).
- * @param  {Number} [br] Radius of bottom right corner (optional).
- * @param  {Number} [bl] Radius of bottom left corner (optional).
- * @return {Rectangle} The rectangle that was created.
- */
-pub.rect = function(x, y, w, h, tl, tr, br, bl) {
-  if (w === 0 || h === 0) {
-    // InDesign doesn't draw a rectangle if width or height are set to 0
-    return false;
-  }
-  if (arguments.length < 4) error("rect(), not enough parameters to draw a rect! Use: x, y, w, h");
-
-  var rectBounds = [];
-  if (currRectMode === pub.CORNER) {
-    rectBounds[0] = y;
-    rectBounds[1] = x;
-    rectBounds[2] = y + h;
-    rectBounds[3] = x + w;
-  } else if (currRectMode === pub.CORNERS) {
-    rectBounds[0] = y;
-    rectBounds[1] = x;
-    rectBounds[2] = h;
-    rectBounds[3] = w;
-  } else if (currRectMode === pub.CENTER) {
-    rectBounds[0] = y - (h / 2);
-    rectBounds[1] = x - (w / 2);
-    rectBounds[2] = y + (h / 2);
-    rectBounds[3] = x + (w / 2);
-  } else if (currRectMode === pub.RADIUS) {
-    rectBounds[0] = y - h;
-    rectBounds[1] = x - w;
-    rectBounds[2] = y + h;
-    rectBounds[3] = x + w;
-  }
-
-  var newRect = currentPage().rectangles.add(currentLayer());
-  newRect.geometricBounds = rectBounds;
-  newRect.strokeWeight = currStrokeWeight;
-  newRect.strokeTint = currStrokeTint;
-  newRect.fillColor = currFillColor;
-  newRect.fillTint = currFillTint;
-  newRect.strokeColor = currStrokeColor;
-
-  if (currRectMode === pub.CENTER || currRectMode === pub.RADIUS) {
-    newRect.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
-                       AnchorPoint.CENTER_ANCHOR,
-                       currMatrix.adobeMatrix(x, y));
-  } else {
-    newRect.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
-                   AnchorPoint.TOP_LEFT_ANCHOR,
-                   currMatrix.adobeMatrix(x, y));
-  }
-
-  if(arguments.length > 4) {
-    for(var i = 4; i < arguments.length;i++){
-      if(arguments[i] < 0 ){
-        error("rect(), needs positive values as arguments for the rounded corners.");
-      }
-    }
-    newRect.topLeftCornerOption = newRect.topRightCornerOption = newRect.bottomRightCornerOption = newRect.bottomLeftCornerOption = CornerOptions.ROUNDED_CORNER;
-    if(arguments.length === 8) {
-      newRect.topLeftCornerRadius = tl;
-      newRect.topRightCornerRadius = tr;
-      newRect.bottomRightCornerRadius = br;
-      newRect.bottomLeftCornerRadius = bl;
-    } else {
-      newRect.topLeftCornerRadius = newRect.topRightCornerRadius = newRect.bottomRightCornerRadius = newRect.bottomLeftCornerRadius = tl;
-    }
-  }
-  return newRect;
-};
-
-
-// -- Attributes --
-
-/**
- * @description Modifies the location from which rectangles or text frames draw. The default
- * mode is rectMode(CORNER), which specifies the location to be the upper left
- * corner of the shape and uses the `w` and `h` parameters to specify the
- * width and height. The syntax rectMode(CORNERS) uses the `x` and `y`
- * parameters of `rect()` or `text()` to set the location of one corner
- * and uses the `w` and `h` parameters to set the opposite corner.
- * The syntax `rectMode(CENTER)` draws the shape from its center point and
- * uses the `w` and `h` parameters to specify the shape's
- * width and height. The syntax `rectMode(RADIUS)` draws the shape from its
- * center point and uses the `w` and `h` parameters to specify
- * half of the shape's width and height.
- *
- * @cat    Document
- * @subcat Attributes
- * @method rectMode
- * @param  {String} mode The rectMode to switch to: either CORNER, CORNERS, CENTER, or RADIUS.
- *
- */
-pub.rectMode = function (mode) {
-  if (arguments.length === 0) return currRectMode;
-  if (mode === pub.CORNER || mode === pub.CORNERS || mode === pub.CENTER || mode === pub.RADIUS) {
-    currRectMode = mode;
-    return currRectMode;
-  } else {
-    error("rectMode(), unsupported rectMode. Use: CORNER, CORNERS, CENTER, RADIUS.");
-  }
-};
-
-/**
- * @description The origin of new ellipses is modified by the `ellipseMode()` function.
- * The default configuration is `ellipseMode(CENTER)`, which specifies the
- * location of the ellipse as the center of the shape. The RADIUS mode is
- * the same, but the `w` and `h` parameters to `ellipse()` specify the
- * radius of the ellipse, rather than the diameter. The CORNER mode draws
- * the shape from the upper-left corner of its bounding box. The CORNERS
- * mode uses the four parameters to `ellipse()` to set two opposing corners
- * of the ellipse's bounding box.
- *
- * @cat    Document
- * @subcat Attributes
- * @method ellipseMode
- * @param  {String} mode The ellipse mode to switch to: either CENTER, RADIUS, CORNER, or CORNERS.
- */
-pub.ellipseMode = function (mode) {
-  if (arguments.length === 0) return currEllipseMode;
-  if (mode === pub.CORNER || mode === pub.CORNERS || mode === pub.CENTER || mode === pub.RADIUS) {
-    currEllipseMode = mode;
-    return currEllipseMode;
-  } else {
-    error("ellipseMode(), unsupported ellipseMode. Use: CENTER, RADIUS, CORNER, CORNERS.");
-  }
-};
-
-/**
- * @description Sets the width of the stroke used for lines and the border around shapes.
- *
- * @cat    Document
- * @subcat Attributes
- * @method strokeWeight
- * @param  {Number} weight The width of the stroke in points.
- */
-pub.strokeWeight = function (weight) {
-  if (typeof weight === "string" || typeof weight === "number") {
-    currStrokeWeight = weight;
-  } else {
-    error("strokeWeight(), not supported type. Please make sure the strokeweight is a number or string");
-  }
-};
-
-/**
- * @description Returns the object style of a given page item or the object style with the given name. If an
- * object style of the given name does not exist, it gets created. Optionally a props object of
- * property name/value pairs can be used to set the object style's properties.
- *
- * @cat    Typography
- * @method objectStyle
- * @param  {PageItem|String} itemOrName A page item whose style to return or the name of the object style to return.
- * @param  {Object} [props] An object of property name/value pairs to set the style's properties.
- * @return {ObjectStyle} The object style instance.
- */
-pub.objectStyle = function(itemOrName, props) {
-  var styleErrorMsg = "objectStyle(), wrong parameters. Use: pageItem|name and props. Props is optional.";
-
-  if(!arguments || arguments.length > 2) {
-    error(styleErrorMsg);
-  }
-
-  var style;
-  if(itemOrName.hasOwnProperty("appliedObjectStyle")) {
-    // pageItem is given
-    style = itemOrName.appliedObjectStyle;
-  } else if(isString(itemOrName)) {
-    // name is given
-    style = findInStylesByName(currentDoc().allObjectStyles, itemOrName);
-    if(!style) {
-      style = currentDoc().objectStyles.add({name: itemOrName});
-    }
-  } else {
-    error(styleErrorMsg);
-  }
-
-  if(props) {
-    try {
-      style.properties = props;
-    } catch (e) {
-      error("objectStyle(), wrong props parameter. Use object of property name/value pairs.");
-    }
-  }
-
-  return style;
-};
-
-/**
- * @description Applies an object style to the given page item. The object style can be given as
- * name or as an object style instance.
- *
- * @cat    Typography
- * @method applyObjectStyle
- * @param  {PageItem} item The page item to apply the style to.
- * @param  {ObjectStyle|String} style An object style instance or the name of the object style to apply.
- * @return {PageItem} The page item that the style was applied to.
- */
-
-pub.applyObjectStyle = function(item, style) {
-
-  if(isString(style)) {
-    var name = style;
-    style = findInStylesByName(currentDoc().allObjectStyles, name);
-    if(!style) {
-      error("applyObjectStyle(), an object style named \"" + name + "\" does not exist.");
-    }
-  }
-
-  if(!(item.hasOwnProperty("appliedObjectStyle")) || !(style instanceof ObjectStyle)) {
-    error("applyObjectStyle(), wrong parameters. Use: pageItem, objectStyle|name");
-  }
-
-  item.appliedObjectStyle = style;
-
-  return item;
-};
-
-/**
- * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use `rectMode()` to set center point.
- *
- * @cat    Document
- * @subcat Transformation
- * @method duplicate
- * @param  {PageItem|Page} item The page item or page to duplicate.
- * @return {Object} The new page item or page.
- */
-pub.duplicate = function(item) {
-
-  if(!(item instanceof Page) && typeof (item) !== "undefined" && item.hasOwnProperty("duplicate")) {
-
-    var newItem = item.duplicate(currentPage().parent);
-    newItem.move(currentLayer());
-
-    return newItem;
-
-  } else if(item instanceof Page) {
-
-    var newPage = item.duplicate(LocationOptions.AFTER, pub.page());
-    return newPage;
-
-  } else {
-    error("Please provide a valid Page or PageItem as parameter for duplicate().");
-  }
-
-};
-
-
-// ----------------------------------------
-// src/includes/color.js
-// ----------------------------------------
-
-/**
- * @description Sets the color or gradient used to fill shapes.
- *
- * @cat    Color
- * @method fill
- * @param  {Color|Gradient|Swatch|Numbers|String} fillColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
- * @param  {String} [name] If created with numbers, a custom swatch name can be given.
- */
-pub.fill = function (fillColor) {
-
-  checkNull(fillColor);
-  if (fillColor instanceof Color || fillColor instanceof Swatch || fillColor instanceof Gradient) {
-    currFillColor = fillColor;
-  } else {
-    if (arguments.length === 1) {
-      if (typeof arguments[0] === "string") {
-        currFillColor = pub.swatch(arguments[0]);
-      }else{
-        currFillColor = pub.color(arguments[0]);
-      }
-    } else if (arguments.length === 2) {
-      currFillColor = pub.color(arguments[0], arguments[1]);
-    } else if (arguments.length === 3) {
-      currFillColor = pub.color(arguments[0], arguments[1], arguments[2]);
-    } else if (arguments.length === 4) {
-      currFillColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3]);
-    } else if (arguments.length === 5) {
-      currFillColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
-    } else {
-      error("fill(), wrong parameters. Use:\n"
-        + "Swatch name or\n"
-        + "GRAY, [name] or\n"
-        + "R, G, B, [name] or\n"
-        + "C, M, Y, K, [name].\n"
-        + "Name is optional.");
-    }
-  }
-};
-
-/**
- * @description Disables filling geometry. If both noStroke() and noFill() are called,
- * newly drawn shapes will be invisible.
- *
- * @cat    Color
- * @method noFill
- */
-pub.noFill = function () {
-  currFillColor = noneSwatchColor;
-};
-
-/**
- * @description Sets the color or gradient used to draw lines and borders around shapes.
- *
- * @cat Color
- * @method stroke
- * @param {Color|Gradient|Swatch|Numbers|String} strokeColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
- */
-pub.stroke = function (strokeColor) {
-  checkNull(strokeColor);
-  if (strokeColor instanceof Color || strokeColor instanceof Swatch || strokeColor instanceof Gradient) {
-    currStrokeColor = strokeColor;
-  } else {
-    if (arguments.length === 1) {
-      if (typeof arguments[0] === "string") {
-        currStrokeColor = pub.swatch(arguments[0]);
-      }else{
-        currStrokeColor = pub.color(arguments[0]);
-      }
-    } else if (arguments.length === 2) {
-      currStrokeColor = pub.color(arguments[0], arguments[1]);
-    } else if (arguments.length === 3) {
-      currStrokeColor = pub.color(arguments[0], arguments[1], arguments[2]);
-    } else if (arguments.length === 4) {
-      currStrokeColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3]);
-    } else if (arguments.length === 5) {
-      currStrokeColor = pub.color(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
-    } else {
-      error("stroke(), wrong parameters. Use:\n"
-        + "Swatch name or\n"
-        + "GRAY, [name] or\n"
-        + "R, G, B, [name] or\n"
-        + "C, M, Y, K, [name].\n"
-        + "Name is optional.");
-    }
-  }
-};
-
-/**
- * @description Disables drawing the stroke. If both noStroke() and noFill() are called,
- * newly drawn shapes will be invisible.
- *
- * @cat    Color
- * @method noStroke
- */
-pub.noStroke = function () {
-  currStrokeColor = noneSwatchColor;
-};
-
-/**
- * @description Sets the tint of the color used to fill shapes.
- *
- * @cat    Color
- * @method fillTint
- * @param  {Number} tint Number from 0 to 100
- */
-pub.fillTint = function (tint) {
-  checkNull(tint);
-  if (typeof tint === "string" || typeof tint === "number") {
-    currFillTint = tint;
-  } else {
-    error("fillTint(), unsupported type. Please make sure the fillTint is a number or string");
-  }
-};
-
-/**
- * @description Sets the tint of the color used to draw lines and borders around shapes.
- *
- * @cat    Color
- * @method strokeTint
- * @param  {Number} tint Number from 0 to 100.
- */
-pub.strokeTint = function (tint) {
-  checkNull(tint);
-  if (typeof tint === "string" || typeof tint === "number") {
-    currStrokeTint = tint;
-  } else {
-    error("strokeTint(), unsupported type. Please make sure the strokeTint parameter is a number or string");
-  }
-};
-
-/**
- * @description Sets the colormode for creating new colors with color() to RGB or CMYK. The default color mode is RGB.
- *
- * @cat    Color
- * @method colorMode
- * @param  {Number} colorMode RGB or CMYK.
- */
-pub.colorMode = function(colorMode) {
-  checkNull(colorMode);
-  if (arguments.length === 0) {
-    return currColorMode;
-  }
-  if (colorMode === pub.RGB || colorMode === pub.CMYK) {
-    currColorMode = colorMode;
-  } else {
-    error("colorMode(), unsupported colormode, use: RGB or CMYK");
-  }
-};
-
-/**
- * @description Sets the gradient mode for gradient() to LINEAR or RADIAL. The default gradient mode is LINEAR.
- *
- * @cat    Color
- * @method gradientMode
- * @param  {String} gradientMode LINEAR or RADIAL.
- */
-pub.gradientMode = function(gradientMode) {
-  checkNull(gradientMode);
-  if (arguments.length === 0) {
-    return currGradientMode;
-  }
-  if (gradientMode === pub.LINEAR || gradientMode === pub.RADIAL) {
-    currGradientMode = gradientMode;
-  } else {
-    error("gradientMode(), unsupported gradient mode, use: LINEAR or RADIAL");
-  }
-};
-
-/**
- * @description Gets a swatch by name.
- *
- * @cat    Color
- * @method swatch
- * @param  {String} swatchName Returns the swatch color/gradient for a given name by string.
- */
-pub.swatch = function(){
-  var newSwatch;
-  var props = {};
-  if (arguments.length === 1) {
-    var a = arguments[0];
-    if (typeof a === "string") {
-      newSwatch = currentDoc().swatches.itemByName(a);
-      if(newSwatch.isValid){
-          return newSwatch;
-        }else{
-          error("A swatch with the provided name doesn't exist.");
-        }
-    }else{
-      error("swatch() requires a string, the name of an existing swatch.");
-    }
-  }
-}
-
-/**
- * @description Creates a new RGB / CMYK color and adds it to the document, or gets a color by name from the document. The default color mode is RGB.
- *
- * @cat    Color
- * @method color
- * @param  {String|Numbers} Get color: the color name. Create new color: GRAY,[name] / R,G,B,[name] / C,M,Y,K,[name]. Name is always optional.
- * @return {Color} Found or new color
- */
-pub.color = function() {
-  var newCol;
-  var props = {};
-  var a = arguments[0],
-    b = arguments[1],
-    c = arguments[2],
-    d = arguments[3],
-    e = arguments[4];
-  var colorErrorMsg = "color(), wrong parameters. Use:\n"
-      + "GRAY,[name] or \n"
-      + "R,G,B,[name] in colorMode(RGB) or\n"
-      + "C,M,Y,K,[name] in colorMode(CMYK).\n"
-      + "Name is optional.\n"
-      + "NB: In InDesign colors don't have an alpha value, use opacity() to set alpha.";
-
-  if (arguments.length === 1) {
-    // get color by name
-    if (typeof a === "string") {
-      newCol = currentDoc().colors.itemByName(a); // check color
-      if (newCol.isValid) {
-        return newCol;
-      } else {
-        error("color(), a color with the provided name doesn't exist.");
-      }
-    } else if (typeof a === "number") {
-      // GRAY
-      if (currColorMode === pub.RGB) {
-        a = pub.constrain(a, 0, 255);
-        props.model = ColorModel.PROCESS;
-        props.space = ColorSpace.RGB;
-        props.colorValue = [a, a, a];
-        props.name = "R=" + a + " G=" + a + " B=" + a;
-      } else {
-        a = pub.constrain(a, 0, 100);
-        props.model = ColorModel.PROCESS;
-        props.space = ColorSpace.CMYK;
-        props.colorValue = [0, 0, 0, a];
-        props.name = "C=" + 0 + " M=" + 0 + " Y=" + 0 + " K=" + a;
-      }
-    } else {
-      error("color(), wrong type of first parameter.");
-    }
-
-  } else if (arguments.length === 2) {
-    // GRAY + name
-    if (currColorMode === pub.RGB) {
-      a = pub.constrain(a, 0, 255);
-      props.model = ColorModel.PROCESS;
-      props.space = ColorSpace.RGB;
-      props.colorValue = [a, a, a];
-      props.name = b;
-    } else {
-      a = pub.constrain(a, 0, 100);
-      props.model = ColorModel.PROCESS;
-      props.space = ColorSpace.CMYK;
-      props.colorValue = [0, 0, 0, a];
-      props.name = b;
-    }
-
-  } else if (arguments.length === 3) {
-    // R G B
-    if (currColorMode === pub.RGB) {
-      a = pub.constrain(a, 0, 255);
-      b = pub.constrain(b, 0, 255);
-      c = pub.constrain(c, 0, 255);
-      props.model = ColorModel.PROCESS;
-      props.space = ColorSpace.RGB;
-      props.colorValue = [a, b, c];
-      props.name = "R=" + a + " G=" + b + " B=" + c;
-    } else {
-      error(colorErrorMsg);
-    }
-
-
-  } else if (arguments.length === 4 && typeof d === "string") {
-    // R G B + name
-    if (currColorMode === pub.RGB) {
-      a = pub.constrain(a, 0, 255);
-      b = pub.constrain(b, 0, 255);
-      c = pub.constrain(c, 0, 255);
-      props.model = ColorModel.PROCESS;
-      props.space = ColorSpace.RGB;
-      props.colorValue = [a, b, c];
-      props.name = d;
-    } else {
-      error(colorErrorMsg);
-    }
-
-  } else if (arguments.length === 4 && typeof d === "number") {
-    // C M Y K
-    if (currColorMode === pub.CMYK) {
-      a = pub.constrain(a, 0, 100);
-      b = pub.constrain(b, 0, 100);
-      c = pub.constrain(c, 0, 100);
-      d = pub.constrain(d, 0, 100);
-      props.model = ColorModel.PROCESS;
-      props.space = ColorSpace.CMYK;
-      props.colorValue = [a, b, c, d];
-      props.name = "C=" + a + " M=" + b + " Y=" + c + " K=" + d;
-    } else {
-      error(colorErrorMsg);
-    }
-
-  } else if (arguments.length === 5 && typeof e === "string" && currColorMode === pub.CMYK) {
-    // C M Y K + name
-    a = pub.constrain(a, 0, 100);
-    b = pub.constrain(b, 0, 100);
-    c = pub.constrain(c, 0, 100);
-    d = pub.constrain(d, 0, 100);
-    props.model = ColorModel.PROCESS;
-    props.space = ColorSpace.CMYK;
-    props.colorValue = [a, b, c, d];
-    props.name = e;
-
-  } else {
-    error(colorErrorMsg);
-  }
-
-  // check whether color was already created and added to colors,
-  // keeps the document clean ...
-  newCol = currentDoc().colors.itemByName(props.name);
-  if (!newCol.isValid) {
-    newCol = currentDoc().colors.add();
-  }
-  newCol.properties = props;
-  return newCol;
-};
-
-/**
- * @description Creates a new gradient and adds it to the document, or gets a gradient by name from the document.<br>
- * If two colors are given as the first two parameters, a gradient is created that blends between these two colors. If an array of colors is used
- * as the first parameter, a gradient with the contained colors will be created. The colors will be distributed evenly. If additionally to this array
- * a second array of gradient stop positions is given, the colors will be positioned at the given gradient stops. Possible gradient stop positions
- * range from 0 to 100. All parameter options allow for an additional name parameter at the end to name the new gradient.
- * If a string is used as the only parameter, the gradient with that name will be returned, if it exists in the document.
- *
- * @cat    Color
- * @method gradient
- * @param  {Color|Array|String} c1 First color of the gradient. Alternatively: Array of colors/gradients or name of gradient to get.
- * @param  {Color|Array|String} c2 Second color of the gradient. Alternatively: Array of gradient stop positions (if first parameter is an array of colors).
- * @param  {String} [name] Optional name of the gradient.
- * @return {Gradient} Found or new gradient
- */
-pub.gradient = function() {
-  var newGrad;
-  // var props = {};
-  var a = arguments[0],
-    b = arguments[1],
-    c = arguments[2];
-  var gradientErrorMsg = "gradient(), wrong parameters. Use:\n"
-      + "c1,c2,[name] or\n"
-      + "arrayOfColors,[name] or\n"
-      + "arrayOfColors,arrayOfGradientStops,[name] or\n"
-      + "gradientName";
-
-  if (typeof a === "string" && arguments.length === 1) {
-    // get gradient by name
-    newGrad = currentDoc().gradients.itemByName(a);
-    if (newGrad.isValid) {
-      return newGrad;
-    } else {
-      error("gradient(), a gradient with the provided name doesn't exist.");
-    }
-  } else if (a instanceof Color && b instanceof Color && (typeof c === "string" || arguments.length === 2)) {
-    // c1 and c2
-    if (typeof c === "string") {
-      if(currentDoc().colors.itemByName(c).isValid) {
-        error("gradient(), \"" + c + "\" already exists as a color. Use another name for the gradient.");
-      }
-      if(currentDoc().gradients.itemByName(c).isValid) {
-        currentDoc().gradients.itemByName(c).remove();
-        warning("gradient(), a gradient named \"" + c + "\" already existed. The old gradient is replaced by a new one.");
-      }
-      newGrad = currentDoc().gradients.add({name: c});
-    } else {
-      newGrad = currentDoc().gradients.add();
-    }
-    newGrad.gradientStops[0].stopColor = a;
-    newGrad.gradientStops[1].stopColor = b;
-    if(currGradientMode === pub.LINEAR) {
-      newGrad.type = GradientType.LINEAR;
-    } else {
-      newGrad.type = GradientType.RADIAL;
-    }
-    return newGrad;
-  } else if (a instanceof Array) {
-    // array of colors
-    var customStopLocations = false;
-    if(arguments.length > 3) {
-      error(gradientErrorMsg);
-    }
-    if(arguments.length > 1 && !(b instanceof Array || typeof b === "string")) {
-      error(gradientErrorMsg);
-    }
-    if(arguments.length === 3 && !(typeof c === "string")) {
-      error(gradientErrorMsg);
-    }
-    if(arguments.length > 1 && b instanceof Array) {
-      customStopLocations = true;
-    }
-    if(customStopLocations && !(a.length === b.length)) {
-      error("gradient(), arrayOfColors and arrayOfGradientStops need to have the same length.");
-    }
-    var z = arguments[arguments.length - 1];
-    if (typeof z === "string") {
-      if(currentDoc().colors.itemByName(z).isValid) {
-        error("gradient(), \"" + z + "\" already exists as a color. Use another name for the gradient.");
-      }
-      if(currentDoc().gradients.itemByName(z).isValid) {
-        currentDoc().gradients.itemByName(z).remove();
-        warning("gradient(), a gradient named \"" + z + "\" already existed. The old gradient is replaced by a new one.");
-      }
-      newGrad = currentDoc().gradients.add({name: z});
-    } else {
-      newGrad = currentDoc().gradients.add();
-    }
-    for (var i = 0; i < a.length; i++) {
-      if(!(a[i] instanceof Color || a[i] instanceof Swatch)) {
-        error("gradient(), element #" + (i + 1) + " of the given arrayOfColors is not a color or swatch.");
-      }
-      if(i > newGrad.gradientStops.length - 1) {
-        newGrad.gradientStops.add();
-      }
-      newGrad.gradientStops[i].stopColor = a[i];
-      if(customStopLocations) {
-        if(!(typeof b[i] === "number")) {
-          error("gradient(), element #" + (i + 1) + " of the given arrayOfGradientStops is not a number.");
-        }
-        newGrad.gradientStops[i].location = pub.constrain(b[i], 0, 100);
-      } else {
-        newGrad.gradientStops[i].location = pub.map(i, 0, a.length - 1, 0, 100);
-      }
-    }
-    if(currGradientMode === pub.LINEAR) {
-      newGrad.type = GradientType.LINEAR;
-    } else {
-      newGrad.type = GradientType.RADIAL;
-    }
-    return newGrad;
-  } else {
-    error(gradientErrorMsg);
-  }
-};
-
-/**
- * @description Sets the opacity property of an object.
- *
- * @cat    Color
- * @method opacity
- * @param  {Object} obj The object to set opacity of.
- * @param  {Number} opacity The opacity value from 0 to 100.
- */
-pub.opacity = function(obj, opacity) {
-  checkNull(obj);
-  if (obj.hasOwnProperty("transparencySettings")) {
-    obj.transparencySettings.blendingSettings.opacity = opacity;
-  } else {
-    warning("opacity(), the object " + obj.toString() + " doesn't have an opacity property");
-  }
-};
-
-/**
- * @description Sets the Effects blendMode property of an object.
- *
- * @cat    Color
- * @method blendMode
- * @param  {Object} obj The object to set blendMode of.
- * @param  {Number} blendMode The blendMode must be one of the InDesign BlendMode enum values:
- *    - `BlendMode.NORMAL`
- *    - `BlendMode.MULTIPLY`
- *    - `BlendMode.SCREEN`
- *    - `BlendMode.OVERLAY`
- *    - `BlendMode.SOFT_LIGHT`
- *    - `BlendMode.HARD_LIGHT`
- *    - `BlendMode.COLOR_DODGE`
- *    - `BlendMode.COLOR_BURN`
- *    - `BlendMode.DARKEN`
- *    - `BlendMode.LIGHTEN`
- *    - `BlendMode.DIFFERENCE`
- *    - `BlendMode.EXCLUSION`
- *    - `BlendMode.HUE`
- *    - `BlendMode.SATURATION`
- *    - `BlendMode.COLOR`
- *    - `BlendMode.LUMINOSITY`
- */
-pub.blendMode = function(obj, blendMode) {
-  checkNull(obj);
-  if (obj.hasOwnProperty("transparencySettings")) {
-    obj.transparencySettings.blendingSettings.blendMode = blendMode;
-  } else {
-    warning("blendMode(), the object " + obj.toString() + " doesn't have a blendMode property");
-  }
-};
-
-/**
- * @description Calculates a color or colors between two colors at a specific increment.<br>
- * The amt parameter is the amount to interpolate between the two values where 0.0 equals the first color, 0.5 is half-way in between and 1.0 equals the second color.
- * N.B.: Both colors must be either CMYK or RGB.
- *
- * @cat    Color
- * @method lerpColor
- * @param  {Color} c1   Input color 1.
- * @param  {Color} c2   Input color 2.
- * @param  {Number} amt The amount to interpolate between the two colors.
- * @return {Color} Interpolated color
- */
-pub.lerpColor = function (c1, c2, amt) {
-  checkNull(c1);
-  checkNull(c2);
-  if ((c1 instanceof Color || c1 instanceof Swatch) &&
-     (c2 instanceof Color || c2 instanceof Swatch) &&
-      typeof amt === "number") {
-    if (c1.space === ColorSpace.CMYK && c2.space === ColorSpace.CMYK) {
-      var C1 = c1.colorValue[0];
-      var M1 = c1.colorValue[1];
-      var Y1 = c1.colorValue[2];
-      var K1 = c1.colorValue[3];
-
-      var C2 = c2.colorValue[0];
-      var M2 = c2.colorValue[1];
-      var Y2 = c2.colorValue[2];
-      var K2 = c2.colorValue[3];
-
-      var COut = Math.round(pub.lerp(C1, C2, amt));
-      var MOut = Math.round(pub.lerp(M1, M2, amt));
-      var YOut = Math.round(pub.lerp(Y1, Y2, amt));
-      var KOut = Math.round(pub.lerp(K1, K2, amt));
-      return pub.color(COut, MOut, YOut, KOut);
-
-    } else if (c1.space === ColorSpace.RGB && c2.space === ColorSpace.RGB) {
-      var R1 = c1.colorValue[0];
-      var G1 = c1.colorValue[1];
-      var B1 = c1.colorValue[2];
-
-      var R2 = c2.colorValue[0];
-      var G2 = c2.colorValue[1];
-      var B2 = c2.colorValue[2];
-
-      var ROut = Math.round(pub.lerp(R1, R2, amt));
-      var GOut = Math.round(pub.lerp(G1, G2, amt));
-      var BOut = Math.round(pub.lerp(B1, B2, amt));
-      return pub.color(ROut, GOut, BOut);
-
-    } else {
-      error("lerpColor(), both colors must be either CMYK or RGB.");
-    }
-  } else {
-    error("lerpColor(), wrong parameters. Use: two colors (of the same type) and a number.");
-  }
-};
-
-  The Lorem ipsum string of LOREM is taken from https://indieweb.org/Lorem_ipsum and
-// ----------------------------------------
-// src/includes/typography.js
-// ----------------------------------------
-
-/**
- * @description Creates a text frame on the current layer on the current page in the current document.
- * The text frame gets created in the position specified by the x and y parameters.
- * The default document font will be used unless a font is set with the textFont() function.
- * The default document font size will be used unless a font size is set with the textSize() function.
- * Change the color of the text with the fill() function.
- * The text displays in relation to the textAlign() and textYAlign() functions.
- * The width and height parameters define a rectangular area.
- *
- * @cat    Typography
- * @method text
- * @param  {String} txt The text content to set in the text frame.
- * @param  {Number} x   x-coordinate of text frame
- * @param  {Number} y   y-coordinate of text frame
- * @param  {Number} w   width of text frame
- * @param  {Number} h   height of text frame
- * @return {TextFrame}  The created text frame instance
- */
-pub.text = function(txt, x, y, w, h) {
-  if (arguments.length !== 5) {
-    error("text(), not enough parameters to draw a text! Use: text(txt, x, y, w, h)");
-  }
-  if (!(isString(txt) || isNumber(txt))) {
-    warning("text(), the first parameter has to be a string! But is something else: " + typeof txt + ". Use: text(txt, x, y, w, h)");
-  }
-
-  var textBounds = [];
-  if (currRectMode === pub.CORNER) {
-    textBounds[0] = y;
-    textBounds[1] = x;
-    textBounds[2] = y + h;
-    textBounds[3] = x + w;
-  } else if (currRectMode === pub.CORNERS) {
-    textBounds[0] = y;
-    textBounds[1] = x;
-    textBounds[2] = h;
-    textBounds[3] = w;
-  } else if (currRectMode === pub.CENTER) {
-    textBounds[0] = y - (h / 2);
-    textBounds[1] = x - (w / 2);
-    textBounds[2] = y + (h / 2);
-    textBounds[3] = x + (w / 2);
-  } else if (currRectMode === pub.RADIUS) {
-    textBounds[0] = y - h;
-    textBounds[1] = x - w;
-    textBounds[2] = y + h;
-    textBounds[3] = x + w;
-  }
-
-  var textFrame = currentPage().textFrames.add(currentLayer());
-  textFrame.contents = txt.toString();
-  textFrame.geometricBounds = textBounds;
-  textFrame.textFramePreferences.verticalJustification = currYAlign;
-
-  pub.typo(textFrame, {
-    appliedFont: currFont,
-    pointSize: currFontSize,
-    fillColor: currFillColor,
-    justification: currAlign,
-    leading: currLeading,
-    kerningValue: currKerning,
-    tracking: currTracking
-  });
-
-
-  if (currRectMode === pub.CENTER || currRectMode === pub.RADIUS) {
-    textFrame.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
-                       AnchorPoint.CENTER_ANCHOR,
-                       currMatrix.adobeMatrix(x, y));
-  } else {
-    textFrame.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
-                   AnchorPoint.TOP_LEFT_ANCHOR,
-                   currMatrix.adobeMatrix(x, y));
-  }
-
-  return textFrame;
-};
-
-/**
- * @description Sets text properties to the given item. If the item is not an instance the text property can be set to,
- * the property gets set to the direct descendants of the given item, e.g. all stories of a given document.
- * <br><br>
- * If no value is given and the given property is a string, the function acts as a getter and returns the
- * corresponding value(s) in an array. This can either be an array containing the value of the concrete item
- * (e.g. character) the values of the item's descendants (e.g. paragraphs of given text frame).
- *
- * @cat    Typography
- * @method typo
- * @param  {Document|Spread|Page|Layer|Story|TextFrame|Text} item  The object to apply the property to.
- * @param  {String|Object} property  The text property name or an object of key/value property/value pairs.
- *                                   If property is a string and no value is given, the function acts as getter.
- * @param  {String|Number|Object} [value]  The value to apply to the property.
- * @return {String[]|Number[]|Object[]}  The property value(s) if the function acts as getter or the items the property
- *                                       was assigned to.
- */
-pub.typo = function(item, property, value) {
-  var result = [],
-    actsAsGetter = typeof property === "string" && (value === undefined || value === null),
-    getOrSetProperties = function(textItem) {
-      if (actsAsGetter) {
-        result.push(textItem[property]);
-      } else {
-        setProperties(textItem);
-      }
-    },
-    setProperties = function(textItem) {
-      if (typeof property === "string") {
-        result.push(textItem);
-        setProperty(textItem, property, value);
-      } else if (typeof property === "object") {
-        result.push(textItem);
-        for (var prop in property) {
-          setProperty(textItem, prop, property[prop]);
-        }
-      }
-    },
-    setProperty = function(textItem, prop, val) {
-      textItem[prop] = val;
-    };
-
-  if(typeof item === "string") error("typo() cannot work on strings. Please pass a Text object to modify.");
-
-  if(!isValid(item)) {
-    warning("typo(), invalid object passed");
-    return;
-  }
-
-  if (item instanceof Document ||
-      item instanceof Spread ||
-      item instanceof Page ||
-      item instanceof Layer) {
-    forEach(item.textFrames, function(textFrame) {
-      pub.typo(textFrame, property, value);
-    });
-  } else if (item instanceof Story ||
-             item instanceof TextFrame) {
-    var paras = item.paragraphs;
-    // loop backwards to prevent invalid object reference error when
-    // start of para is overflown in "invisible" textFrame area after
-    // applying prop to previous para(s)
-    for (var i = paras.length - 1; i >= 0; i--) {
-      getOrSetProperties(paras[i]);
-    }
-  } else if (isText(item)) {
-    getOrSetProperties(item);
-  }
-  return result;
-};
-
-var isValid = function (item) {
-
-  checkNull(item);
-
-  if (item.hasOwnProperty("isValid")) {
-    if (!item.isValid) {
-      return false;
-    } else {
-      return true;
-    }
-  }
-  return true; // if does not have isValid field -> normal array element and not collection
-
-  return false;
-};
-
-/**
- * @description Returns the current font and sets it if argument fontName is given.
- *
- * @cat    Typography
- * @method textFont
- * @param  {String} [fontName] The name of the font to set e.g. Helvetica
- * @param  {String} [fontStyle] The font style e.g. Bold
- * @return {Font} The current font object
- */
-pub.textFont = function(fontName, fontStyle) {
-
-  if (arguments.length === 2) {
-    fontName = fontName + "\t" + fontStyle;
-  } else if (arguments.length === 1) {
-    fontName = fontName + "\tRegular";
-  } else if (arguments.length === 0) {
-    return currFont;
-  } else {
-    error("textFont(), wrong parameters. To set font use: fontName, fontStyle. fontStyle is optional.");
-  }
-
-  if(app.fonts.itemByName(fontName).status !== FontStatus.INSTALLED) {
-    warning("textFont(), font \"" + fontName.replace("\t", " ") + "\" not installed. "
-      + "Using current font \"" + currFont.fontFamily + " " + currFont.fontStyleName + "\" instead.");
-  } else {
-    currFont = app.fonts.itemByName(fontName);
-  }
-
-  return currFont;
-};
-
-/**
- * @description Returns the current font size in points and sets it if argument pointSize is given.
- *
- * @cat    Typography
- * @method textSize
- * @param  {Number} [pointSize] The size in points to set.
- * @return {Number}             The current point size.
- */
-pub.textSize = function(pointSize) {
-  if (arguments.length === 1) {
-    currFontSize = pointSize;
-  }
-  return currFontSize;
-};
-
-/**
- * @description Sets the current horizontal and vertical text alignment.
- *
- * @cat    Typography
- * @method textAlign
- * @param  {String} align    The horizontal text alignment to set. Must be one of the InDesign Justification enum values:
- *                           Justification.AWAY_FROM_BINDING_SIDE<br>
- *                           Justification.CENTER_ALIGN<br>
- *                           Justification.CENTER_JUSTIFIED<br>
- *                           Justification.FULLY_JUSTIFIED<br>
- *                           Justification.LEFT_ALIGN<br>
- *                           Justification.RIGHT_ALIGN<br>
- *                           Justification.RIGHT_JUSTIFIED<br>
- *                           Justification.TO_BINDING_SIDE<br>
- * @param  {String} [yAlign] The vertical text alignment to set. Must be one of the InDesign VerticalJustification enum values:
- *                           VerticalJustification.BOTTOM_ALIGN<br>
- *                           VerticalJustification.CENTER_ALIGN<br>
- *                           VerticalJustification.JUSTIFY_ALIGN<br>
- *                           VerticalJustification.TOP_ALIGN<br>
- */
-pub.textAlign = function(align, yAlign) {
-  currAlign = align;
-  if (arguments.length === 2) currYAlign = yAlign;
-};
-
-/**
- * @description Returns the spacing between lines of text in units of points and sets it if argument leading is given.
- *
- * @cat    Typography
- * @method textLeading
- * @param  {Number|String} [leading] The spacing between lines of text in units of points or the default InDesign enum
- *                                   value Leading.AUTO.
- * @return {Number|String}           The current leading.
- */
-pub.textLeading = function(leading) {
-  if (arguments.length === 1) {
-    currLeading = leading;
-  }
-  return currLeading;
-};
-
-/**
- * @description Returns the current kerning and sets it if argument kerning is given.
- *
- * @cat    Typography
- * @method textKerning
- * @param  {Number} [kerning] The value to set.
- * @return {Number}           The current kerning.
- */
-pub.textKerning = function(kerning) {
-  if (arguments.length === 1) {
-    currKerning = kerning;
-  }
-  return currKerning;
-};
-
-/**
- * @description Returns the current tracking and sets it if argument tracking is given.
- *
- * @cat    Typography
- * @method textTracking
- * @param  {Number} [tracking] The value to set.
- * @return {Number}            The current tracking.
- */
-pub.textTracking = function(tracking) {
-  if (arguments.length === 1) {
-    currTracking = tracking;
-  }
-  return currTracking;
-};
-
-/**
- * @description Returns the character style of a given text object or the character style with the given name. If a
- * character style of the given name does not exist, it gets created. Optionally a props object of
- * property name/value pairs can be used to set the character style's properties.
- *
- * @cat    Typography
- * @method characterStyle
- * @param  {Text|String} textOrName  A text object whose style to return or the name of the character style to return.
- * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
- * @return {CharacterStyle}  The character style instance.
- */
-pub.characterStyle = function(textOrName, props) {
-  var styleErrorMsg = "characterStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
-
-  if(!arguments || arguments.length > 2) {
-    error(styleErrorMsg);
-  }
-
-  var style;
-  if(isText(textOrName)) {
-    // text object is given
-    style = textOrName.appliedCharacterStyle;
-  } else if(isString(textOrName)) {
-    // name is given
-    style = findInStylesByName(currentDoc().allCharacterStyles, textOrName);
-    if(!style) {
-      style = currentDoc().characterStyles.add({name: textOrName});
-    }
-  } else {
-    error(styleErrorMsg);
-  }
-
-  if(props) {
-    try {
-      style.properties = props;
-    } catch (e) {
-      error("characterStyle(), wrong props parameter. Use object of property name/value pairs.");
-    }
-  }
-
-  return style;
-};
-
-/**
- * @description Applies a character style to the given text object, text frame or story. The character style
- * can be given as name or as character style instance.
- *
- * @cat    Typography
- * @method applyCharacterStyle
- * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
- * @param  {CharacterStyle|String} style  A character style instance or the name of the character style to apply.
- * @return {Text}  The text that the style was applied to.
- */
-
-pub.applyCharacterStyle = function(text, style) {
-
-  if(isString(style)) {
-    var name = style;
-    style = findInStylesByName(currentDoc().allCharacterStyles, name);
-    if(!style) {
-      error("applyCharacterStyle(), a character style named \"" + name + "\" does not exist.");
-    }
-  }
-
-  if(!(pub.isText(text) || text instanceof TextFrame || text instanceof Story) || !(style instanceof CharacterStyle)) {
-    error("applyCharacterStyle(), wrong parameters. Use: textObject|textFrame|story, characterStyle|name");
-  }
-
-  if(text instanceof TextFrame) {
-    text = text.characters.everyItem();
-  }
-
-  text.appliedCharacterStyle = style;
-
-  return text;
-};
-
-/**
- * @description Returns the paragraph style of a given text object or the paragraph style with the given name. If a
- * paragraph style of the given name does not exist, it gets created. Optionally a props object of
- * property name/value pairs can be used to set the paragraph style's properties.
- *
- * @cat    Typography
- * @method paragraphStyle
- * @param  {Text|String} textOrName  A text object whose style to return or the name of the paragraph style to return.
- * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
- * @return {ParagraphStyle}  The paragraph style instance.
- */
-pub.paragraphStyle = function(textOrName, props) {
-  var styleErrorMsg = "paragraphStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
-
-  if(!arguments || arguments.length > 2) {
-    error(styleErrorMsg);
-  }
-
-  var style;
-  if(isText(textOrName)) {
-    // text object is given
-    style = textOrName.appliedParagraphStyle;
-  } else if(isString(textOrName)) {
-    // name is given
-    style = findInStylesByName(currentDoc().allParagraphStyles, textOrName);
-    if(!style) {
-      style = currentDoc().paragraphStyles.add({name: textOrName});
-    }
-  } else {
-    error(styleErrorMsg);
-  }
-
-  if(props) {
-    try {
-      style.properties = props;
-    } catch (e) {
-      error("paragraphStyle(), wrong props parameter. Use object of property name/value pairs.");
-    }
-  }
-
-  return style;
-};
-
-/**
- * @description Applies a paragraph style to the given text object, text frame or story. The paragraph style
- * can be given as name or as paragraph style instance.
- *
- * @cat    Typography
- * @method applyParagraphStyle
- * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
- * @param  {ParagraphStyle|String} style  A paragraph style instance or the name of the paragraph style to apply.
- * @return {Text}  The text that the style was applied to.
- */
-
-pub.applyParagraphStyle = function(text, style) {
-
-  if(isString(style)) {
-    var name = style;
-    style = findInStylesByName(currentDoc().allParagraphStyles, name);
-    if(!style) {
-      error("applyParagraphStyle(), a paragraph style named \"" + name + "\" does not exist.");
-    }
-  }
-
-  if(!(pub.isText(text) || text instanceof TextFrame || text instanceof Story) || !(style instanceof ParagraphStyle)) {
-    error("applyParagraphStyle(), wrong parameters. Use: textObject|textFrame|story, paragraphStyle|name");
-  }
-
-  if(text instanceof TextFrame) {
-    text = text.paragraphs.everyItem();
-  }
-
-  text.appliedParagraphStyle = style;
-
-  return text;
-};
-
-/**
- * @description Links the stories of two textframes to one story. Text of first textframe overflows to second one.
- *
- * @cat    Story
- * @method linkTextFrames
- * @param  {TextFrame} textFrameA
- * @param  {TextFrame} textFrameB
- */
-pub.linkTextFrames = function (textFrameA, textFrameB) {
-  if (textFrameA instanceof TextFrame && textFrameB instanceof TextFrame) {
-    textFrameA.nextTextFrame = textFrameB;
-  } else {
-    error("linkTextFrames(), wrong type of parameter! linkTextFrames() needs two textFrame objects to link the stories. Use: textFrameA, textFrameB");
-  }
-};
-
-/**
- * @description Fills the given textFrame and all linked textFrame with random placeholder text. The placeholder text will be added at the end of any already existing text in the text frame.
- *
- * @cat    Story
- * @method placeholder
- * @param  {TextFrame} textFrame
- * @return {Text} The inserted placeholder text.
- */
-pub.placeholder = function (textFrame) {
-  if (textFrame instanceof TextFrame) {
-    var startIx = textFrame.parentStory.insertionPoints[-1].index;
-    textFrame.contents = TextFrameContents.PLACEHOLDER_TEXT;
-    var endIx = textFrame.parentStory.insertionPoints[-1].index - 1;
-    return textFrame.parentStory.characters.itemByRange(startIx, endIx);
-  } else {
-    error("placeholder(), wrong type of parameter! Use: textFrame");
-  }
-};
-  is available under a CC0 public domain dedication.
-// ----------------------------------------
-// src/includes/image.js
-// ----------------------------------------
-
-/**
- * @description Adds an image to the document. If the image argument is given as a string the image file must be in the document's
- * data directory which is in the same directory where the document is saved in. The image argument can also be a File
- * instance which can be placed even before the document was saved.
- * The second argument can either be the x position of the frame to create or an instance of a rectangle,
- * oval or polygon to place the image in. If an x position is given, a y position must be given, too.
- * If x and y positions are given and width and height are not given, the frame's size gets set to the original image size.
- *
- * @cat    Document
- * @subcat Image
- * @method image
- * @param  {String|File} img The image file name in the document's data directory or a File instance.
- * @param  {Number|Rectangle|Oval|Polygon} x The x position on the current page or the item instance to place the image in.
- * @param  {Number} [y] The y position on the current page. Ignored if x is not a number.
- * @param  {Number} [w] The width of the rectangle to add the image to. Ignored if x is not a number.
- * @param  {Number} [h] The height of the rectangle to add the image to. Ignored if x is not a number.
- * @return {Rectangle|Oval|Polygon} The item instance the image was placed in.
- */
-pub.image = function(img, x, y, w, h) {
-  var file = initDataFile(img),
-    frame = null,
-    fitOptions = null,
-    width = null,
-    height = null,
-    imgErrorMsg = "image(), wrong parameters. Use:\n"
-      + "image( {String|File}, {Rectangle|Oval|Polygon} ) or\n"
-      + "image( {String|File}, x, y ) or\n"
-      + "image( {String|File}, x, y, w, h )";
-
-  if(arguments.length < 2 || arguments.length === 4 || arguments.length > 5) error(imgErrorMsg);
-
-  if (x instanceof Rectangle ||
-      x instanceof Oval ||
-      x instanceof Polygon) {
-    frame = x;
-    fitOptions = FitOptions.FILL_PROPORTIONALLY;
-  } else if (typeof x === "number" && typeof y === "number") {
-    width = 1;
-    height = 1;
-    if (currImageMode === pub.CORNERS) {
-      if (typeof w === "number" && typeof h === "number") {
-        width = w - x;
-        height = h - y;
-        fitOptions = FitOptions.FILL_PROPORTIONALLY;
-      } else if (arguments.length === 3) {
-        fitOptions = FitOptions.frameToContent;
-      } else {
-        error(imgErrorMsg);
-      }
-    } else {
-      if (typeof w === "number" && typeof h === "number") {
-        if (w <= 0 || h <= 0) error("image(), invalid parameters. When using image(img, x, y, w, h) with the default imageMode CORNER, parameters w and h need to be greater than 0.");
-        width = w;
-        height = h;
-        fitOptions = FitOptions.FILL_PROPORTIONALLY;
-      } else if (arguments.length === 3) {
-        fitOptions = FitOptions.frameToContent;
-      } else {
-        error(imgErrorMsg);
-      }
-    }
-
-    frame = currentPage().rectangles.add(currentLayer(),
-      {geometricBounds:[y, x, y + height, x + width]}
-    );
-  } else {
-    error(imgErrorMsg);
-  }
-
-  frame.place(file);
-
-  if (fitOptions) {
-    frame.fit(fitOptions);
-  }
-
-  if (currImageMode === pub.CENTER) {
-    var bounds = frame.geometricBounds;
-    width = bounds[3] - bounds[1];
-    height = bounds[2] - bounds[0];
-    frame.move(null, [-(width / 2), -(height / 2)]);
-    frame.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
-                       AnchorPoint.CENTER_ANCHOR,
-                       currMatrix.adobeMatrix(x, y));
-  } else {
-    frame.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
-                   AnchorPoint.TOP_LEFT_ANCHOR,
-                   currMatrix.adobeMatrix(x, y));
-  }
-
-
-  frame.strokeWeight = currStrokeWeight;
-  frame.strokeTint = currStrokeTint;
-  frame.strokeColor = currStrokeColor;
-
-  return frame;
-};
-
-/**
- * @description Modifies the location from which images draw. The default mode is imageMode(CORNER), which specifies the location to be the upper left corner and uses the fourth and fifth parameters of image() to set the image's width and height. The syntax imageMode(CORNERS) uses the second and third parameters of image() to set the location of one corner of the image and uses the fourth and fifth parameters to set the opposite corner. Use imageMode(CENTER) to draw images centered at the given x and y position.
- * If no parameter is passed the currently set mode is returned as String.
- *
- * @cat    Document
- * @subcat Image
- * @method imageMode
- * @param  {String} [mode] Either CORNER, CORNERS, or CENTER.
- * @return {String} The current mode.
- */
-pub.imageMode = function(mode) {
-  if (arguments.length === 0) return currImageMode;
-
-  if (mode === pub.CORNER || mode === pub.CORNERS || mode === pub.CENTER) {
-    currImageMode = mode;
-  } else {
-    error("imageMode(), unsupported imageMode. Use: CORNER, CORNERS, CENTER.");
-  }
-  return currImageMode;
-};
-
-// ----------------------------------------
-// src/includes/math.js
-// ----------------------------------------
-
-var Vector = pub.Vector = function() {
-
-  /**
-   * @description A class to describe a two or three dimensional vector. This datatype stores two or three variables that are commonly used as a position, velocity, and/or acceleration. Technically, position is a point and velocity and acceleration are vectors, but this is often simplified to consider all three as vectors. For example, if you consider a rectangle moving across the screen, at any given instant it has a position (the object's location, expressed as a point.), a velocity (the rate at which the object's position changes per time unit, expressed as a vector), and acceleration (the rate at which the object's velocity changes per time unit, expressed as a vector). Since vectors represent groupings of values, we cannot simply use traditional addition/multiplication/etc. Instead, we'll need to do some "vector" math, which is made easy by the methods inside the Vector class.
-   * <br><br>
-   * Constructor of Vector, can be two- or three-dimensional.
-   *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector
-   * @param  {Number} x The first vector.
-   * @param  {Number} y The second vector.
-   * @param  {Number} [z] The third vector.
-   * @constructor
-   */
-  function Vector(x, y, z) {
-    this.x = x || 0;
-    this.y = y || 0;
-    this.z = z || 0;
-  }
-  /**
-   * @description Static function. Calculates the Euclidean distance between two points (considering a point as a vector object).
-   * Is meant to be called "static" i.e. Vector.dist(v1, v2);
-   *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.dist
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The distance.
-   * @static
-   */
-  Vector.dist = function(v1, v2) {
-    return v1.dist(v2);
-  };
-
-  /**
-   * @description Static function. Calculates the dot product of two vectors.
-   * Is meant to be called "static" i.e. Vector.dot(v1, v2);
-   *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.dot
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The dot product.
-   * @static
-   */
-  Vector.dot = function(v1, v2) {
-    return v1.dot(v2);
-  };
-
-  /**
-   * @description Static function. Calculates the cross product of two vectors.
-   * Is meant to be called "static" i.e. Vector.cross(v1, v2);
-   *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.cross
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The cross product.
-   * @static
-   */
-  Vector.cross = function(v1, v2) {
-    return v1.cross(v2);
-  };
-
-  /**
-   * @description Static function. Calculates the angle between two vectors.
-   * Is meant to be called "static" i.e. Vector.angleBetween(v1, v2);
-   *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.angleBetween
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The angle.
-   * @static
-   */
-  Vector.angleBetween = function(v1, v2) {
-    return Math.acos(v1.dot(v2) / (v1.mag() * v2.mag()));
-  };
-
-  Vector.prototype = {
-
-    /**
-     * @description Sets the x, y, and z component of the vector using three separate variables, the data from a Vector, or the values from a float array.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.set
-     * @param  {Number|Array|Vector} v Either a vector, array or x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     */
-    set: function(v, y, z) {
-      if (arguments.length === 1) this.set(v.x || v[0] || 0, v.y || v[1] || 0, v.z || v[2] || 0);
-      else {
-        this.x = v;
-        this.y = y;
-        this.z = z;
-      }
-    },
-    /**
-     * @description Gets a copy of the vector, returns a Vector object.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.get
-     * @return {Vector} A copy of the vector.
-     */
-    get: function() {
-      return new Vector(this.x, this.y, this.z);
-    },
-    /**
-     * @description Calculates the magnitude (length) of the vector and returns the result as a float
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.mag
-     * @return {Number} The length.
-     */
-    mag: function() {
-      var x = this.x,
-        y = this.y,
-        z = this.z;
-      return Math.sqrt(x * x + y * y + z * z);
-    },
-    /**
-     * @description Adds x, y, and z components to a vector, adds one vector to another.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.add
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     */
-    add: function(v, y, z) {
-      if (arguments.length === 1) {
-        this.x += v.x;
-        this.y += v.y;
-        this.z += v.z;
-      } else {
-        this.x += v;
-        this.y += y;
-        this.z += z;
-      }
-    },
-    /**
-     * @description Substract x, y, and z components or a full vector from this vector
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.sub
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     */
-    sub: function(v, y, z) {
-      if (arguments.length === 1) {
-        this.x -= v.x;
-        this.y -= v.y;
-        this.z -= v.z;
-      } else {
-        this.x -= v;
-        this.y -= y;
-        this.z -= z;
-      }
-    },
-    /**
-     * @description Multiplies this vector with x, y, and z components or another vector.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.mult
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     */
-    mult: function(v) {
-      if (typeof v === "number") {
-        this.x *= v;
-        this.y *= v;
-        this.z *= v;
-      } else {
-        this.x *= v.x;
-        this.y *= v.y;
-        this.z *= v.z;
-      }
-    },
-    /**
-     * @description Divides this vector through x, y, and z components or another vector.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.div
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     */
-    div: function(v) {
-      if (typeof v === "number") {
-        this.x /= v;
-        this.y /= v;
-        this.z /= v;
-      } else {
-        this.x /= v.x;
-        this.y /= v.y;
-        this.z /= v.z;
-      }
-    },
-    /**
-     * @description Calculates the distance from this vector to another as x, y, and z components or full vector.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.dist
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     * @return {Number} The distance.
-     */
-    dist: function(v) {
-      var dx = this.x - v.x,
-        dy = this.y - v.y,
-        dz = this.z - v.z;
-      return Math.sqrt(dx * dx + dy * dy + dz * dz);
-    },
-    /**
-     * @description Calculates the dot product from this vector to another as x, y, and z components or full vector.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.dot
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     * @return {Number} The dot product.
-     */
-    dot: function(v, y, z) {
-      if (arguments.length === 1) return this.x * v.x + this.y * v.y + this.z * v.z;
-      return this.x * v + this.y * y + this.z * z;
-    },
-    /**
-     * @description Calculates the cross product from this vector to another as x, y, and z components or full vector.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.cross
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     * @return {Number} The cross product.
-     */
-    cross: function(v) {
-      var x = this.x,
-        y = this.y,
-        z = this.z;
-      return new Vector(y * v.z - v.y * z, z * v.x - v.z * x, x * v.y - v.x * y);
-    },
-    /**
-     * @description Normalizes the length of this vector to 1.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.normalize
-     */
-    normalize: function() {
-      var m = this.mag();
-      if (m > 0) this.div(m);
-    },
-    /**
-     * @description Normalizes the length of this vector to the given parameter.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.limit
-     * @param  {Number} high The value to scale to.
-     */
-    limit: function(high) {
-      if (this.mag() > high) {
-        this.normalize();
-        this.mult(high);
-      }
-    },
-    /**
-     * @description The 2D orientation (heading) of this vector in radian.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.heading
-     * @return {Number} A radian angle value.
-     */
-    heading: function() {
-      return -Math.atan2(-this.y, this.x);
-    },
-    /**
-     * @description Returns data about this vector as a string.
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.toString
-     * @return {String} The x, y and z components as a string.
-     */
-    toString: function() {
-      return "[" + this.x + ", " + this.y + ", " + this.z + "]";
-    },
-    /**
-     * @description Returns this vector as an array [x,y,z].
-     *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.array
-     * @return {Array} The x, y and z components as  an Array of [x,y,z].
-     */
-    array: function() {
-      return [this.x, this.y, this.z];
-    }
-  };
-
-  function createVectorMethod(method) {
-    return function(v1, v2) {
-      var v = v1.get();
-      v[method](v2);
-      return v;
-    };
-  }
-  for (var method in Vector.prototype) if (Vector.prototype.hasOwnProperty(method) && !Vector.hasOwnProperty(method)) Vector[method] = createVectorMethod(method);
-  return Vector;
-}();
-
-
-// -- Calculation --
-
-/**
- * @description Calculates the absolute value (magnitude) of a number. The absolute value of a number is always positive.
- *
- * @cat    Math
- * @subcat Calculation
- * @method abs
- * @param  {Number} val A number.
- * @return {Number} The absolute value of that number.
- */
-pub.abs = Math.abs;
-
-/**
- * @description Calculates the closest int value that is greater than or equal to the value of the parameter. For example, ceil(9.03) returns the value 10.
- *
- * @cat    Math
- * @subcat Calculation
- * @method ceil
- * @param  {Number} val An arbitrary number.
- * @return {Number} The next highest integer value.
- */
-pub.ceil = Math.ceil;
-
-/**
- * @description Constrains a value to not exceed a maximum and minimum value.
- *
- * @cat    Math
- * @subcat Calculation
- * @method constrain
- * @param  {Number} aNumber The value to constrain.
- * @param  {Number} aMin Minimum limit.
- * @param  {Number} aMax Maximum limit.
- * @return {Number} The constrained value.
- */
-pub.constrain = function(aNumber, aMin, aMax) {
-  if(arguments.length !== 3) error("constrain(), wrong argument count.");
-  if(aNumber <= aMin) return aMin;
-  if(aNumber >= aMax) return aMax;
-  return aNumber;
-};
-
-/**
- * @description Calculates the distance between two points.
- *
- * @cat    Math
- * @subcat Calculation
- * @method dist
- * @param  {Number} x1 The x-coordinate of the first point.
- * @param  {Number} y1 The y-coordinate of the first point.
- * @param  {Number} x2 The x-coordinate of the second point.
- * @param  {Number} y2 The y-coordinate of the second point.
- * @return {Number} The distance.
- */
-pub.dist = function() {
-  var dx, dy, dz;
-  if (arguments.length === 4) {
-    dx = arguments[0] - arguments[2];
-    dy = arguments[1] - arguments[3];
-    return Math.sqrt(dx * dx + dy * dy);
-  } else {
-    error("dist(), wrong argument count.");
-  }
-};
-
-/**
- * @description The Math.exp() function returns ex, where x is the argument, and e is Euler's number (also known as Napier's constant), the base of the natural logarithms.
- *
- * @cat    Math
- * @subcat Calculation
- * @method exp
- * @param  {Number} x A number.
- * @return {Number} A number representing ex.
- */
-pub.exp = Math.exp;
-
-/**
- * @description Calculates the closest int value that is less than or equal to the value of the parameter.
- *
- * @cat    Math
- * @subcat Calculation
- * @method floor
- * @param  {Number} a A number.
- * @return {Number} Integer number.
- */
-pub.floor = Math.floor;
-
-/**
- * @description Calculates a number between two numbers at a specific increment. The amt parameter is the amount to interpolate between the two values where 0.0 equal to the first point, 0.1 is very near the first point, 0.5 is half-way in between, etc. The lerp function is convenient for creating motion along a straight path and for drawing dotted lines.
- *
- * @cat    Math
- * @subcat Calculation
- * @method lerp
- * @param  {Number} value1 First value.
- * @param  {Number} value2 Second value.
- * @param  {Number} amt Amount between 0.0 and 1.0.
- * @return {Number} The mapped value.
- */
-pub.lerp = function(value1, value2, amt) {
-  if(arguments.length !== 3) error("lerp(), wrong argument count.");
-  return (value2 - value1) * amt + value1;
-};
-
-/**
- * @description Calculates the natural logarithm (the base-e logarithm) of a number. This function expects the values greater than 0.0.
- *
- * @cat    Math
- * @subcat Calculation
- * @method log
- * @param  {Number} x A number, must be greater then 0.0.
- * @return {Number} The natural logarithm.
- */
-pub.log = Math.log;
-
-/**
- * @description Calculates the magnitude (or length) of a vector. A vector is a direction in space commonly used in computer graphics and linear algebra. Because it has no "start" position, the magnitude of a vector can be thought of as the distance from coordinate (0,0) to its (x,y) value. Therefore, mag() is a shortcut for writing "dist(0, 0, x, y)".
- *
- * @cat    Math
- * @subcat Calculation
- * @method mag
- * @param  {Number} x Coordinate.
- * @param  {Number} y Coordinate.
- * @param  {Number} [z] Coordinate, optional.
- * @return {Number} The magnitude.
- */
-pub.mag = function(a, b, c) {
-  if(!(arguments.length === 2 || arguments.length === 3)) error("mag(), wrong argument count.");
-  if (c) return Math.sqrt(a * a + b * b + c * c);
-  return Math.sqrt(a * a + b * b);
-};
-
-/**
- * @description Re-maps a number from one range to another.<br>
- * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
- *
- * @cat    Math
- * @subcat Calculation
- * @method map
- * @param  {Number} value The value to be mapped.
- * @param  {Number} istart The start of the input range.
- * @param  {Number} istop The end of the input range.
- * @param  {Number} ostart The start of the output range.
- * @param  {Number} ostop The end of the output range.
- * @return {Number} The mapped value.
- */
-pub.map = function(value, istart, istop, ostart, ostop) {
-  if(arguments.length !== 5) error("map(), wrong argument count. Use: map(value, istart, istop, ostart, ostop)");
-  return ostart + (ostop - ostart) * ((value - istart) / (istop - istart));
-};
-
-/**
- * @description Determines the largest value in a sequence of numbers.
- *
- * @cat    Math
- * @subcat Calculation
- * @method max
- * @param  {Number|Array} a A value or an array of Numbers.
- * @param  {Number} [b] Another value to be compared.
- * @param  {Number} [c] Another value to be compared.
- * @return {Number} The highest value.
- */
-pub.max = function() {
-  if (arguments.length === 2) return arguments[0] < arguments[1] ? arguments[1] : arguments[0];
-  var numbers = arguments.length === 1 ? arguments[0] : arguments;
-  if (!("length" in numbers && numbers.length > 0)) error("max(), non-empty array is expected");
-  var max = numbers[0],
-    count = numbers.length;
-  for (var i = 1; i < count; ++i) if (max < numbers[i]) max = numbers[i];
-  return max;
-};
-
-/**
- * @description Determines the smallest value in a sequence of numbers.
- *
- * @cat    Math
- * @subcat Calculation
- * @method min
- * @param  {Number|Array} a A value or an array of Numbers.
- * @param  {Number} [b] Another value to be compared.
- * @param  {Number} [c] Another value to be compared.
- * @return {Number} The lowest value.
- */
-pub.min = function() {
-  if (arguments.length === 2) return arguments[0] < arguments[1] ? arguments[0] : arguments[1];
-  var numbers = arguments.length === 1 ? arguments[0] : arguments;
-  if (!("length" in numbers && numbers.length > 0)) error("min(), non-empty array is expected");
-  var min = numbers[0],
-    count = numbers.length;
-  for (var i = 1; i < count; ++i) if (min > numbers[i]) min = numbers[i];
-  return min;
-};
-
-/**
- * @description Normalizes a number from another range into a value between 0 and 1.<br>
- * Identical to map(value, low, high, 0, 1);<br>
- * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
- *
- * @cat    Math
- * @subcat Calculation
- * @method norm
- * @param  {Number} aNumber The value to be normed.
- * @param  {Number} low The lowest value to be expected.
- * @param  {Number} high The highest value to be expected.
- * @return {Number} The normalized value.
- */
-pub.norm = function(aNumber, low, high) {
-  if(arguments.length !== 3) error("norm(), wrong argument count.");
-  return (aNumber - low) / (high - low);
-};
-
-/**
- * @description Facilitates exponential expressions. The pow() function is an efficient way of multiplying numbers by themselves (or their reciprocal) in large quantities. For example, pow(3, 5) is equivalent to the expression 3*3*3*3*3 and pow(3, -5) is equivalent to 1 / 3*3*3*3*3
- *
- * @cat    Math
- * @subcat Calculation
- * @method pow
- * @param  {Number} num Base of the exponential expression.
- * @param  {Number} exponent Power of which to raise the base.
- * @return {Number} the result
- */
-pub.pow = Math.pow;
-
-/**
- * @description Calculates the integer closest to the value parameter. For example, round(9.2) returns the value 9.
- *
- * @cat    Math
- * @subcat Calculation
- * @method round
- * @param  {Number} value The value to be rounded.
- * @return {Number} The rounded value.
- */
-pub.round = Math.round;
-
-/**
- * @description Squares a number (multiplies a number by itself). The result is always a positive number, as multiplying two negative numbers always yields a positive result. For example, -1 * -1 = 1.
- *
- * @cat    Math
- * @subcat Calculation
- * @method sq
- * @param  {Number} aNumber The value to be squared.
- * @return {Number} Squared number.
- */
-pub.sq = function(aNumber) {
-  if(arguments.length !== 1) error("sq(), wrong argument count.");
-  return aNumber * aNumber;
-};
-
-// -- Trigonometry --
-
-/**
- * @description Calculates the square root of a number. The square root of a number is always positive, even though there may be a valid negative root. The square root s of number a is such that s*s = a. It is the opposite of squaring.
- *
- * @cat    Math
- * @subcat Trigonometry
- * @method sqrt
- * @param  {Number} val A value.
- * @return {Number} Square root.
- */
-pub.sqrt = Math.sqrt;
-
-/**
- * @description The inverse of cos(), returns the arc cosine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
- *
- * @cat    Math
- * @subcat Trigonometry
- * @method acos
- * @param  {Number} value The value whose arc cosine is to be returned.
- * @return {Number} The arc cosine.
- */
-pub.acos = Math.acos;
-
-/**
- * @description The inverse of sin(), returns the arc sine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
- *
- * @cat    Math
- * @subcat Trigonometry
- * @method asin
- * @param  {Number} value The value whose arc sine is to be returned.
- * @return {Number} The arc sine.
- */
-pub.asin = Math.asin;
-
-/**
- * @description The inverse of tan(), returns the arc tangent of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
- *
- * @cat    Math
- * @subcat Trigonometry
- * @method atan
- * @param  {Number} value The value whose arc tangent is to be returned.
- * @return {Number} The arc tangent.
- */
-pub.atan = Math.atan;
-
-/**
- * @description Calculates the angle (in radians) from a specified point to the coordinate origin as measured from the positive x-axis. Values are returned as a float in the range from PI to -PI. The atan2() function is most often used for orienting geometry to the position of the cursor. Note: The y-coordinate of the point is the first parameter and the x-coordinate is the second due the the structure of calculating the tangent.
- *
- * @cat    Math
- * @subcat Trigonometry
- * @method atan2
- * @param  {Number} y The y coordinate.
- * @param  {Number} x The x coordinate.
- * @return {Number} The atan2 value.
- */
-pub.atan2 = Math.atan2;
-
-/**
- * @description Calculates the cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range -1 to 1.
- *
- * @cat    Math
- * @subcat Trigonometry
- * @method cos
- * @param  {Number} rad A value in radians.
- * @return {Number} The cosine.
- */
-pub.cos = Math.cos;
-
-/**
- * @description Converts a radian measurement to its corresponding value in degrees. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
- *
- * @cat    Math
- * @subcat Trigonometry
- * @method degrees
- * @param  {Number} aAngle An angle in radians.
- * @return {Number} The given angle in degree.
- */
-pub.degrees = function(aAngle) {
-  return aAngle * 180 / Math.PI;
-};
-
-/**
- * @description Converts a degree measurement to its corresponding value in radians. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
- *
- * @cat    Math
- * @subcat Trigonometry
- * @method radians
- * @param  {Number} aAngle An angle in degree.
- * @return {Number} The given angle in radians.
- */
-pub.radians = function(aAngle) {
-  return aAngle / 180 * Math.PI;
-};
-
-/**
- * @description Calculates the sine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to 6.28). Values are returned in the range -1 to 1.
- *
- * @cat    Math
- * @subcat Trigonometry
- * @method sin
- * @param  {Number} rad A value in radians.
- * @return {Number} The sine value.
- */
-pub.sin = Math.sin;
-
-/**
- * @description Calculates the ratio of the sine and cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range infinity to -infinity.
- *
- * @cat    Math
- * @subcat Trigonometry
- * @method tan
- * @param  {Number} rad A value in radians.
- * @return {Number} The tangent value.
- */
-pub.tan = Math.tan;
-
-// -- Random --
-
-var currentRandom = Math.random;
-
-/**
- * @description Generates random numbers. Each time the random() function is called, it returns an unexpected value within the specified range. If one parameter is passed to the function it will return a float between zero and the value of the high parameter. The function call random(5) returns values between 0 and 5. If two parameters are passed, it will return a float with a value between the the parameters. The function call random(-5, 10.2) returns values between -5 and 10.2.<br>
- * One parameter sets the range from 0 to the given parameter, while with two parameters present you set the range from val1 - val2.
- *
- * @cat    Math
- * @subcat Random
- * @method random
- * @param  {Number} [low] The low border of the range.
- * @param  {Number} [high] The high border of the range.
- * @return {Number} A random number.
- */
-pub.random = function() {
-  if (arguments.length === 0) return currentRandom();
-  if (arguments.length === 1) return currentRandom() * arguments[0];
-  var aMin = arguments[0],
-    aMax = arguments[1];
-  return currentRandom() * (aMax - aMin) + aMin;
-};
-
-function Marsaglia(i1, i2) {
-  var z = i1 || 362436069,
-    w = i2 || 521288629;
-  var nextInt = function() {
-    z = 36969 * (z & 65535) + (z >>> 16) & 4294967295;
-    w = 18E3 * (w & 65535) + (w >>> 16) & 4294967295;
-    return ((z & 65535) << 16 | w & 65535) & 4294967295;
-  };
-  this.nextDouble = function() {
-    var i = nextInt() / 4294967296;
-    return i < 0 ? 1 + i : i;
-  };
-  this.nextInt = nextInt;
-}
-Marsaglia.createRandomized = function() {
-  var now = new Date();
-  return new Marsaglia(now / 6E4 & 4294967295, now & 4294967295);
-};
-/**
- * @description Sets the seed value for random().<br>
- * By default, random() produces different results each time the program is run. Set the seed parameter to a constant to return the same pseudo-random numbers each time the software is run.
- *
- * @cat    Math
- * @subcat Random
- * @method randomSeed
- * @param  {Number} seed The seed value.
- */
-pub.randomSeed = function(seed) {
-  currentRandom = (new Marsaglia(seed)).nextDouble;
-};
-/**
- * @description Random Generator with Gaussian distribution.
- *
- * @cat    Math
- * @subcat Random
- * @method Random
- * @param  {Number} seed The seed value.
- * @constructor
- */
-pub.Random = function(seed) {
-  var haveNextNextGaussian = false,
-    nextNextGaussian, random;
-  /**
-   * @method Random.nextGaussian
-   * @return {Number} The next Gaussian random value.
-   */
-  this.nextGaussian = function() {
-    if (haveNextNextGaussian) {
-      haveNextNextGaussian = false;
-      return nextNextGaussian;
-    }
-    var v1, v2, s;
-    do {
-      v1 = 2 * random() - 1;
-      v2 = 2 * random() - 1;
-      s = v1 * v1 + v2 * v2;
-    } while (s >= 1 || s === 0);
-    var multiplier = Math.sqrt(-2 * Math.log(s) / s);
-    nextNextGaussian = v2 * multiplier;
-    haveNextNextGaussian = true;
-    return v1 * multiplier;
-  };
-  random = seed === undefined ? Math.random : (new Marsaglia(seed)).nextDouble;
-};
-
-function PerlinNoise(seed) {
-  var rnd = seed !== undefined ? new Marsaglia(seed) : Marsaglia.createRandomized();
-  var i, j;
-  var perm = [];
-  for (i = 0; i < 256; ++i) perm[i] = i;
-  for (i = 0; i < 256; ++i) {
-    var t = perm[j = rnd.nextInt() & 255];
-    perm[j] = perm[i];
-    perm[i] = t;
-  }
-  for (i = 0; i < 256; ++i) perm[i + 256] = perm[i];
-
-  function grad3d(i, x, y, z) {
-    var h = i & 15;
-    var u = h < 8 ? x : y,
-      v = h < 4 ? y : h === 12 || h === 14 ? x : z;
-    return ((h & 1) === 0 ? u : -u) + ((h & 2) === 0 ? v : -v);
-  }
-
-  function grad2d(i, x, y) {
-    var v = (i & 1) === 0 ? x : y;
-    return (i & 2) === 0 ? -v : v;
-  }
-
-  function grad1d(i, x) {
-    return (i & 1) === 0 ? -x : x;
-  }
-  function lerp(t, a, b) {
-    return a + t * (b - a);
-  }
-
-  this.noise3d = function(x, y, z) {
-    var X = Math.floor(x) & 255,
-      Y = Math.floor(y) & 255,
-      Z = Math.floor(z) & 255;
-    x -= Math.floor(x);
-    y -= Math.floor(y);
-    z -= Math.floor(z);
-    var fx = (3 - 2 * x) * x * x,
-      fy = (3 - 2 * y) * y * y,
-      fz = (3 - 2 * z) * z * z;
-    var p0 = perm[X] + Y,
-      p00 = perm[p0] + Z,
-      p01 = perm[p0 + 1] + Z,
-      p1 = perm[X + 1] + Y,
-      p10 = perm[p1] + Z,
-      p11 = perm[p1 + 1] + Z;
-    return lerp(fz, lerp(fy, lerp(fx, grad3d(perm[p00], x, y, z), grad3d(perm[p10], x - 1, y, z)), lerp(fx, grad3d(perm[p01], x, y - 1, z), grad3d(perm[p11], x - 1, y - 1, z))), lerp(fy, lerp(fx, grad3d(perm[p00 + 1], x, y, z - 1), grad3d(perm[p10 + 1], x - 1, y, z - 1)), lerp(fx, grad3d(perm[p01 + 1], x, y - 1, z - 1), grad3d(perm[p11 + 1], x - 1, y - 1, z - 1))));
-  };
-
-  this.noise2d = function(x, y) {
-    var X = Math.floor(x) & 255,
-      Y = Math.floor(y) & 255;
-    x -= Math.floor(x);
-    y -= Math.floor(y);
-    var fx = (3 - 2 * x) * x * x,
-      fy = (3 - 2 * y) * y * y;
-    var p0 = perm[X] + Y,
-      p1 = perm[X + 1] + Y;
-    return lerp(fy, lerp(fx, grad2d(perm[p0], x, y), grad2d(perm[p1], x - 1, y)), lerp(fx, grad2d(perm[p0 + 1], x, y - 1), grad2d(perm[p1 + 1], x - 1, y - 1)));
-  };
-
-  this.noise1d = function(x) {
-    var X = Math.floor(x) & 255;
-    x -= Math.floor(x);
-    var fx = (3 - 2 * x) * x * x;
-    return lerp(fx, grad1d(perm[X], x), grad1d(perm[X + 1], x - 1));
-  };
-}
-var noiseProfile = {
-  generator: undefined,
-  octaves: 4,
-  fallout: 0.5,
-  seed: undefined
-};
-
-/**
- * @description Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural ordered, harmonic succession of numbers compared to the standard random() function. It was invented by Ken Perlin in the 1980s and been used since in graphical applications to produce procedural textures, natural motion, shapes, terrains etc.
- * <br><br>
- * The main difference to the random() function is that Perlin noise is defined in an infinite n-dimensional space where each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. basil.js can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space. The 2nd and 3rd dimension can also be interpreted as time.
- * <br><br>
- * The actual noise is structured similar to an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, perlin noise is computed over several octaves which are added together for the final result.
- * <br><br>
- * Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space the value of the coordinates doesn't matter as such, only the distance between successive coordinates does (eg. when using noise() within a loop). As a general rule the smaller the difference between coordinates, the smoother the resulting noise sequence will be. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
- *
- * @cat    Math
- * @subcat Random
- * @method noise
- * @param  {Number} x Coordinate in x space.
- * @param  {Number} [y] Coordinate in y space.
- * @param  {Number} [z] Coordinate in z space.
- * @return {Number} The noise value.
- */
-pub.noise = function(x, y, z) {
-  if (noiseProfile.generator === undefined) noiseProfile.generator = new PerlinNoise(noiseProfile.seed);
-  var generator = noiseProfile.generator;
-  var effect = 1,
-    k = 1,
-    sum = 0;
-  for (var i = 0; i < noiseProfile.octaves; ++i) {
-    effect *= noiseProfile.fallout;
-    switch (arguments.length) {
-      case 1:
-        sum += effect * (1 + generator.noise1d(k * x)) / 2;
-        break;
-      case 2:
-        sum += effect * (1 + generator.noise2d(k * x, k * y)) / 2;
-        break;
-      case 3:
-        sum += effect * (1 + generator.noise3d(k * x, k * y, k * z)) / 2;
-        break;
-    }
-    k *= 2;
-  }
-  return sum;
-};
-
-/**
- * @description Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overal intensity of the noise, whereas higher octaves create finer grained details in the noise sequence. By default, noise is computed over 4 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the 1st octave. This falloff amount can be changed by adding an additional function parameter. Eg. a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. Any value between 0.0 and 1.0 is valid, however note that values greater than 0.5 might result in greater than 1.0 values returned by noise().
- * <br><br>
- * By changing these parameters, the signal created by the noise() function can be adapted to fit very specific needs and characteristics.
- *
- * @cat    Math
- * @subcat Random
- * @method noiseDetail
- * @param  {Number} octaves Number of octaves to be used by the noise() function.
- * @param  {Number} fallout Falloff factor for each octave.
- */
-pub.noiseDetail = function(octaves, fallout) {
-  noiseProfile.octaves = octaves;
-  if (fallout !== undefined) noiseProfile.fallout = fallout;
-};
-
-/**
- * @description Sets the seed value for noise(). By default, noise() produces different results each time the program is run. Set the value parameter to a constant to return the same pseudo-random numbers each time the software is run.
- *
- * @cat    Math
- * @subcat Random
- * @method noiseSeed
- * @param  {Number} seed Noise seed value.
- */
-pub.noiseSeed = function(seed) {
-  noiseProfile.seed = seed;
-  noiseProfile.generator = undefined;
-};
-
-
-// ----------------------------------------
-// Transform
-// geometricBounds hint: [y1, x1, y2, x2]
-
-var precision = function(num, dec) {
-  return Math.round(num * Math.pow(10, dec)) / Math.pow(10, dec);
-};
-
-/**
- * @description The function calculates the geometric bounds of any given page item or text. Use the `transforms()` function to modify page items.
- * In case the object is any kind of text, additional typographic information baseline and xHeight are calculated.
- *
- * @cat    Document
- * @subcat Transformation
- * @method bounds
- * @param  {PageItem|Text} obj The page item or text to calculate the geometric bounds.
- * @return {Object} Geometric bounds object with these properties: width, height, left, right, top, bottom and for text: baseline, xHeight.
- */
-pub.bounds = function (obj) {
-  var x1, y1, x2, y2, w, h;
-
-  if (isText(obj)) {
-    var baseline = obj.baseline;
-    var ascent = obj.ascent;
-    var descent = obj.descent;
-
-    x1 = obj.horizontalOffset;
-    y1 = baseline - ascent;
-    x2 = obj.endHorizontalOffset;
-    y2 = baseline + descent;
-    w = x2 - x1;
-    h = y2 - y1;
-
-    if (w < 0 || h < 0) {
-      warning("bounds(), not possible to get correct bounds, possible line break within textObj");
-    }
-
-    // We not sure if this 100% correct, check
-    // http://en.wikipedia.org/wiki/File:Typography_Line_Terms.svg
-    var xHeight = y1 + descent;
-
-    return {"width":w,
-            "height":h,
-            "left":x1,
-            "right":x2,
-            "top":y1,
-            "bottom":y2,
-            "baseline":baseline,
-            "xHeight":xHeight};
-  } else {
-    // is it a pageItem?
-    if (obj.hasOwnProperty("geometricBounds")) {
-      var geometricBounds = obj.geometricBounds; // [y1, x1, y2, x2]
-      x1 = geometricBounds[1];
-      y1 = geometricBounds[0];
-      x2 = geometricBounds[3];
-      y2 = geometricBounds[2];
-      w = x2 - x1;
-      h = y2 - y1;
-      return {"width":w, "height":h, "left":x1, "right":x2, "top":y1, "bottom":y2};
-    }
-    // everything else e.g. page, spread
-    else if (obj.hasOwnProperty("bounds")) {
-      var bounds = obj.bounds; // [y1, x1, y2, x2]
-      x1 = bounds[1];
-      y1 = bounds[0];
-      x2 = bounds[3];
-      y2 = bounds[2];
-      w = x2 - x1;
-      h = y2 - y1;
-      return {"width":w, "height":h, "left":x1, "right":x2, "top":y1, "bottom":y2};
-    }
-    // no idea what that might be, give up
-    else {
-      error("bounds(), invalide type of parameter! Can't get bounds for this object.");
-    }
-  }
-};
-
-
-  Supported Adobe InDesign versions: CS 5+
-
-  .--.--.- .-.-......-....--.-- -.... -..---.-.... .-- . .---.- -... -.-..---.-. ..--.-- -.. -
-*/
-/* globals init */
-// @target "InDesign";
-
-
-// ----------------------------------------
-// src/includes/transformation.js
-// ----------------------------------------
-/* global precision */
-
-/**
- * @description Sets the reference point for transformations using the `transform()` function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.<br>
- * Arguments can be the basil constants `TOP_LEFT`, `TOP_CENTER`, `TOP_RIGHT`, `CENTER_LEFT`, `CENTER`, `CENTER_RIGHT`, `BOTTOM_LEFT`, `BOTTOM_CENTER` or `BOTTOM_RIGHT`. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.<br>
- * If the function is used without any arguments the currently set reference point will be returned.
- *
- * @cat    Document
- * @subcat Transformation
- * @method referencePoint
- * @param  {String} [referencePoint] The reference point to set.
- * @return {String} Current reference point setting.
- */
-pub.referencePoint = function(rp) {
-  if(!arguments.length) {
-    return currRefPoint;
-  }
-
-  var anchorEnum;
-
-  if(rp === pub.TOP_LEFT || rp === 7 || rp === AnchorPoint.TOP_LEFT_ANCHOR) {
-    currRefPoint = pub.TOP_LEFT;
-    anchorEnum = AnchorPoint.TOP_LEFT_ANCHOR;
-  } else if(rp === pub.TOP_CENTER || rp === 8 || rp === AnchorPoint.TOP_CENTER_ANCHOR) {
-    currRefPoint = pub.TOP_CENTER;
-    anchorEnum = AnchorPoint.TOP_CENTER_ANCHOR;
-  } else if(rp === pub.TOP_RIGHT || rp === 9 || rp === AnchorPoint.TOP_RIGHT_ANCHOR) {
-    currRefPoint = pub.TOP_RIGHT;
-    anchorEnum = AnchorPoint.TOP_RIGHT_ANCHOR;
-  } else if(rp === pub.CENTER_LEFT || rp === 4 || rp === AnchorPoint.LEFT_CENTER_ANCHOR) {
-    currRefPoint = pub.CENTER_LEFT;
-    anchorEnum = AnchorPoint.LEFT_CENTER_ANCHOR;
-  } else if(rp === pub.CENTER || rp === pub.CENTER_CENTER || rp === 5 || rp === AnchorPoint.CENTER_ANCHOR) {
-    currRefPoint = pub.CENTER;
-    anchorEnum = AnchorPoint.CENTER_ANCHOR;
-  } else if(rp === pub.CENTER_RIGHT || rp === 6 || rp === AnchorPoint.RIGHT_CENTER_ANCHOR) {
-    currRefPoint = pub.CENTER_RIGHT;
-    anchorEnum = AnchorPoint.RIGHT_CENTER_ANCHOR;
-  } else if(rp === pub.BOTTOM_LEFT || rp === 1 || rp === AnchorPoint.BOTTOM_LEFT_ANCHOR) {
-    currRefPoint = pub.BOTTOM_LEFT;
-    anchorEnum = AnchorPoint.BOTTOM_LEFT_ANCHOR;
-  } else if(rp === pub.BOTTOM_CENTER || rp === 2 || rp === AnchorPoint.BOTTOM_CENTER_ANCHOR) {
-    currRefPoint = pub.BOTTOM_CENTER;
-    anchorEnum = AnchorPoint.BOTTOM_CENTER_ANCHOR;
-  } else if(rp === pub.BOTTOM_RIGHT || rp === 3 || rp === AnchorPoint.BOTTOM_RIGHT_ANCHOR) {
-    currRefPoint = pub.BOTTOM_RIGHT;
-    anchorEnum = AnchorPoint.BOTTOM_RIGHT_ANCHOR;
-  } else {
-    error("referencePoint(), wrong argument! Use reference point constant (TOP_LEFT, TOP_CENTER, ...), a digit between 1 and 9 or an InDesign anchor point enumerator.");
-  }
-
-  if(app.properties.activeWindow instanceof LayoutWindow ) {
-    app.activeWindow.transformReferencePoint = anchorEnum;
-  }
-
-  return currRefPoint;
-};
-
-/**
- * @description Transforms a given page item. The type of transformation is determinded with the second parameter. The third parameter is the transformation value, either a number or an array of x and y values. The transformation's reference point (top left, bottom center etc.) can be set beforehand by using the `referencePoint()` function. If the third parameter is ommited, the function can be used to measure the value of the page item.
- * There are 10 different transformation types:
- *    - `"translate"`: Translates the page item by the given `[x, y]` values. Returns the coordinates of the page item's anchor point as an array.
- *    - `"rotate"`: Rotates the page item to the given degree value. Returns the page item's rotation value in degrees.
- *    - `"scale"`: Scales the page item to the given `[x, y]` scale factor values. Alternatively, a single scale factor value can be used to scale the page item uniformely. Returns the scale factor values of the page item's current scale as an array.
- *    - `"shear"`: Shears the page item to the given degree value. Returns the page item's shear value in degrees.
- *    - `"size"`: Sets the page item's size to the given `[x, y]` dimensions. Returns the size of the page item as an array.
- *    - `"width"`: Sets the page item's width to the given value. Returns the width of the page item.
- *    - `"height"`: Sets the page item's height to the given value. Returns the height of the page item.
- *    - `"position"`: Sets the position of the page item's anchor point to the given `[x, y]` coordinates. Returns the coordinates of the page item's anchor point as an array.
- *    - `"x"`: Sets the x-position of the page item's anchor point to the given value. Returns the x-coordinate of the page item's anchor point.
- *    - `"y"`: Sets the y-position of the page item's anchor point to the given value. Returns the y-coordinate of the page item's anchor point.
- *
- * @cat    Document
- * @subcat Transformation
- * @method transform
- * @param  {PageItem} pItem The page item to transform.
- * @param  {String} type The type of transformation.
- * @param  {Number|Array} [value] The value(s) of the transformation.
- * @return {Number|Array} The current value(s) of the specified transformation.
- *
- * @example <caption>Rotating a rectangle to a 25 degrees angle</caption>
- * var r = rect(20, 40, 200, 100);
- * transform(r, "rotate", 25);
- *
- * @example <caption>Measure the width of a rectangle</caption>
- * var r = rect(20, 40, random(100, 300), 100);
- * var w = transform(r, "width");
- * println(w); // prints the rectangle's random width between 100 and 300
- *
- * @example <caption>Position a rectangle's lower right corner at a certain position</caption>
- * var r = rect(20, 40, random(100, 300), random(50, 150));
- * referencePoint(BOTTOM_RIGHT);
- * transform(r, "position", [40, 40]);
- */
-pub.transform = function(pItem, type, value) {
-
-  if(!pItem || !pItem.hasOwnProperty("geometricBounds")) {
-    error("transform(), invalid first parameter. Use page item.");
-  }
-
-  app.transformPreferences.adjustStrokeWeightWhenScaling = false;
-  app.transformPreferences.whenScaling = WhenScalingOptions.ADJUST_SCALING_PERCENTAGE;
-
-  var result = null;
-  var idAnchorPoints = {
-    topLeft: AnchorPoint.TOP_LEFT_ANCHOR,
-    topCenter: AnchorPoint.TOP_CENTER_ANCHOR,
-    topRight: AnchorPoint.TOP_RIGHT_ANCHOR,
-    centerLeft: AnchorPoint.LEFT_CENTER_ANCHOR,
-    center: AnchorPoint.CENTER_ANCHOR,
-    centerRight: AnchorPoint.RIGHT_CENTER_ANCHOR,
-    bottomLeft: AnchorPoint.BOTTOM_LEFT_ANCHOR,
-    bottomCenter: AnchorPoint.BOTTOM_CENTER_ANCHOR,
-    bottomRight: AnchorPoint.BOTTOM_RIGHT_ANCHOR
-  };
-  var basilUnits = {
-    pt: MeasurementUnits.POINTS,
-    mm: MeasurementUnits.MILLIMETERS,
-    cm: MeasurementUnits.CENTIMETERS,
-    inch: MeasurementUnits.INCHES,
-    px: MeasurementUnits.PIXELS
-  }
-
-  var aPoint = idAnchorPoints[currRefPoint];
-  var unitEnum = basilUnits[currUnits];
-
-  var tm = app.transformationMatrices.add();
-  var bounds = pItem.geometricBounds;
-  var w = Math.abs(bounds[3] - bounds[1]);
-  var h = Math.abs(bounds[2] - bounds[0]);
-
-  if(type === "width") {
-    if(isNumber(value)) {
-      tm = tm.scaleMatrix(value / w, 1);
-      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
-    } else {
-      result = precision(w, 12);
-    }
-
-  } else if (type === "height") {
-    if(isNumber(value)) {
-      tm = tm.scaleMatrix(1, value / h);
-      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
-    } else {
-      result = precision(h, 12);
-    }
-
-  } else if (type === "size") {
-    if(isArray(value)) {
-      tm = tm.scaleMatrix(value[0] / w, value[1] / h);
-      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
-    } else {
-      result = [precision(w, 12), precision(h, 12)];
-    }
-
-  } else if(type === "translate" || type === "translation") {
-    if(isArray(value)) {
-
-      // for proper matrix translation, convert units to points
-      value[0] = UnitValue(value[0], unitEnum).as(MeasurementUnits.POINTS);
-      value[1] = UnitValue(value[1], unitEnum).as(MeasurementUnits.POINTS);
-
-      tm = tm.translateMatrix(value[0], value[1]);
-      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
-    }
-    result = transform(pItem, "position");
-
-  } else if (type === "rotate" || type === "rotation") {
-    if(isNumber(value)) {
-      tm = tm.rotateMatrix(-pItem.rotationAngle - value);
-      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
-    }
-    result = -pItem.rotationAngle;
-
-  } else if (type === "scale" || type === "scaling") {
-    if(isNumber(value)) {
-      tm = tm.scaleMatrix(value, value);
-      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
-    } else if(isArray(value)) {
-      tm = tm.scaleMatrix(value[0], value[1]);
-      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
-    }
-    result = [pItem.horizontalScale / 100, pItem.verticalScale / 100];
-
-  } else if (type === "shear"  || type === "shearing") {
-    if(isNumber(value)) {
-      tm = tm.shearMatrix(-pItem.shearAngle - value);
-      pItem.transform(CoordinateSpaces.PASTEBOARD_COORDINATES, aPoint, tm);
-    }
-    result = -pItem.shearAngle;
-
-  } else if (type === "position" || type === "x" || type === "y") {
-
-    // find page that holds the top left corner of the current canvas mode
-    var refPage = currPage;
-    if(!(currCanvasMode === PAGE || currCanvasMode === MARGIN || currCanvasMode === BLEED)) {
-      refPage = currPage.parent.pages.firstItem();
-    }
-
-    var topLeft = refPage.resolve([AnchorPoint.TOP_LEFT_ANCHOR, BoundingBoxLimits.GEOMETRIC_PATH_BOUNDS, CoordinateSpaces.INNER_COORDINATES], CoordinateSpaces.SPREAD_COORDINATES)[0];
-
-    topLeft[0] += UnitValue(currOriginX, unitEnum).as(MeasurementUnits.POINTS);
-    topLeft[1] += UnitValue(currOriginY, unitEnum).as(MeasurementUnits.POINTS);
-
-    var anchorPosOnSpread = pItem.resolve([aPoint, BoundingBoxLimits.GEOMETRIC_PATH_BOUNDS, CoordinateSpaces.INNER_COORDINATES], CoordinateSpaces.SPREAD_COORDINATES)[0];
-    var anchorPosOnPagePt = [anchorPosOnSpread[0] - topLeft[0], anchorPosOnSpread[1] - topLeft[1]];
-
-    // convert position to user units
-    var anchorPosOnPage = [
-      UnitValue(anchorPosOnPagePt[0], MeasurementUnits.POINTS).as(unitEnum),
-      UnitValue(anchorPosOnPagePt[1], MeasurementUnits.POINTS).as(unitEnum),
-    ];
-
-    if(type === "x") {
-      if(isNumber(value)) {
-        transform(pItem, "position", [value, anchorPosOnPage[1]]);
-        return value;
-      } else {
-        result = precision(anchorPosOnPage[0], 12);
-      }
-
-    } else if (type === "y") {
-      if(isNumber(value)) {
-        transform(pItem, "position", [anchorPosOnPage[0], value]);
-        return value;
-      } else {
-        result = precision(anchorPosOnPage[1], 12);
-      }
-
-    } else {
-      if(isArray(value)) {
-        var offset = [value[0] - anchorPosOnPage[0], value[1] - anchorPosOnPage[1]];
-        transform(pItem, "translate", offset);
-        return value;
-      } else {
-        result = [precision(anchorPosOnPage[0], 12), precision(anchorPosOnPage[1], 12)];
-      }
-    }
-
-  } else {
-    error("transform(), invalid transform type. Use \"translate\", \"rotate\", \"scale\", \"shear\", \"size\", \"width\", \"height\", \"position\", \"x\" or \"y\".");
-  }
-
-  app.transformPreferences.adjustStrokeWeightWhenScaling = true;
-  app.transformPreferences.whenScaling = WhenScalingOptions.APPLY_TO_CONTENT;
-
-  if(result === null) {
-    result = value;
-  }
-  return result;
-
-}
-
-var printMatrixHelper = function(elements) {
-  var big = 0;
-  for (var i = 0; i < elements.length; i++) {
-    if (i !== 0) {
-      big = Math.max(big, Math.abs(elements[i]));
-
-    } else {
-      big = Math.abs(elements[i]);
-    }
-  }
-  var digits = (big + "").indexOf(".");
-  if (digits === 0) {
-    digits = 1;
-  } else if (digits === -1) {
-    digits = (big + "").length;
-  }
-  return digits;
-};
-
-// ----------------------------------------
-// private matrix functions
-
-var Matrix2D = function() {
-  if (arguments.length === 0) {
-    this.reset();
-  } else if (arguments.length === 1 && arguments[0] instanceof Matrix2D) {
-    this.set(arguments[0].array());
-  } else if (arguments.length === 6) {
-    this.set(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5]);
-  }
-};
-
-Matrix2D.prototype = {
-
-  // Set a Matrix.
-  set: function() {
-    if (arguments.length === 6) {
-      var a = arguments;
-      this.set([a[0], a[1], a[2], a[3], a[4], a[5]]);
-    } else if (arguments.length === 1 && arguments[0] instanceof Matrix2D) {
-      this.elements = arguments[0].array();
-    } else if (arguments.length === 1 && arguments[0] instanceof Array) {
-      this.elements = arguments[0].slice();
-    }
-  },
-
-  // Get a Matrix.
-  get: function() {
-    var outgoing = new Matrix2D();
-    outgoing.set(this.elements);
-    return outgoing;
-  },
-
-  // Reset the Matrix.
-  reset: function() {
-    this.set([1, 0, 0, 0, 1, 0]);
-  },
-
-  // Slice the Matrix into an array.
-  array: function array() {
-    return this.elements.slice();
-  },
-
-  adobeMatrix: function array(x, y) {
-    // this seems to work:
-    // it's important to know the position of the object around which it will be rotated and scaled.
-
-    // 1. making a copy of this matrix
-    var tmpMatrix = this.get();
-
-    // 2. pre-applying a translation as if the object was starting from the origin
-    tmpMatrix.preApply([1, 0, -x, 0, 1, -y]);
-
-    // 3. move to object to its given coordinates
-    tmpMatrix.apply([1, 0, x, 0, 1, y]);
-
-    var uVX = new UnitValue(tmpMatrix.elements[2], currUnits);
-    var uVY = new UnitValue(tmpMatrix.elements[5], currUnits);
-
-    return [
-      tmpMatrix.elements[0],
-      tmpMatrix.elements[3],
-      tmpMatrix.elements[1],
-      tmpMatrix.elements[4],
-      uVX.as("pt"),
-      uVY.as("pt")
-    ];
-  },
-
-  translate: function(tx, ty) {
-    this.elements[2] = tx * this.elements[0] + ty * this.elements[1] + this.elements[2];
-    this.elements[5] = tx * this.elements[3] + ty * this.elements[4] + this.elements[5];
-  },
-
-  scale: function(sx, sy) {
-    if (sx && !sy) {
-      sy = sx;
-    }
-    if (sx && sy) {
-      this.elements[0] *= sx;
-      this.elements[1] *= sy;
-      this.elements[3] *= sx;
-      this.elements[4] *= sy;
-    }
-  },
-
-  apply: function() {
-    var source;
-    if (arguments.length === 1 && arguments[0] instanceof Matrix2D) {
-      source = arguments[0].array();
-    } else if (arguments.length === 6) {
-      source = Array.prototype.slice.call(arguments);
-    } else if (arguments.length === 1 && arguments[0] instanceof Array) {
-      source = arguments[0];
-    }
-    var result = [0, 0, this.elements[2], 0, 0, this.elements[5]];
-    var e = 0;
-    for (var row = 0; row < 2; row++) {
-      for (var col = 0; col < 3; col++, e++) {
-        result[e] += this.elements[row * 3 + 0] * source[col + 0] + this.elements[row * 3 + 1] * source[col + 3];
-      }
-    }
-    this.elements = result.slice();
-  },
-
-  preApply: function() {
-    var source;
-    if (arguments.length === 1 && arguments[0] instanceof Matrix2D) {
-      source = arguments[0].array();
-    } else if (arguments.length === 6) {
-      source = Array.prototype.slice.call(arguments);
-    } else if (arguments.length === 1 && arguments[0] instanceof Array) {
-      source = arguments[0];
-    }
-    var result = [0, 0, source[2], 0, 0, source[5]];
-    result[2] = source[2] + this.elements[2] * source[0] + this.elements[5] * source[1];
-    result[5] = source[5] + this.elements[2] * source[3] + this.elements[5] * source[4];
-    result[0] = this.elements[0] * source[0] + this.elements[3] * source[1];
-    result[3] = this.elements[0] * source[3] + this.elements[3] * source[4];
-    result[1] = this.elements[1] * source[0] + this.elements[4] * source[1];
-    result[4] = this.elements[1] * source[3] + this.elements[4] * source[4];
-    this.elements = result.slice();
-  },
-
-  rotate: function(angle) {
-    var c = Math.cos(angle);
-    var s = Math.sin(angle);
-    var temp1 = this.elements[0];
-    var temp2 = this.elements[1];
-    this.elements[0] = c * temp1 + s * temp2;
-    this.elements[1] = -s * temp1 + c * temp2;
-    temp1 = this.elements[3];
-    temp2 = this.elements[4];
-    this.elements[3] = c * temp1 + s * temp2;
-    this.elements[4] = -s * temp1 + c * temp2;
-  },
-
-  print: function() {
-    var digits = printMatrixHelper(this.elements);
-    var output = "" + pub.nfs(this.elements[0], digits, 4) + " " + pub.nfs(this.elements[1], digits, 4) + " " + pub.nfs(this.elements[2], digits, 4) + "\n" + pub.nfs(this.elements[3], digits, 4) + " " + pub.nfs(this.elements[4], digits, 4) + " " + pub.nfs(this.elements[5], digits, 4) + "\n\n";
-    pub.println(output);
-  }
-};
-
-/**
- * @description Multiplies the current matrix by the one specified through the parameters.
- *
- * @cat    Document
- * @subcat Transformation
- * @method applyMatrix
- * @param  {Matrix2D} matrix The matrix to be applied.
- */
-pub.applyMatrix = function (matrix) {
-  currMatrix.apply(matrix);
-};
-
-/**
- * @description Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
- *
- * @cat    Document
- * @subcat Transformation
- * @method popMatrix
- */
-pub.popMatrix = function () {
-  if (matrixStack.length > 0) {
-    currMatrix.set(matrixStack.pop());
-  } else {
-    error("popMatrix(), missing a pushMatrix() to go with that popMatrix()");
-  }
-};
-
-/**
- * @description Prints the current matrix to the console window.
- *
- * @cat    Document
- * @subcat Transformation
- * @method printMatrix
- */
-pub.printMatrix = function () {
-  currMatrix.print();
-};
-
-/**
- * @description Pushes the current transformation matrix onto the matrix stack. Understanding `pushMatrix()` and `popMatrix()` requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
- *
- * @cat    Document
- * @subcat Transformation
- * @method pushMatrix
- */
-pub.pushMatrix = function () {
-  matrixStack.push(currMatrix.array());
-};
-
-/**
- * @description Replaces the current matrix with the identity matrix.
- *
- * @cat    Document
- * @subcat Transformation
- * @method resetMatrix
- */
-pub.resetMatrix = function () {
-  matrixStack = [];
-  currMatrix = new Matrix2D();
-
-  pub.translate(currOriginX, currOriginY);
-};
-
-/**
- * @description Rotates an object the amount specified by the angle parameter. Angles should be specified in radians (values from 0 to `PI`*2) or converted to radians with the `radians()` function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a clockwise direction with 0 radians or degrees being up and `HALF_PI` being to the right etc. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `rotate(PI/2)` and then `rotate(PI/2)` is the same as `rotate(PI)`. If `rotate()` is called within the `draw()`, the transformation is reset when the loop begins again. Technically, `rotate()` multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
- *
- * @cat    Document
- * @subcat Transformation
- * @method rotate
- * @param  {Number} angle The angle specified in radians
- */
-pub.rotate = function (angle) {
-  if(typeof arguments[0] === "undefined") {
-    error("Please provide an angle for rotation.");
-  }
-  currMatrix.rotate(angle);
-};
-
-/**
- * @description Increasing and decreasing the size of an object by expanding and contracting vertices. Scale values are specified as decimal percentages. The function call `scale(2.0)` increases the dimension of a shape by 200%. Objects always scale from their relative origin to the coordinate system. Transformations apply to everything that happens after and subsequent calls to the function multiply the effect. For example, calling `scale(2.0)` and then `scale(1.5)` is the same as `scale(3.0)`. If `scale()` is called within `draw()`, the transformation is reset when the loop begins again. This function can be further controlled by `pushMatrix()` and `popMatrix()`.
- * If only one parameter is given, it is applied on X and Y axis.
- *
- * @cat    Document
- * @subcat Transformation
- * @method scale
- * @param  {Number} scaleX The amount to scale the X axis.
- * @param  {Number} scaleY The amount to scale the Y axis.
- */
-pub.scale = function (scaleX, scaleY) {
-  if(typeof arguments[0] != "number" || (arguments.length === 2 && typeof arguments[1] != "number")) {
-    error("Please provide valid x and/or y factors for scaling.");
-  }
-  currMatrix.scale(scaleX, scaleY);
-};
-
-/**
- * @description Specifies an amount to displace objects within the page. The x parameter specifies left/right translation, the y parameter specifies up/down translation. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `translate(50, 0)` and then `translate(20, 0)` is the same as `translate(70, 0)`. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
- *
- * @cat    Document
- * @subcat Transformation
- * @method translate
- * @param  {Number} tx The amount of offset on the X axis.
- * @param  {Number} ty The amount of offset on the Y axis.
- */
-pub.translate = function (tx, ty) {
-  if(typeof arguments[0] === "undefined" || typeof arguments[1] === "undefined") {
-    error("Please provide x and y coordinates for translation.");
-  }
-  currMatrix.translate(tx, ty);
-};
-
-// clearing global space if it is still populated from previous run of a loop script
-// ----------------------------------------
-// src/includes/ui.js
-// ----------------------------------------
-
-// Hey Ken, this is your new home...
-// to ensure basil methods work properly
-
-if($.engineName === "loop" && $.global.basilGlobal) {
-init();
-
-})();
-  for (var i = basilGlobal.length - 1; i >= 0; i--) {
-    if($.global.hasOwnProperty(basilGlobal[i])) {
-      try{
-        delete $.global[basilGlobal[i]];
-      } catch(e) {
-        // could not delete
-      }
-    }
-  }
-  delete $.global.basilGlobal;
-}
-
-if(!$.global.hasOwnProperty("basilTest")) {
-  // load global vars of the user script
-  var sourceScript;
-  try {
-    app.nonExistingProperty;
-  } catch(e) {
-    sourceScript = e.source;
-  }
-
-  var userScript = sourceScript.replace(/[\s\S]*[#@]\s*[i]nclude\s+.+basil\.js["']*[\s;)}]*/, "");
-  app.doScript(userScript);
-}
-
-
-(function() {
-
-var pub = {};
-
-/**
- * The basil version
- * @property VERSION {String}
- * @cat Environment
- */
-pub.VERSION = "1.1.0";
-
 // ----------------------------------------
 // src/includes/constants.js
 // ----------------------------------------
@@ -8760,12 +1026,18 @@ var prepareLoop = function() {
 }
 
 /**
- * @description Sets the framerate per second to determine how often loop() is called per second. If the processor is not fast enough to maintain the specified rate, the frame rate will not be achieved. Setting the frame rate within setup() is recommended. The default rate is 25 frames per second. Calling frameRate() with no arguments returns the currently set framerate.
+ * @description Sets the framerate per second to determine how often `loop()` is
+ *          called per second. If the processor is not fast enough to maintain
+ *          the specified rate, the frame rate will not be achieved. Setting the
+ *          frame rate within `setup()` is recommended. The default rate is 25
+ *          frames per second. Calling `frameRate()` with no arguments returns
+ *          the currently set framerate.
  *
- * @cat    Environment
- * @method frameRate
- * @param  {Number} [fps] Frames per second.
- * @return {Number} Currently set frame rate.
+ * @cat     Environment
+ * @method  frameRate
+ *
+ * @param   {Number} [fps] Frames per second.
+ * @return  {Number} Currently set frame rate.
  */
 pub.frameRate = function(fps) {
   if(arguments.length) {
@@ -8782,10 +1054,11 @@ pub.frameRate = function(fps) {
 };
 
 /**
- * @description Stops basil from continuously executing the code within loop() and quits the script.
+ * @description Stops basil from continuously executing the code within `loop()`
+ *          and quits the script.
  *
- * @cat    Environment
- * @method noLoop
+ * @cat     Environment
+ * @method  noLoop
  */
 pub.noLoop = function(printFinished) {
   var allIdleTasks = app.idleTasks;
@@ -8800,14 +1073,36 @@ pub.noLoop = function(printFinished) {
 };
 
 /**
- * @description Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, `mode()` should be placed in the beginning of the script. In basil there are three different performance modes:<br>
- * `VISIBLE` is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.<br>
- * `HIDDEN` allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use `println("yourMessage")` in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.<br>
- * `SILENT` processes the document without redrawing the screen. The document will stay visible and only update once the script is finished or once the mode is changed back to `VISIBLE`.
+ * @description Used to set the performance mode. While modes can be switched
+ *          during script execution, to use a mode for the entire script
+ *          execution, `mode()` should be placed in the beginning of the script.
+ *          In basil there are three different performance modes:
  *
- * @cat    Environment
- * @method mode
- * @param  {String} mode The performance mode to switch to.
+ *      - `VISIBLE`
+ *          is the default mode. In this mode, during script execution the
+ *          document will be processed with screen redraw, allowing to see
+ *          direct results during the process. As the screen needs to redraw
+ *          continuously, this is slower than the other modes.
+ *      - `HIDDEN`
+ *          allows to process the document in background mode. The document is
+ *          not visible in this mode, which speeds up the script execution. In
+ *          this mode you will likely look at InDesign with no open document for
+ *          quite some time – do not work in InDesign during this time. You may
+ *          want to use `println("yourMessage")` in your script and look at the
+ *          console to get information about the process. Note: In order to
+ *          enter this mode either a saved document needs to be open or no
+ *          document at all. If you have an unsaved document open, basil will
+ *          automatically save it for you. If it has not been saved before, you
+ *          will be prompted to save it to your hard drive.
+ *      - `SILENT`
+ *          processes the document without redrawing the screen. The document
+ *          will stay visible and only update once the script is finished or
+ *          once the mode is changed back to `VISIBLE`.
+ *
+ * @cat     Environment
+ * @method  mode
+ *
+ * @param   {String} mode The performance mode to switch to.
  */
 pub.mode = function(mode) {
 
@@ -10961,16 +3256,20 @@ pub.timestamp = function() {
 
 pub.JSON = {
   /**
-   * @description Function parses and validates a string as JSON-object. Usage:<br>
+   * @description Function parses and validates a string as JSON-object.
+   *
+   * @cat     Data
+   * @subcat  JSON
+   * @method  JSON.decode
+   *
+   * @param   {String} String to be parsed as JSON-object.
+   * @return  {Object} Returns JSON-object or throws an error if invalid JSON
+   *          has been provided.
+   *
+   * @example
    * var obj = JSON.decode(str);
    * var str = JSON.encode(obj);
-   *
-   * @cat    Data
-   * @subcat JSON
-   * @method JSON.decode
-   * @param  {String} String to be parsed as JSON-object.
-   * @return {Object} Returns JSON-object or throws an error if invalid JSON has been provided.
-  */
+   */
   // From: jQuery JavaScript Library v1.7.1 http://jquery.com/
   decode: function(data) {
     if (typeof data !== "string" || !data) {
@@ -10991,15 +3290,18 @@ pub.JSON = {
     error("JSON.decode(), invalid JSON: " + data);
   },
   /**
-   * Function convert an javascript object to a JSON-string. Usage:<br>
+   * Function convert an javascript object to a JSON-string.
+   *
+   * @cat     Data
+   * @subcat  JSON
+   * @method  JSON.encode
+   *
+   * @param   {Object} Object to be converted to a JSON-string
+   * @return  {String} Returns JSON-string
+   *
+   * @example
    * var str = JSON.encode(obj);
    * var obj = JSON.decode(str);
-   *
-   * @cat    Data
-   * @subcat JSON
-   * @method JSON.encode
-   * @param  {Object} Object to be converted to a JSON-string
-   * @return {String} Returns JSON-string
    */
   // From: https://gist.github.com/754454
   encode: function(obj) {
@@ -11045,12 +3347,13 @@ function CSV() {
   /**
    * @description Sets the delimiter of the CSV decode and encode function.
    *
-   * @cat    Data
-   * @subcat CSV
-   * @method CSV.delimiter
-   * @param  {String} [delimiter] Optional Sets the delimiter for CSV parsing
-   * @return {String} Returns the current delimiter if called without argument
-  */
+   * @cat     Data
+   * @subcat  CSV
+   * @method  CSV.delimiter
+   *
+   * @param   {String} [delimiter] Optional Sets the delimiter for CSV parsing
+   * @return  {String} Returns the current delimiter if called without argument
+   */
   this.delimiter = function(delimiter) {
     if (arguments.length === 0) return delimiterStr;
     if (typeof delimiter === "string") {
@@ -11061,16 +3364,19 @@ function CSV() {
   };
 
   /**
-   * @description Function parses a string as CSV-object Array. Usage:<br>
+   * @description Function parses a string as CSV-object Array.
+   *
+   * @cat     Data
+   * @subcat  CSV
+   * @method  CSV.decode
+   *
+   * @param   {String} String to be parsed as CSV-object.
+   * @return  {Array} Returns CSV-object Array
+   *
+   * @example
    * var arr = CSV.decode(str);
    * var str = CSV.encode(arr);
-   *
-   * @cat    Data
-   * @subcat CSV
-   * @method CSV.decode
-   * @param  {String} String to be parsed as CSV-object.
-   * @return {Array} Returns CSV-object Array
-  */
+   */
   this.decode = function(text) {
     var header;
     return parseRows(text, function(row, i) {
@@ -11086,15 +3392,19 @@ function CSV() {
   };
 
   /**
-   * @description Function convert an javascript array of objects to a CSV-string. Usage:<br>
+   * @description Function convert an javascript array of objects to a
+   *          CSV-string.
+   *
+   * @cat     Data
+   * @subcat  CSV
+   * @method  CSV.encode
+   *
+   * @param   {Array} Array to be converted to a CSV-string
+   * @return  {String} Returns CSV-string
+   *
+   * @example
    * var str = CSV.encode(arr);
    * var arr = CSV.decode(str);
-   *
-   * @cat    Data
-   * @subcat CSV
-   * @method CSV.encode
-   * @param  {Array} Array to be converted to a CSV-string
-   * @return {String} Returns CSV-string
    */
   this.encode = function(rows) {
     var csvStrings = [];
@@ -11190,17 +3500,19 @@ function CSV() {
 
 /**
  * @description Converts a byte, char, int, or color to a String containing the
- * equivalent binary notation. For example color(0, 102, 153, 255)
- * will convert to the String "11111111000000000110011010011001". This
- * function can help make your geeky debugging sessions much happier.
+ *          equivalent binary notation. For example `color(0, 102, 153, 255)`
+ *          will convert to the String `"11111111000000000110011010011001"`.
+ *          This function can help make your geeky debugging sessions much
+ *          happier.
  *
-
- * @cat    Data
- * @subcat Conversion
- * @method binary
- * @param  {Number} num value to convert
- * @param  {Number} [numBits] number of digits to return
- * @return {String} A formatted string
+ *
+ * @cat     Data
+ * @subcat  Conversion
+ * @method  binary
+ *
+ * @param   {Number} num value to convert
+ * @param   {Number} [numBits] number of digits to return
+ * @return  {String} A formatted string
  */
  // From: http://processingjs.org/reference/binary_/
 pub.binary = function(num, numBits) {
@@ -11220,14 +3532,15 @@ pub.binary = function(num, numBits) {
 
 /**
  * @description Converts a String representation of a binary number to its
- * equivalent integer value. For example, unbinary("00001000") will
- * return 8.
+ *          equivalent integer value. For example, `unbinary("00001000")` will
+ *          return `8`.
  *
- * @cat    Data
- * @subcat Conversion
- * @method unbinary
- * @param  {String} binaryString value to convert
- * @return {Number} The integer representation
+ * @cat     Data
+ * @subcat  Conversion
+ * @method  unbinary
+ *
+ * @param   {String} binaryString value to convert
+ * @return  {Number} The integer representation
  */
  // From: http://processingjs.org/reference/unbinary_/
 pub.unbinary = function(binaryString) {
@@ -11256,12 +3569,14 @@ var decimalToHex = function(d, padding) {
 /**
  * @description Convert a number to a hex representation.
  *
- * @cat    Data
- * @subcat Conversion
- * @method hex
- * @param  {Number} value The number to convert
- * @param  {Number} [len] The length of the hex number to be created, default: 8
- * @return {String} The hex representation as a string
+ * @cat     Data
+ * @subcat  Conversion
+ * @method  hex
+ *
+ * @param   {Number} value The number to convert
+ * @param   {Number} [len] The length of the hex number to be created, default:
+ *          `8`
+ * @return  {String} The hex representation as a string
  */
 pub.hex = function(value, len) {
   if (arguments.length === 1) len = 8;
@@ -11277,11 +3592,12 @@ var unhexScalar = function(hex) {
 /**
  * @description Convert a hex representation to a number.
  *
- * @cat    Data
- * @subcat Conversion
- * @method unhex
- * @param  {String} hex The hex representation
- * @return {Number} The number
+ * @cat     Data
+ * @subcat  Conversion
+ * @method  unhex
+ *
+ * @param   {String} hex The hex representation
+ * @return  {Number} The number
  */
 pub.unhex = function(hex) {
   if (hex instanceof Array) {
@@ -11298,13 +3614,16 @@ pub.unhex = function(hex) {
 
 
 /**
- * @description Removes multiple, leading or trailing spaces and punctuation from "words". E.g. converts "word!" to "word". Especially useful together with words();
+ * @description Removes multiple, leading or trailing spaces and punctuation
+ *          from "words". E.g. converts `"word!"` to `"word"`. Especially useful
+ *          together with `words()`;
  *
- * @cat    Data
- * @subcat String Functions
- * @method trimWord
- * @param  {String} s The String to trim
- * @return {String} The trimmed string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  trimWord
+ *
+ * @param   {String} s The String to trim
+ * @return  {String} The trimmed string
  */
  // from: https://stackoverflow.com/a/25575009/3399765
 pub.trimWord = function(s) {
@@ -11316,16 +3635,17 @@ pub.trimWord = function(s) {
 
 /**
  * @description Combines an array of Strings into one String, each separated by
- * the character(s) used for the separator parameter. To join arrays
- * of ints or floats, it's necessary to first convert them to strings
- * using nf() or nfs().
+ *          the character(s) used for the separator parameter. To join arrays of
+ *          ints or floats, it's necessary to first convert them to strings
+ *          using `nf()` or `nfs()`.
  *
- * @cat    Data
- * @subcat String Functions
- * @method join
- * @param  {Array} array A string array
- * @param  {String} separator The separator to be inserted
- * @return {String} The joined string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  join
+ *
+ * @param   {Array} array A string array
+ * @param   {String} separator The separator to be inserted
+ * @return  {String} The joined string
  */
  // http://processingjs.org/reference/join_/
 pub.join = function(array, separator) {
@@ -11333,25 +3653,23 @@ pub.join = function(array, separator) {
 };
 
 /**
- * @description The split() function breaks a string into pieces using a
- * character or string as the divider. The delim parameter specifies the
- * character or characters that mark the boundaries between each piece. A
- * String[] array is returned that contains each of the pieces.
- * <br><br>
- * If the result is a set of numbers, you can convert the String[] array
- * to to a float[] or int[] array using the datatype conversion functions
- * int() and float() (see example above).
- * <br><br>
- * The splitTokens() function works in a similar fashion, except that it
- * splits using a range of characters instead of a specific character or
- * sequence.
+ * @description The `split()` function breaks a string into pieces using a
+ *          character or string as the divider. The `delim` parameter specifies
+ *          the character or characters that mark the boundaries between each
+ *          piece. An array of strings is returned that contains each of the
+ *          pieces.
+ *          <br><br>
+ *          The `splitTokens()` function works in a similar fashion, except that
+ *          it splits using a range of characters instead of a specific
+ *          character or sequence.
  *
- * @cat    Data
- * @subcat String Functions
- * @method split
- * @param  {String} str the String to be split
- * @param  {String} [delim] The string used to separate the data
- * @return {Array} Array of strings
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  split
+ *
+ * @param   {String} str the String to be split
+ * @param   {String} [delim] The string used to separate the data
+ * @return  {Array} Array of strings
  */
  // http://processingjs.org/reference/split_/
 pub.split = function(str, delim) {
@@ -11359,22 +3677,23 @@ pub.split = function(str, delim) {
 };
 
 /**
- * @description The splitTokens() function splits a String at one or many character
- * "tokens." The tokens parameter specifies the character or characters
- * to be used as a boundary.
- * <br><br>
- * If no tokens character is specified, any whitespace character is used
- * to split. Whitespace characters include tab (\t), line feed (\n),
- * carriage return (\r), form feed (\f), and space. To convert a String
- * to an array of integers or floats, use the datatype conversion functions
- * int() and float() to convert the array of Strings.
+ * @description The `splitTokens()` function splits a string at one or many
+ *          character "tokens." The tokens parameter specifies the character or
+ *          characters to be used as a boundary.
+ *          <br><br>
+ *          If no tokens character
+ *          is specified, any whitespace character is used to split. Whitespace
+ *          characters include tab (`\t`), line feed (`\n`), carriage return
+ *          (`\r`), form feed (`\f`), and space.
  *
- * @cat    Data
- * @subcat String Functions
- * @method splitTokens
- * @param  {String} str the String to be split
- * @param  {String} [tokens] list of individual characters that will be used as separators
- * @return {Array} Array of strings
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  splitTokens
+ *
+ * @param   {String} str the String to be split
+ * @param   {String} [tokens] list of individual characters that will be used as
+ *          separators
+ * @return  {Array} Array of strings
  */
  // From: http://processingjs.org/reference/splitTokens_/
 pub.splitTokens = function(str, tokens) {
@@ -11460,23 +3779,24 @@ function nfCore(value, plus, minus, leftDigits, rightDigits, group) {
 }
 
 /**
- * @description Utility function for formatting numbers into strings. There
- * are two versions, one for formatting floats and one for formatting
- * ints. The values for the digits, left, and right parameters should
- * always be positive integers.
- * <br><br>
- * As shown in the above example, nf() is used to add zeros to the
- * left and/or right of a number. This is typically for aligning a list
- * of numbers. To remove digits from a floating-point number, use the
- * int(), ceil(), floor(), or round() functions.
+ * @description Utility function for formatting numbers into strings. There are
+ *          two versions, one for formatting floats and one for formatting ints.
+ *          The values for the digits, left, and right parameters should always
+ *          be positive integers.
+ *          <br><br>
+ *          `nf()` is used to add zeros to the
+ *          left and/or right of a number. This is typically for aligning a list
+ *          of numbers. To remove digits from a floating-point number, use the
+ *          `ceil()`, `floor()`, or `round()` functions.
  *
- * @cat    Data
- * @subcat String Functions
- * @method nf
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  nf
+ *
+ * @param   {Number} value The Number to convert
+ * @param   {Number} leftDigits { parameter_description }
+ * @param   {Number} rightDigits { parameter_description }
+ * @return  {String} The formatted string
  */
  // From: http://processingjs.org/reference/nf_/
 pub.nf = function(value, leftDigits, rightDigits) {
@@ -11484,20 +3804,21 @@ pub.nf = function(value, leftDigits, rightDigits) {
 };
 
 /**
- * @description Utility function for formatting numbers into strings. Similar to nf()
- * but leaves a blank space in front of positive numbers so they align
- * with negative numbers in spite of the minus symbol. There are two
- * versions, one for formatting floats and one for formatting ints. The
- * values for the digits, left, and right parameters should always be
- * positive integers.
+ * @description Utility function for formatting numbers into strings. Similar to
+ *          `nf()` but leaves a blank space in front of positive numbers so they
+ *          align with negative numbers in spite of the minus symbol. There are
+ *          two versions, one for formatting floats and one for formatting ints.
+ *          The values for the digits, left, and right parameters should always
+ *          be positive integers.
  *
- * @cat    Data
- * @subcat String Functions
- * @method nfs
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  nfs
+ *
+ * @param   {Number} value The Number to convert
+ * @param   {Number} leftDigits { parameter_description }
+ * @param   {Number} rightDigits { parameter_description }
+ * @return  {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfs_/
 pub.nfs = function(value, leftDigits, rightDigits) {
@@ -11505,19 +3826,21 @@ pub.nfs = function(value, leftDigits, rightDigits) {
 };
 
 /**
- * @description Utility function for formatting numbers into strings. Similar to nf()
- * but puts a "+" in front of positive numbers and a "-" in front of
- * negative numbers. There are two versions, one for formatting floats
- * and one for formatting ints. The values for the digits, left, and right
- * parameters should always be positive integers.
+ * @description Utility function for formatting numbers into strings. Similar to
+ *          `nf()` but puts a `+` in front of positive numbers and a `-` in
+ *          front of negative numbers. There are two versions, one for
+ *          formatting floats and one for formatting ints. The values for the
+ *          digits, left, and right parameters should always be positive
+ *          integers.
  *
- * @cat    Data
- * @subcat String Functions
- * @method nfp
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  nfp
+ *
+ * @param   {Number} value The Number to convert
+ * @param   {Number} leftDigits { parameter_description }
+ * @param   {Number} rightDigits { parameter_description }
+ * @return  {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfp_/
 pub.nfp = function(value, leftDigits, rightDigits) {
@@ -11526,17 +3849,18 @@ pub.nfp = function(value, leftDigits, rightDigits) {
 
 /**
  * @description Utility function for formatting numbers into strings and placing
- * appropriate commas to mark units of 1000. There are two versions, one
- * for formatting ints and one for formatting an array of ints. The value
- * for the digits parameter should always be a positive integer.
+ *          appropriate commas to mark units of 1000. There are two versions,
+ *          one for formatting ints and one for formatting an array of ints. The
+ *          value for the digits parameter should always be a positive integer.
  *
- * @cat    Data
- * @subcat String Functions
- * @method nfc
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  nfc
+ *
+ * @param   {Number} value The Number to convert
+ * @param   {Number} leftDigits { parameter_description }
+ * @param   {Number} rightDigits { parameter_description }
+ * @return  {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfc_/
 pub.nfc = function(value, leftDigits, rightDigits) {
@@ -11545,15 +3869,17 @@ pub.nfc = function(value, leftDigits, rightDigits) {
 
 
 /**
- * @description Removes whitespace characters from the beginning and end of a String.
- * In addition to standard whitespace characters such as space, carriage
- * return, and tab, this function also removes the Unicode "nbsp" character.
+ * @description Removes whitespace characters from the beginning and end of a
+ *          String. In addition to standard whitespace characters such as space,
+ *          carriage return, and tab, this function also removes the Unicode
+ *          "nbsp" character.
  *
- * @cat    Data
- * @subcat String Functions
- * @method trim
- * @param  {String|Array} str A string or an array of strings to be trimmed
- * @return {String|Array} Returns the input in a trimmed way
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  trim
+ *
+ * @param   {String|Array} str A string or an array of strings to be trimmed
+ * @return  {String|Array} Returns the input in a trimmed way
  */
  // From: http://processingjs.org/reference/trim_/
 pub.trim = function(str) {
@@ -11568,11 +3894,12 @@ pub.trim = function(str) {
 /**
  * @description Checks whether an URL string is valid.
  *
- * @cat    Data
- * @subcat String Functions
- * @method isURL
- * @param  {String} url An url string to be checked
- * @return {Boolean} Returns either true or false
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  isURL
+ *
+ * @param   {String} url An url string to be checked
+ * @return  {Boolean} Returns either true or false
  */
 var isURL = pub.isURL = function(url) {
   var pattern = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
@@ -11580,14 +3907,16 @@ var isURL = pub.isURL = function(url) {
 };
 
 /**
- * @description Checks whether a string ends with a specific character or string.
+ * @description Checks whether a string ends with a specific character or
+ *          string.
  *
- * @cat    Data
- * @subcat String Functions
- * @method endsWith
- * @param  {String} str A string to be checked
- * @param  {String} suffix The string to look for
- * @return {Boolean} Returns either true or false
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  endsWith
+ *
+ * @param   {String} str A string to be checked
+ * @param   {String} suffix The string to look for
+ * @return  {Boolean} Returns either true or false
  */
 var endsWith = pub.endsWith = function(str, suffix) {
   if(!isString(str) || !isString(suffix)) {
@@ -11597,14 +3926,16 @@ var endsWith = pub.endsWith = function(str, suffix) {
 };
 
 /**
- * @description Checks whether a string starts with a specific character or string.
+ * @description Checks whether a string starts with a specific character or
+ *          string.
  *
- * @cat    Data
- * @subcat String Functions
- * @method startsWith
- * @param  {String} str A string to be checked
- * @param  {String} prefix The string to look for
- * @return {Boolean} Returns either true or false
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  startsWith
+ *
+ * @param   {String} str A string to be checked
+ * @param   {String} prefix The string to look for
+ * @return  {Boolean} Returns either true or false
  */
 var startsWith = pub.startsWith = function(str, prefix) {
   if(!isString(str) || !isString(prefix)) {
@@ -11615,26 +3946,30 @@ var startsWith = pub.startsWith = function(str, prefix) {
 
 
 /**
- * @description Checks whether a var is an Array, returns true if this is the case
+ * @description Checks whether a var is an array, returns `true` if this is the
+ *          case.
  *
- * @cat    Data
- * @subcat Type-Check
- * @method isArray
- * @param  {Object|String|Number|Boolean} obj The object to check
- * @return {Boolean} returns true if this is the case
+ * @cat     Data
+ * @subcat  Type-Check
+ * @method  isArray
+ *
+ * @param   {Object|String|Number|Boolean} obj The object to check
+ * @return  {Boolean} returns true if this is the case
  */
 var isArray = pub.isArray = function(obj) {
   return Object.prototype.toString.call(obj) === "[object Array]";
 };
 
 /**
- * @description Checks whether a var is a number, returns true if this is the case
+ * @description Checks whether a var is a number, returns `true if this is the
+ *          case.
  *
- * @cat    Data
- * @subcat Type-Check
- * @method isNumber
- * @param  {Object|String|Number|Boolean}  num The number to check
- * @return {Boolean} returns true if this is the case
+ * @cat     Data
+ * @subcat  Type-Check
+ * @method  isNumber
+ *
+ * @param   {Object|String|Number|Boolean} num The number to check
+ * @return  {Boolean} returns true if this is the case
  */
 var isNumber = pub.isNumber = function(num) {
   if (num === null) {
@@ -11648,41 +3983,48 @@ var isNumber = pub.isNumber = function(num) {
 
 
 /**
- * @description Checks whether a var is an integer, returns true if this is the case.
+ * @description Checks whether a var is an integer, returns `true` if this is
+ *          the case.
  *
- * @cat    Data
- * @subcat Type-Check
- * @method isInteger
- * @param  {Object|String|Number|Boolean}  num The number to check.
- * @return {Boolean} Returns true if the given argument is an integer.
+ * @cat     Data
+ * @subcat  Type-Check
+ * @method  isInteger
+ *
+ * @param   {Object|String|Number|Boolean} num The number to check.
+ * @return  {Boolean} Returns true if the given argument is an integer.
  */
 var isInteger = pub.isInteger = function(num) {
   return Object.prototype.toString.call(num) === "[object Number]" && num % 1 === 0;
 };
 
 /**
- * @description Checks whether a var is a string, returns true if this is the case
+ * @description Checks whether a var is a string, returns `true` if this is the
+ *          case
  *
- * @cat    Data
- * @subcat Type-Check
- * @method isString
- * @param  {Object|String|Number|Boolean} str The string to check
- * @return {Boolean} returns true if this is the case
+ * @cat     Data
+ * @subcat  Type-Check
+ * @method  isString
+ *
+ * @param   {Object|String|Number|Boolean} str The string to check
+ * @return  {Boolean} returns true if this is the case
  */
 var isString = pub.isString = function(str) {
   return Object.prototype.toString.call(str) === "[object String]";
 };
 
 /**
- * @description Checks whether a var is an InDesign text object, returns true if this is the case
- * NB: a InDesign TextFrame will return false as it is just a container holding text.
- * So you could say that isText() refers to all the things inside a TextFrame.
+ * @description Checks whether a var is an InDesign text object, returns `true`
+ *          if this is the case. NB: a InDesign text frame will return `false`
+ *          as it is just a container holding text. So you could say that
+ *          `isText()` refers to all the things inside a text frame.
  *
- * @cat    Document
- * @subcat Type-Check
- * @method isText
- * @param  {Character|InsertionPoint|Line|Paragraph|TextColumn|TextStyleRange|Word}  obj The object to check
- * @return {Boolean} returns true if this is the case
+ * @cat     Document
+ * @subcat  Type-Check
+ * @method  isText
+ *
+ * @param   {Character|InsertionPoint|Line|Paragraph|TextColumn|TextStyleRange|Word} obj The
+ *          object to check
+ * @return  {Boolean} returns true if this is the case
  */
 var isText = pub.isText = function(obj) {
 
@@ -11801,12 +4143,14 @@ var initExportFile = function(file) {
 };
 
 /**
- * @description Get the folder of the active document as a Folder object. Use .absoluteURI to access a string representation of the folder path.
+ * @description Get the folder of the active document as a Folder object. Use
+ *          .absoluteURI to access a string representation of the folder path.
  *
- * @cat    Document
- * @subcat Misc
- * @method projectFolder
- * @return {Folder} The folder of the the active document
+ * @cat     Document
+ * @subcat  Misc
+ * @method  projectFolder
+ *
+ * @return  {Folder} The folder of the the active document
  */
 pub.projectFolder = function() {
   if(!currentDoc().saved) {
@@ -11817,15 +4161,17 @@ pub.projectFolder = function() {
 
 
 /**
- * @description Executes a shell command and returns the result, currently Mac only.
- * <br><br>
- * BE CAREFUL!
+ * @description Executes a shell command and returns the result, currently Mac
+ *          only.
+ *          <br><br>
+ *          BE CAREFUL!
  *
- * @cat    Data
- * @subcat Input
- * @method shellExecute
- * @param  {String} cmd The shell command to execute
- * @return {String}
+ * @cat     Data
+ * @subcat  Input
+ * @method  shellExecute
+ *
+ * @param   {String} cmd The shell command to execute
+ * @return  {String} { description_of_the_return_value }
  */
 pub.shellExecute = function(cmd) {
   if (Folder.fs === "Macintosh") {
@@ -11840,14 +4186,17 @@ pub.shellExecute = function(cmd) {
 };
 
 /**
- * @description Reads the contents of a file or loads an URL into a String.
- * If the file is specified by name as String, it must be located in the document's data directory.
+ * @description Reads the contents of a file or loads an URL into a String. If
+ *          the file is specified by name as String, it must be located in the
+ *          document's data directory.
  *
- * @cat    Data
- * @subcat Input
- * @method loadString
- * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
- * @return {String}  String file or URL content.
+ * @cat     Data
+ * @subcat  Input
+ * @method  loadString
+ *
+ * @param   {String|File} file The text file name in the document's data
+ *          directory or a File instance or an URL
+ * @return  {String} String file or URL content.
  */
 pub.loadString = function(file) {
   if (isURL(file)) {
@@ -11875,14 +4224,17 @@ var getURL = function(url) {
 };
 
 /**
- * @description Reads the contents of a file or loads an URL and creates a String array of its individual lines.
- * If the file is specified by name as String, it must be located in the document's data directory.
+ * @description Reads the contents of a file or loads an URL and creates a
+ *          string array of its individual lines. If the file is specified by
+ *          name as string, it must be located in the document's data directory.
  *
- * @cat    Data
- * @subcat Input
- * @method loadStrings
- * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
- * @return {Array}  Array of the individual lines in the given File or URL
+ * @cat     Data
+ * @subcat  Input
+ * @method  loadStrings
+ *
+ * @param   {String|File} file The text file name in the document's data
+ *          directory or a file instance or an URL
+ * @return  {Array} Array of the individual lines in the given file or URL
  */
 pub.loadStrings = function(file) {
   if (isURL(file)) {
@@ -11905,11 +4257,14 @@ pub.loadStrings = function(file) {
 // Output
 
 /**
- * @description Prints a message line to the console output in the ExtendScript editor.
+ * @description Prints a message line to the console output in the ExtendScript
+ *          editor.
  *
- * @cat Output
- * @method println
- * @param {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
+ * @cat     Output
+ * @method  println
+ *
+ * @param   {Any} msg Any combination of Number, String, Object, Boolean, Array
+ *          to print.
  */
 var println = pub.println = function() {
   var msg = Array.prototype.slice.call(arguments).join(" ");
@@ -11919,11 +4274,15 @@ var println = pub.println = function() {
 };
 
 /**
- * @description Prints a message to the console output in the ExtendScript editor, but unlike println() it doesn't return the carriage to a new line at the end.
+ * @description Prints a message to the console output in the ExtendScript
+ *          editor, but unlike `println()` it doesn't return the carriage to a
+ *          new line at the end.
  *
- * @cat    Output
- * @method print
- * @param  {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
+ * @cat     Output
+ * @method  print
+ *
+ * @param   {Any} msg Any combination of Number, String, Object, Boolean, Array
+ *          to print.
  */
 pub.print = function() {
   var msg = Array.prototype.slice.call(arguments).join(" ");
@@ -11933,10 +4292,11 @@ pub.print = function() {
 };
 
 /**
- * @description Print numerous information about the current environment to the console
+ * @description Print numerous information about the current environment to the
+ *          console.
  *
- * @cat    Output
- * @method printInfo
+ * @cat     Output
+ * @method  printInfo
  */
 pub.printInfo = function() {
 
@@ -11951,14 +4311,15 @@ pub.printInfo = function() {
 };
 
 /**
- * @description Writes an array of strings to a file, one line per string.
- * If the given file exists it gets overridden.
+ * @description Writes an array of strings to a file, one line per string. If
+ *          the given file exists it gets overridden.
  *
- * @cat    Output
- * @method saveStrings
- * @param  {String|File} file The file name or a File instance
- * @param  {Array} strings The string array to be written
- * @return {File} The file the strings were written to.
+ * @cat     Output
+ * @method  saveStrings
+ *
+ * @param   {String|File} file The file name or a File instance
+ * @param   {Array} strings The string array to be written
+ * @return  {File} The file the strings were written to.
  */
 pub.saveStrings = function(file, strings) {
   if(!isArray(strings)) {
@@ -11976,14 +4337,15 @@ pub.saveStrings = function(file, strings) {
 };
 
 /**
- * @description Writes a string to a file.
- * If the given file exists it gets overridden.
+ * @description Writes a string to a file. If the given file exists it gets
+ *          overridden.
  *
- * @cat    Output
- * @method saveString
- * @param  {String|File} file The file name or a File instance.
- * @param  {String} string The string to be written.
- * @return {File} The file the string was written to.
+ * @cat     Output
+ * @method  saveString
+ *
+ * @param   {String|File} file The file name or a File instance.
+ * @param   {String} string The string to be written.
+ * @return  {File} The file the string was written to.
  */
 pub.saveString = function(file, string) {
   if(!isString(string)) {
@@ -11999,13 +4361,16 @@ pub.saveString = function(file, string) {
 };
 
 /**
- * @description Exports the current document as PDF to the documents folder. Please note, that export options default to the last used export settings.
+ * @description Exports the current document as PDF to the documents folder.
+ *          Please note that export options default to the last used export
+ *          settings.
  *
- * @cat    Output
- * @method savePDF
- * @param  {String|File} file The file name or a File instance.
- * @param  {Boolean} [showOptions] Whether to show the export dialog.
- * @return {File} The exported PDF file.
+ * @cat     Output
+ * @method  savePDF
+ *
+ * @param   {String|File} file The file name or a File instance.
+ * @param   {Boolean} [showOptions] Whether to show the export dialog.
+ * @return  {File} The exported PDF file.
  */
 pub.savePDF = function(file, showOptions) {
   var outputFile = initExportFile(file);
@@ -12020,13 +4385,16 @@ pub.savePDF = function(file, showOptions) {
 };
 
 /**
- * @description Exports the current document as PNG (or sequence of PNG files) to the documents folder. Please note, that export options default to the last used export settings.
+ * @description Exports the current document as PNG (or sequence of PNG files)
+ *          to the documents folder. Please note, that export options default to
+ *          the last used export settings.
  *
- * @cat    Output
- * @method savePNG
- * @param  {String|File} file The file name or a File instance
- * @param  {Boolean} [showOptions] Whether to show the export dialog
- * @return {File} The exported PNG file.
+ * @cat     Output
+ * @method  savePNG
+ *
+ * @param   {String|File} file The file name or a File instance
+ * @param   {Boolean} [showOptions] Whether to show the export dialog
+ * @return  {File} The exported PNG file.
  */
 pub.savePNG = function(file, showOptions) {
   var outputFile = initExportFile(file);
@@ -12043,10 +4411,12 @@ pub.savePNG = function(file, showOptions) {
 /**
  * @description Downloads an URL to a file, currently Mac only.
  *
- * @cat    Output
- * @method download
- * @param  {String} url The download url
- * @param  {String|File} [file] A relative file path in the project folder or a File instance
+ * @cat     Output
+ * @method  download
+ *
+ * @param   {String} url The download url
+ * @param   {String|File} [file] A relative file path in the project folder or a
+ *          File instance
  */
 pub.download = function(url, file) {
   var projPath = pub.projectFolder().fsName.replace(" ", "\\ ");
@@ -12766,10 +5136,14 @@ pub.duplicate = function(item) {
 /**
  * @description Sets the color or gradient used to fill shapes.
  *
- * @cat    Color
- * @method fill
- * @param  {Color|Gradient|Swatch|Numbers|String} fillColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
- * @param  {String} [name] If created with numbers, a custom swatch name can be given.
+ * @cat     Color
+ * @method  fill
+ *
+ * @param   {Color|Gradient|Swatch|Numbers|String} fillColor Accepts a
+ *          color/gradient/swatch as string name or variable. Or values: GRAY /
+ *          R,G,B / C,M,Y,K.
+ * @param   {String} [name] If created with numbers, a custom swatch name can be
+ *          given.
  */
 pub.fill = function (fillColor) {
 
@@ -12803,22 +5177,26 @@ pub.fill = function (fillColor) {
 };
 
 /**
- * @description Disables filling geometry. If both noStroke() and noFill() are called,
- * newly drawn shapes will be invisible.
+ * @description Disables filling geometry. If both `noStroke()` and `noFill()`
+ *          are called, newly drawn shapes will be invisible.
  *
- * @cat    Color
- * @method noFill
+ * @cat     Color
+ * @method  noFill
  */
 pub.noFill = function () {
   currFillColor = noneSwatchColor;
 };
 
 /**
- * @description Sets the color or gradient used to draw lines and borders around shapes.
+ * @description Sets the color or gradient used to draw lines and borders around
+ *          shapes.
  *
- * @cat Color
- * @method stroke
- * @param {Color|Gradient|Swatch|Numbers|String} strokeColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
+ * @cat     Color
+ * @method  stroke
+ *
+ * @param   {Color|Gradient|Swatch|Numbers|String} strokeColor Accepts a
+ *          color/gradient/swatch as string name or variable. Or values: GRAY /
+ *          R,G,B / C,M,Y,K.
  */
 pub.stroke = function (strokeColor) {
   checkNull(strokeColor);
@@ -12851,11 +5229,11 @@ pub.stroke = function (strokeColor) {
 };
 
 /**
- * @description Disables drawing the stroke. If both noStroke() and noFill() are called,
- * newly drawn shapes will be invisible.
+ * @description Disables drawing the stroke. If both noStroke() and noFill() are
+ *          called, newly drawn shapes will be invisible.
  *
- * @cat    Color
- * @method noStroke
+ * @cat     Color
+ * @method  noStroke
  */
 pub.noStroke = function () {
   currStrokeColor = noneSwatchColor;
@@ -12864,9 +5242,10 @@ pub.noStroke = function () {
 /**
  * @description Sets the tint of the color used to fill shapes.
  *
- * @cat    Color
- * @method fillTint
- * @param  {Number} tint Number from 0 to 100
+ * @cat     Color
+ * @method  fillTint
+ *
+ * @param   {Number} tint Number from 0 to 100
  */
 pub.fillTint = function (tint) {
   checkNull(tint);
@@ -12878,11 +5257,13 @@ pub.fillTint = function (tint) {
 };
 
 /**
- * @description Sets the tint of the color used to draw lines and borders around shapes.
+ * @description Sets the tint of the color used to draw lines and borders around
+ *          shapes.
  *
- * @cat    Color
- * @method strokeTint
- * @param  {Number} tint Number from 0 to 100.
+ * @cat     Color
+ * @method  strokeTint
+ *
+ * @param   {Number} tint Number from 0 to 100.
  */
 pub.strokeTint = function (tint) {
   checkNull(tint);
@@ -12894,11 +5275,13 @@ pub.strokeTint = function (tint) {
 };
 
 /**
- * @description Sets the colormode for creating new colors with color() to RGB or CMYK. The default color mode is RGB.
+ * @description Sets the colormode for creating new colors with color() to RGB
+ *          or CMYK. The default color mode is RGB.
  *
- * @cat    Color
- * @method colorMode
- * @param  {Number} colorMode RGB or CMYK.
+ * @cat     Color
+ * @method  colorMode
+ *
+ * @param   {Number} colorMode RGB or CMYK.
  */
 pub.colorMode = function(colorMode) {
   checkNull(colorMode);
@@ -12913,11 +5296,13 @@ pub.colorMode = function(colorMode) {
 };
 
 /**
- * @description Sets the gradient mode for gradient() to LINEAR or RADIAL. The default gradient mode is LINEAR.
+ * @description Sets the gradient mode for gradient() to `LINEAR` or `RADIAL`.
+ *          The default gradient mode is `LINEAR`.
  *
- * @cat    Color
- * @method gradientMode
- * @param  {String} gradientMode LINEAR or RADIAL.
+ * @cat     Color
+ * @method  gradientMode
+ *
+ * @param   {String} gradientMode `LINEAR` or `RADIAL`.
  */
 pub.gradientMode = function(gradientMode) {
   checkNull(gradientMode);
@@ -12934,9 +5319,11 @@ pub.gradientMode = function(gradientMode) {
 /**
  * @description Gets a swatch by name.
  *
- * @cat    Color
- * @method swatch
- * @param  {String} swatchName Returns the swatch color/gradient for a given name by string.
+ * @cat     Color
+ * @method  swatch
+ *
+ * @param   {String} swatchName Returns the swatch color/gradient for a given
+ *          name by string.
  */
 pub.swatch = function(){
   var newSwatch;
@@ -12957,12 +5344,17 @@ pub.swatch = function(){
 }
 
 /**
- * @description Creates a new RGB / CMYK color and adds it to the document, or gets a color by name from the document. The default color mode is RGB.
+ * @description Creates a new RGB / CMYK color and adds it to the document, or
+ *          gets a color by name from the document. The default color mode is
+ *          RGB.
  *
- * @cat    Color
- * @method color
- * @param  {String|Numbers} Get color: the color name. Create new color: GRAY,[name] / R,G,B,[name] / C,M,Y,K,[name]. Name is always optional.
- * @return {Color} Found or new color
+ * @cat     Color
+ * @method  color
+ *
+ * @param   {String|Numbers} Get color: the color name. Create new color:
+ *          GRAY,[name] / R,G,B,[name] / C,M,Y,K,[name]. Name is always
+ *          optional.
+ * @return  {Color} Found or new color
  */
 pub.color = function() {
   var newCol;
@@ -13093,19 +5485,30 @@ pub.color = function() {
 };
 
 /**
- * @description Creates a new gradient and adds it to the document, or gets a gradient by name from the document.<br>
- * If two colors are given as the first two parameters, a gradient is created that blends between these two colors. If an array of colors is used
- * as the first parameter, a gradient with the contained colors will be created. The colors will be distributed evenly. If additionally to this array
- * a second array of gradient stop positions is given, the colors will be positioned at the given gradient stops. Possible gradient stop positions
- * range from 0 to 100. All parameter options allow for an additional name parameter at the end to name the new gradient.
- * If a string is used as the only parameter, the gradient with that name will be returned, if it exists in the document.
+ * @description Creates a new gradient and adds it to the document, or gets a
+ *          gradient by name from the document.<br>
+ *          If two colors are given as
+ *          the first two parameters, a gradient is created that blends between
+ *          these two colors. If an array of colors is used as the first
+ *          parameter, a gradient with the contained colors will be created. The
+ *          colors will be distributed evenly. If additionally to this array a
+ *          second array of gradient stop positions is given, the colors will be
+ *          positioned at the given gradient stops. Possible gradient stop
+ *          positions range from 0 to 100. All parameter options allow for an
+ *          additional name parameter at the end to name the new gradient. If a
+ *          string is used as the only parameter, the gradient with that name
+ *          will be returned, if it exists in the document.
  *
- * @cat    Color
- * @method gradient
- * @param  {Color|Array|String} c1 First color of the gradient. Alternatively: Array of colors/gradients or name of gradient to get.
- * @param  {Color|Array|String} c2 Second color of the gradient. Alternatively: Array of gradient stop positions (if first parameter is an array of colors).
- * @param  {String} [name] Optional name of the gradient.
- * @return {Gradient} Found or new gradient
+ * @cat     Color
+ * @method  gradient
+ *
+ * @param   {Color|Array|String} c1 First color of the gradient. Alternatively:
+ *          Array of colors/gradients or name of gradient to get.
+ * @param   {Color|Array|String} c2 Second color of the gradient. Alternatively:
+ *          Array of gradient stop positions (if first parameter is an array of
+ *          colors).
+ * @param   {String} [name] Optional name of the gradient.
+ * @return  {Gradient} Found or new gradient
  */
 pub.gradient = function() {
   var newGrad;
@@ -13211,10 +5614,11 @@ pub.gradient = function() {
 /**
  * @description Sets the opacity property of an object.
  *
- * @cat    Color
- * @method opacity
- * @param  {Object} obj The object to set opacity of.
- * @param  {Number} opacity The opacity value from 0 to 100.
+ * @cat     Color
+ * @method  opacity
+ *
+ * @param   {Object} obj The object to set opacity of.
+ * @param   {Number} opacity The opacity value from 0 to 100.
  */
 pub.opacity = function(obj, opacity) {
   checkNull(obj);
@@ -13228,26 +5632,28 @@ pub.opacity = function(obj, opacity) {
 /**
  * @description Sets the Effects blendMode property of an object.
  *
- * @cat    Color
- * @method blendMode
- * @param  {Object} obj The object to set blendMode of.
- * @param  {Number} blendMode The blendMode must be one of the InDesign BlendMode enum values:
- *    - `BlendMode.NORMAL`
- *    - `BlendMode.MULTIPLY`
- *    - `BlendMode.SCREEN`
- *    - `BlendMode.OVERLAY`
- *    - `BlendMode.SOFT_LIGHT`
- *    - `BlendMode.HARD_LIGHT`
- *    - `BlendMode.COLOR_DODGE`
- *    - `BlendMode.COLOR_BURN`
- *    - `BlendMode.DARKEN`
- *    - `BlendMode.LIGHTEN`
- *    - `BlendMode.DIFFERENCE`
- *    - `BlendMode.EXCLUSION`
- *    - `BlendMode.HUE`
- *    - `BlendMode.SATURATION`
- *    - `BlendMode.COLOR`
- *    - `BlendMode.LUMINOSITY`
+ * @cat     Color
+ * @method  blendMode
+ *
+ * @param   {Object} obj The object to set blendMode of.
+ * @param   {Number} blendMode The blendMode must be one of the InDesign
+ *          BlendMode enum values:
+ *      - `BlendMode.NORMAL`
+ *      - `BlendMode.MULTIPLY`
+ *      - `BlendMode.SCREEN`
+ *      - `BlendMode.OVERLAY`
+ *      - `BlendMode.SOFT_LIGHT`
+ *      - `BlendMode.HARD_LIGHT`
+ *      - `BlendMode.COLOR_DODGE`
+ *      - `BlendMode.COLOR_BURN`
+ *      - `BlendMode.DARKEN`
+ *      - `BlendMode.LIGHTEN`
+ *      - `BlendMode.DIFFERENCE`
+ *      - `BlendMode.EXCLUSION`
+ *      - `BlendMode.HUE`
+ *      - `BlendMode.SATURATION`
+ *      - `BlendMode.COLOR`
+ *      - `BlendMode.LUMINOSITY`
  */
 pub.blendMode = function(obj, blendMode) {
   checkNull(obj);
@@ -13259,16 +5665,20 @@ pub.blendMode = function(obj, blendMode) {
 };
 
 /**
- * @description Calculates a color or colors between two colors at a specific increment.<br>
- * The amt parameter is the amount to interpolate between the two values where 0.0 equals the first color, 0.5 is half-way in between and 1.0 equals the second color.
- * N.B.: Both colors must be either CMYK or RGB.
+ * @description Calculates a color or colors between two colors at a specific
+ *          increment.<br>
+ *          The `amt` parameter is the amount to interpolate between
+ *          the two values where 0.0 equals the first color, 0.5 is half-way in
+ *          between and 1.0 equals the second color. N.B.: Both colors must be
+ *          either CMYK or RGB.
  *
- * @cat    Color
- * @method lerpColor
- * @param  {Color} c1   Input color 1.
- * @param  {Color} c2   Input color 2.
- * @param  {Number} amt The amount to interpolate between the two colors.
- * @return {Color} Interpolated color
+ * @cat     Color
+ * @method  lerpColor
+ *
+ * @param   {Color} c1 Input color 1.
+ * @param   {Color} c2 Input color 2.
+ * @param   {Number} amt The amount to interpolate between the two colors.
+ * @return  {Color} Interpolated color
  */
 pub.lerpColor = function (c1, c2, amt) {
   checkNull(c1);

--- a/src/includes/color.js
+++ b/src/includes/color.js
@@ -3,8 +3,9 @@
 // ----------------------------------------
 
 /**
- * Sets the color or gradient used to fill shapes.
- * @cat Color
+ * @description Sets the color or gradient used to fill shapes.
+ *
+ * @cat    Color
  * @method fill
  * @param  {Color|Gradient|Swatch|Numbers|String} fillColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
  * @param  {String} [name] If created with numbers, a custom swatch name can be given.
@@ -41,10 +42,10 @@ pub.fill = function (fillColor) {
 };
 
 /**
- * Disables filling geometry. If both noStroke() and noFill() are called,
+ * @description Disables filling geometry. If both noStroke() and noFill() are called,
  * newly drawn shapes will be invisible.
  *
- * @cat Color
+ * @cat    Color
  * @method noFill
  */
 pub.noFill = function () {
@@ -52,10 +53,11 @@ pub.noFill = function () {
 };
 
 /**
- * Sets the color or gradient used to draw lines and borders around shapes.
+ * @description Sets the color or gradient used to draw lines and borders around shapes.
+ *
  * @cat Color
  * @method stroke
- * @param  {Color|Gradient|Swatch|Numbers|String} strokeColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
+ * @param {Color|Gradient|Swatch|Numbers|String} strokeColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
  */
 pub.stroke = function (strokeColor) {
   checkNull(strokeColor);
@@ -88,10 +90,10 @@ pub.stroke = function (strokeColor) {
 };
 
 /**
- * Disables drawing the stroke. If both noStroke() and noFill() are called,
+ * @description Disables drawing the stroke. If both noStroke() and noFill() are called,
  * newly drawn shapes will be invisible.
  *
- * @cat Color
+ * @cat    Color
  * @method noStroke
  */
 pub.noStroke = function () {
@@ -99,9 +101,9 @@ pub.noStroke = function () {
 };
 
 /**
- * Sets the tint of the color used to fill shapes.
+ * @description Sets the tint of the color used to fill shapes.
  *
- * @cat Color
+ * @cat    Color
  * @method fillTint
  * @param  {Number} tint Number from 0 to 100
  */
@@ -115,9 +117,9 @@ pub.fillTint = function (tint) {
 };
 
 /**
- * Sets the tint of the color used to draw lines and borders around shapes.
+ * @description Sets the tint of the color used to draw lines and borders around shapes.
  *
- * @cat Color
+ * @cat    Color
  * @method strokeTint
  * @param  {Number} tint Number from 0 to 100.
  */
@@ -131,9 +133,9 @@ pub.strokeTint = function (tint) {
 };
 
 /**
- * Sets the colormode for creating new colors with color() to RGB or CMYK. The default color mode is RGB.
+ * @description Sets the colormode for creating new colors with color() to RGB or CMYK. The default color mode is RGB.
  *
- * @cat Color
+ * @cat    Color
  * @method colorMode
  * @param  {Number} colorMode RGB or CMYK.
  */
@@ -150,9 +152,9 @@ pub.colorMode = function(colorMode) {
 };
 
 /**
- * Sets the gradient mode for gradient() to LINEAR or RADIAL. The default gradient mode is LINEAR.
+ * @description Sets the gradient mode for gradient() to LINEAR or RADIAL. The default gradient mode is LINEAR.
  *
- * @cat Color
+ * @cat    Color
  * @method gradientMode
  * @param  {String} gradientMode LINEAR or RADIAL.
  */
@@ -169,11 +171,11 @@ pub.gradientMode = function(gradientMode) {
 };
 
 /**
- * Gets a swatch by name.
+ * @description Gets a swatch by name.
  *
- * @cat Color
+ * @cat    Color
  * @method swatch
- * @param {String} swatchName Returns the swatch color/gradient for a given name by string.
+ * @param  {String} swatchName Returns the swatch color/gradient for a given name by string.
  */
 pub.swatch = function(){
   var newSwatch;
@@ -194,9 +196,9 @@ pub.swatch = function(){
 }
 
 /**
- * Creates a new RGB / CMYK color and adds it to the document, or gets a color by name from the document. The default color mode is RGB.
+ * @description Creates a new RGB / CMYK color and adds it to the document, or gets a color by name from the document. The default color mode is RGB.
  *
- * @cat Color
+ * @cat    Color
  * @method color
  * @param  {String|Numbers} Get color: the color name. Create new color: GRAY,[name] / R,G,B,[name] / C,M,Y,K,[name]. Name is always optional.
  * @return {Color} Found or new color
@@ -330,18 +332,18 @@ pub.color = function() {
 };
 
 /**
- * Creates a new gradient and adds it to the document, or gets a gradient by name from the document.
+ * @description Creates a new gradient and adds it to the document, or gets a gradient by name from the document.<br>
  * If two colors are given as the first two parameters, a gradient is created that blends between these two colors. If an array of colors is used
  * as the first parameter, a gradient with the contained colors will be created. The colors will be distributed evenly. If additionally to this array
  * a second array of gradient stop positions is given, the colors will be positioned at the given gradient stops. Possible gradient stop positions
  * range from 0 to 100. All parameter options allow for an additional name parameter at the end to name the new gradient.
  * If a string is used as the only parameter, the gradient with that name will be returned, if it exists in the document.
  *
- * @cat Color
+ * @cat    Color
  * @method gradient
- * @param {Color|Array|String} c1 First color of the gradient. Alternatively: Array of colors/gradients or name of gradient to get.
- * @param {Color|Array|String} c2 Second color of the gradient. Alternatively: Array of gradient stop positions (if first parameter is an array of colors).
- * @param {String} [name] Optional name of the gradient.
+ * @param  {Color|Array|String} c1 First color of the gradient. Alternatively: Array of colors/gradients or name of gradient to get.
+ * @param  {Color|Array|String} c2 Second color of the gradient. Alternatively: Array of gradient stop positions (if first parameter is an array of colors).
+ * @param  {String} [name] Optional name of the gradient.
  * @return {Gradient} Found or new gradient
  */
 pub.gradient = function() {
@@ -446,9 +448,9 @@ pub.gradient = function() {
 };
 
 /**
- * Sets the opacity property of an object.
+ * @description Sets the opacity property of an object.
  *
- * @cat Color
+ * @cat    Color
  * @method opacity
  * @param  {Object} obj The object to set opacity of.
  * @param  {Number} opacity The opacity value from 0 to 100.
@@ -463,28 +465,28 @@ pub.opacity = function(obj, opacity) {
 };
 
 /**
- * Sets the Effects blendMode property of an object.
+ * @description Sets the Effects blendMode property of an object.
  *
- * @cat Color
+ * @cat    Color
  * @method blendMode
  * @param  {Object} obj The object to set blendMode of.
  * @param  {Number} blendMode The blendMode must be one of the InDesign BlendMode enum values:
- *                           BlendMode.NORMAL <br />
- *                           BlendMode.MULTIPLY <br />
- *                           BlendMode.SCREEN <br />
- *                           BlendMode.OVERLAY <br />
- *                           BlendMode.SOFT_LIGHT <br />
- *                           BlendMode.HARD_LIGHT <br />
- *                           BlendMode.COLOR_DODGE <br />
- *                           BlendMode.COLOR_BURN <br />
- *                           BlendMode.DARKEN <br />
- *                           BlendMode.LIGHTEN <br />
- *                           BlendMode.DIFFERENCE <br />
- *                           BlendMode.EXCLUSION <br />
- *                           BlendMode.HUE <br />
- *                           BlendMode.SATURATION <br />
- *                           BlendMode.COLOR <br />
- *                           BlendMode.LUMINOSITY <br />
+ *                           BlendMode.NORMAL<br>
+ *                           BlendMode.MULTIPLY<br>
+ *                           BlendMode.SCREEN<br>
+ *                           BlendMode.OVERLAY<br>
+ *                           BlendMode.SOFT_LIGHT<br>
+ *                           BlendMode.HARD_LIGHT<br>
+ *                           BlendMode.COLOR_DODGE<br>
+ *                           BlendMode.COLOR_BURN<br>
+ *                           BlendMode.DARKEN<br>
+ *                           BlendMode.LIGHTEN<br>
+ *                           BlendMode.DIFFERENCE<br>
+ *                           BlendMode.EXCLUSION<br>
+ *                           BlendMode.HUE<br>
+ *                           BlendMode.SATURATION<br>
+ *                           BlendMode.COLOR<br>
+ *                           BlendMode.LUMINOSITY<br>
  */
 pub.blendMode = function(obj, blendMode) {
   checkNull(obj);
@@ -496,11 +498,11 @@ pub.blendMode = function(obj, blendMode) {
 };
 
 /**
- * Calculates a color or colors between two colors at a specific increment.
+ * @description Calculates a color or colors between two colors at a specific increment.<br>
  * The amt parameter is the amount to interpolate between the two values where 0.0 equals the first color, 0.5 is half-way in between and 1.0 equals the second color.
  * N.B.: Both colors must be either CMYK or RGB.
  *
- * @cat Color
+ * @cat    Color
  * @method lerpColor
  * @param  {Color} c1   Input color 1.
  * @param  {Color} c2   Input color 2.

--- a/src/includes/color.js
+++ b/src/includes/color.js
@@ -5,10 +5,14 @@
 /**
  * @description Sets the color or gradient used to fill shapes.
  *
- * @cat    Color
- * @method fill
- * @param  {Color|Gradient|Swatch|Numbers|String} fillColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
- * @param  {String} [name] If created with numbers, a custom swatch name can be given.
+ * @cat     Color
+ * @method  fill
+ *
+ * @param   {Color|Gradient|Swatch|Numbers|String} fillColor Accepts a
+ *          color/gradient/swatch as string name or variable. Or values: GRAY /
+ *          R,G,B / C,M,Y,K.
+ * @param   {String} [name] If created with numbers, a custom swatch name can be
+ *          given.
  */
 pub.fill = function (fillColor) {
 
@@ -42,22 +46,26 @@ pub.fill = function (fillColor) {
 };
 
 /**
- * @description Disables filling geometry. If both noStroke() and noFill() are called,
- * newly drawn shapes will be invisible.
+ * @description Disables filling geometry. If both `noStroke()` and `noFill()`
+ *          are called, newly drawn shapes will be invisible.
  *
- * @cat    Color
- * @method noFill
+ * @cat     Color
+ * @method  noFill
  */
 pub.noFill = function () {
   currFillColor = noneSwatchColor;
 };
 
 /**
- * @description Sets the color or gradient used to draw lines and borders around shapes.
+ * @description Sets the color or gradient used to draw lines and borders around
+ *          shapes.
  *
- * @cat Color
- * @method stroke
- * @param {Color|Gradient|Swatch|Numbers|String} strokeColor Accepts a color/gradient/swatch as string name or variable. Or values: GRAY / R,G,B / C,M,Y,K.
+ * @cat     Color
+ * @method  stroke
+ *
+ * @param   {Color|Gradient|Swatch|Numbers|String} strokeColor Accepts a
+ *          color/gradient/swatch as string name or variable. Or values: GRAY /
+ *          R,G,B / C,M,Y,K.
  */
 pub.stroke = function (strokeColor) {
   checkNull(strokeColor);
@@ -90,11 +98,11 @@ pub.stroke = function (strokeColor) {
 };
 
 /**
- * @description Disables drawing the stroke. If both noStroke() and noFill() are called,
- * newly drawn shapes will be invisible.
+ * @description Disables drawing the stroke. If both noStroke() and noFill() are
+ *          called, newly drawn shapes will be invisible.
  *
- * @cat    Color
- * @method noStroke
+ * @cat     Color
+ * @method  noStroke
  */
 pub.noStroke = function () {
   currStrokeColor = noneSwatchColor;
@@ -103,9 +111,10 @@ pub.noStroke = function () {
 /**
  * @description Sets the tint of the color used to fill shapes.
  *
- * @cat    Color
- * @method fillTint
- * @param  {Number} tint Number from 0 to 100
+ * @cat     Color
+ * @method  fillTint
+ *
+ * @param   {Number} tint Number from 0 to 100
  */
 pub.fillTint = function (tint) {
   checkNull(tint);
@@ -117,11 +126,13 @@ pub.fillTint = function (tint) {
 };
 
 /**
- * @description Sets the tint of the color used to draw lines and borders around shapes.
+ * @description Sets the tint of the color used to draw lines and borders around
+ *          shapes.
  *
- * @cat    Color
- * @method strokeTint
- * @param  {Number} tint Number from 0 to 100.
+ * @cat     Color
+ * @method  strokeTint
+ *
+ * @param   {Number} tint Number from 0 to 100.
  */
 pub.strokeTint = function (tint) {
   checkNull(tint);
@@ -133,11 +144,13 @@ pub.strokeTint = function (tint) {
 };
 
 /**
- * @description Sets the colormode for creating new colors with color() to RGB or CMYK. The default color mode is RGB.
+ * @description Sets the colormode for creating new colors with color() to RGB
+ *          or CMYK. The default color mode is RGB.
  *
- * @cat    Color
- * @method colorMode
- * @param  {Number} colorMode RGB or CMYK.
+ * @cat     Color
+ * @method  colorMode
+ *
+ * @param   {Number} colorMode RGB or CMYK.
  */
 pub.colorMode = function(colorMode) {
   checkNull(colorMode);
@@ -152,11 +165,13 @@ pub.colorMode = function(colorMode) {
 };
 
 /**
- * @description Sets the gradient mode for gradient() to LINEAR or RADIAL. The default gradient mode is LINEAR.
+ * @description Sets the gradient mode for gradient() to `LINEAR` or `RADIAL`.
+ *          The default gradient mode is `LINEAR`.
  *
- * @cat    Color
- * @method gradientMode
- * @param  {String} gradientMode LINEAR or RADIAL.
+ * @cat     Color
+ * @method  gradientMode
+ *
+ * @param   {String} gradientMode `LINEAR` or `RADIAL`.
  */
 pub.gradientMode = function(gradientMode) {
   checkNull(gradientMode);
@@ -173,9 +188,11 @@ pub.gradientMode = function(gradientMode) {
 /**
  * @description Gets a swatch by name.
  *
- * @cat    Color
- * @method swatch
- * @param  {String} swatchName Returns the swatch color/gradient for a given name by string.
+ * @cat     Color
+ * @method  swatch
+ *
+ * @param   {String} swatchName Returns the swatch color/gradient for a given
+ *          name by string.
  */
 pub.swatch = function(){
   var newSwatch;
@@ -196,12 +213,17 @@ pub.swatch = function(){
 }
 
 /**
- * @description Creates a new RGB / CMYK color and adds it to the document, or gets a color by name from the document. The default color mode is RGB.
+ * @description Creates a new RGB / CMYK color and adds it to the document, or
+ *          gets a color by name from the document. The default color mode is
+ *          RGB.
  *
- * @cat    Color
- * @method color
- * @param  {String|Numbers} Get color: the color name. Create new color: GRAY,[name] / R,G,B,[name] / C,M,Y,K,[name]. Name is always optional.
- * @return {Color} Found or new color
+ * @cat     Color
+ * @method  color
+ *
+ * @param   {String|Numbers} Get color: the color name. Create new color:
+ *          GRAY,[name] / R,G,B,[name] / C,M,Y,K,[name]. Name is always
+ *          optional.
+ * @return  {Color} Found or new color
  */
 pub.color = function() {
   var newCol;
@@ -332,19 +354,30 @@ pub.color = function() {
 };
 
 /**
- * @description Creates a new gradient and adds it to the document, or gets a gradient by name from the document.<br>
- * If two colors are given as the first two parameters, a gradient is created that blends between these two colors. If an array of colors is used
- * as the first parameter, a gradient with the contained colors will be created. The colors will be distributed evenly. If additionally to this array
- * a second array of gradient stop positions is given, the colors will be positioned at the given gradient stops. Possible gradient stop positions
- * range from 0 to 100. All parameter options allow for an additional name parameter at the end to name the new gradient.
- * If a string is used as the only parameter, the gradient with that name will be returned, if it exists in the document.
+ * @description Creates a new gradient and adds it to the document, or gets a
+ *          gradient by name from the document.<br>
+ *          If two colors are given as
+ *          the first two parameters, a gradient is created that blends between
+ *          these two colors. If an array of colors is used as the first
+ *          parameter, a gradient with the contained colors will be created. The
+ *          colors will be distributed evenly. If additionally to this array a
+ *          second array of gradient stop positions is given, the colors will be
+ *          positioned at the given gradient stops. Possible gradient stop
+ *          positions range from 0 to 100. All parameter options allow for an
+ *          additional name parameter at the end to name the new gradient. If a
+ *          string is used as the only parameter, the gradient with that name
+ *          will be returned, if it exists in the document.
  *
- * @cat    Color
- * @method gradient
- * @param  {Color|Array|String} c1 First color of the gradient. Alternatively: Array of colors/gradients or name of gradient to get.
- * @param  {Color|Array|String} c2 Second color of the gradient. Alternatively: Array of gradient stop positions (if first parameter is an array of colors).
- * @param  {String} [name] Optional name of the gradient.
- * @return {Gradient} Found or new gradient
+ * @cat     Color
+ * @method  gradient
+ *
+ * @param   {Color|Array|String} c1 First color of the gradient. Alternatively:
+ *          Array of colors/gradients or name of gradient to get.
+ * @param   {Color|Array|String} c2 Second color of the gradient. Alternatively:
+ *          Array of gradient stop positions (if first parameter is an array of
+ *          colors).
+ * @param   {String} [name] Optional name of the gradient.
+ * @return  {Gradient} Found or new gradient
  */
 pub.gradient = function() {
   var newGrad;
@@ -450,10 +483,11 @@ pub.gradient = function() {
 /**
  * @description Sets the opacity property of an object.
  *
- * @cat    Color
- * @method opacity
- * @param  {Object} obj The object to set opacity of.
- * @param  {Number} opacity The opacity value from 0 to 100.
+ * @cat     Color
+ * @method  opacity
+ *
+ * @param   {Object} obj The object to set opacity of.
+ * @param   {Number} opacity The opacity value from 0 to 100.
  */
 pub.opacity = function(obj, opacity) {
   checkNull(obj);
@@ -467,26 +501,28 @@ pub.opacity = function(obj, opacity) {
 /**
  * @description Sets the Effects blendMode property of an object.
  *
- * @cat    Color
- * @method blendMode
- * @param  {Object} obj The object to set blendMode of.
- * @param  {Number} blendMode The blendMode must be one of the InDesign BlendMode enum values:
- *    - `BlendMode.NORMAL`
- *    - `BlendMode.MULTIPLY`
- *    - `BlendMode.SCREEN`
- *    - `BlendMode.OVERLAY`
- *    - `BlendMode.SOFT_LIGHT`
- *    - `BlendMode.HARD_LIGHT`
- *    - `BlendMode.COLOR_DODGE`
- *    - `BlendMode.COLOR_BURN`
- *    - `BlendMode.DARKEN`
- *    - `BlendMode.LIGHTEN`
- *    - `BlendMode.DIFFERENCE`
- *    - `BlendMode.EXCLUSION`
- *    - `BlendMode.HUE`
- *    - `BlendMode.SATURATION`
- *    - `BlendMode.COLOR`
- *    - `BlendMode.LUMINOSITY`
+ * @cat     Color
+ * @method  blendMode
+ *
+ * @param   {Object} obj The object to set blendMode of.
+ * @param   {Number} blendMode The blendMode must be one of the InDesign
+ *          BlendMode enum values:
+ *      - `BlendMode.NORMAL`
+ *      - `BlendMode.MULTIPLY`
+ *      - `BlendMode.SCREEN`
+ *      - `BlendMode.OVERLAY`
+ *      - `BlendMode.SOFT_LIGHT`
+ *      - `BlendMode.HARD_LIGHT`
+ *      - `BlendMode.COLOR_DODGE`
+ *      - `BlendMode.COLOR_BURN`
+ *      - `BlendMode.DARKEN`
+ *      - `BlendMode.LIGHTEN`
+ *      - `BlendMode.DIFFERENCE`
+ *      - `BlendMode.EXCLUSION`
+ *      - `BlendMode.HUE`
+ *      - `BlendMode.SATURATION`
+ *      - `BlendMode.COLOR`
+ *      - `BlendMode.LUMINOSITY`
  */
 pub.blendMode = function(obj, blendMode) {
   checkNull(obj);
@@ -498,16 +534,20 @@ pub.blendMode = function(obj, blendMode) {
 };
 
 /**
- * @description Calculates a color or colors between two colors at a specific increment.<br>
- * The amt parameter is the amount to interpolate between the two values where 0.0 equals the first color, 0.5 is half-way in between and 1.0 equals the second color.
- * N.B.: Both colors must be either CMYK or RGB.
+ * @description Calculates a color or colors between two colors at a specific
+ *          increment.<br>
+ *          The `amt` parameter is the amount to interpolate between
+ *          the two values where 0.0 equals the first color, 0.5 is half-way in
+ *          between and 1.0 equals the second color. N.B.: Both colors must be
+ *          either CMYK or RGB.
  *
- * @cat    Color
- * @method lerpColor
- * @param  {Color} c1   Input color 1.
- * @param  {Color} c2   Input color 2.
- * @param  {Number} amt The amount to interpolate between the two colors.
- * @return {Color} Interpolated color
+ * @cat     Color
+ * @method  lerpColor
+ *
+ * @param   {Color} c1 Input color 1.
+ * @param   {Color} c2 Input color 2.
+ * @param   {Number} amt The amount to interpolate between the two colors.
+ * @return  {Color} Interpolated color
  */
 pub.lerpColor = function (c1, c2, amt) {
   checkNull(c1);

--- a/src/includes/color.js
+++ b/src/includes/color.js
@@ -471,22 +471,22 @@ pub.opacity = function(obj, opacity) {
  * @method blendMode
  * @param  {Object} obj The object to set blendMode of.
  * @param  {Number} blendMode The blendMode must be one of the InDesign BlendMode enum values:
- *                           BlendMode.NORMAL<br>
- *                           BlendMode.MULTIPLY<br>
- *                           BlendMode.SCREEN<br>
- *                           BlendMode.OVERLAY<br>
- *                           BlendMode.SOFT_LIGHT<br>
- *                           BlendMode.HARD_LIGHT<br>
- *                           BlendMode.COLOR_DODGE<br>
- *                           BlendMode.COLOR_BURN<br>
- *                           BlendMode.DARKEN<br>
- *                           BlendMode.LIGHTEN<br>
- *                           BlendMode.DIFFERENCE<br>
- *                           BlendMode.EXCLUSION<br>
- *                           BlendMode.HUE<br>
- *                           BlendMode.SATURATION<br>
- *                           BlendMode.COLOR<br>
- *                           BlendMode.LUMINOSITY<br>
+ *    - `BlendMode.NORMAL`
+ *    - `BlendMode.MULTIPLY`
+ *    - `BlendMode.SCREEN`
+ *    - `BlendMode.OVERLAY`
+ *    - `BlendMode.SOFT_LIGHT`
+ *    - `BlendMode.HARD_LIGHT`
+ *    - `BlendMode.COLOR_DODGE`
+ *    - `BlendMode.COLOR_BURN`
+ *    - `BlendMode.DARKEN`
+ *    - `BlendMode.LIGHTEN`
+ *    - `BlendMode.DIFFERENCE`
+ *    - `BlendMode.EXCLUSION`
+ *    - `BlendMode.HUE`
+ *    - `BlendMode.SATURATION`
+ *    - `BlendMode.COLOR`
+ *    - `BlendMode.LUMINOSITY`
  */
 pub.blendMode = function(obj, blendMode) {
   checkNull(obj);

--- a/src/includes/color.js
+++ b/src/includes/color.js
@@ -507,22 +507,22 @@ pub.opacity = function(obj, opacity) {
  * @param   {Object} obj The object to set blendMode of.
  * @param   {Number} blendMode The blendMode must be one of the InDesign
  *          BlendMode enum values:
- *      - `BlendMode.NORMAL`
- *      - `BlendMode.MULTIPLY`
- *      - `BlendMode.SCREEN`
- *      - `BlendMode.OVERLAY`
- *      - `BlendMode.SOFT_LIGHT`
- *      - `BlendMode.HARD_LIGHT`
- *      - `BlendMode.COLOR_DODGE`
- *      - `BlendMode.COLOR_BURN`
- *      - `BlendMode.DARKEN`
- *      - `BlendMode.LIGHTEN`
- *      - `BlendMode.DIFFERENCE`
- *      - `BlendMode.EXCLUSION`
- *      - `BlendMode.HUE`
- *      - `BlendMode.SATURATION`
- *      - `BlendMode.COLOR`
- *      - `BlendMode.LUMINOSITY`
+ *   - `BlendMode.NORMAL`
+ *   - `BlendMode.MULTIPLY`
+ *   - `BlendMode.SCREEN`
+ *   - `BlendMode.OVERLAY`
+ *   - `BlendMode.SOFT_LIGHT`
+ *   - `BlendMode.HARD_LIGHT`
+ *   - `BlendMode.COLOR_DODGE`
+ *   - `BlendMode.COLOR_BURN`
+ *   - `BlendMode.DARKEN`
+ *   - `BlendMode.LIGHTEN`
+ *   - `BlendMode.DIFFERENCE`
+ *   - `BlendMode.EXCLUSION`
+ *   - `BlendMode.HUE`
+ *   - `BlendMode.SATURATION`
+ *   - `BlendMode.COLOR`
+ *   - `BlendMode.LUMINOSITY`
  */
 pub.blendMode = function(obj, blendMode) {
   checkNull(obj);

--- a/src/includes/constants.js
+++ b/src/includes/constants.js
@@ -404,7 +404,7 @@ var stackArray = $.stack.
 pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1] : stackArray[0];
 
 /**
-* Used with <code>mode()</code> to set performance mode. Disables screen redraw during processing.
+* Used with `mode()` to set performance mode. Disables screen redraw during processing.
 * @property SILENT {String}
 * @cat Environment
 * @subcat modes
@@ -412,7 +412,7 @@ pub.SCRIPTNAME = stackArray[0] === "jsRunner.jsx" ? stackArray[1] : stackArray[0
 pub.SILENT = "silent";
 
 /**
- * Used with <code>mode()</code> to set performance mode. Processes the document in background mode. The document will not be visible until the script is done or until the mode is changed back to <code>VISIBLE</code>. The document will be removed from the display list and added again after the script is done. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use <code>println("yourMessage")</code> in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.
+ * Used with `mode()` to set performance mode. Processes the document in background mode. The document will not be visible until the script is done or until the mode is changed back to `VISIBLE`. The document will be removed from the display list and added again after the script is done. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use `println("yourMessage")` in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.
  * @property HIDDEN {String}
  * @cat Environment
  * @subcat modes
@@ -420,7 +420,7 @@ pub.SILENT = "silent";
 pub.HIDDEN = "hidden";
 
 /**
- * Default mode. Used with <code>mode()</code> to set performance mode. Processes the document with screen redraw, use this option to see direct results during the process. This will slow down the process in terms of processing time.
+ * Default mode. Used with `mode()` to set performance mode. Processes the document with screen redraw, use this option to see direct results during the process. This will slow down the process in terms of processing time.
  * @property VISIBLE {String}
  * @cat Environment
  * @subcat modes

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -142,12 +142,18 @@ var prepareLoop = function() {
 }
 
 /**
- * @description Sets the framerate per second to determine how often loop() is called per second. If the processor is not fast enough to maintain the specified rate, the frame rate will not be achieved. Setting the frame rate within setup() is recommended. The default rate is 25 frames per second. Calling frameRate() with no arguments returns the currently set framerate.
+ * @description Sets the framerate per second to determine how often `loop()` is
+ *          called per second. If the processor is not fast enough to maintain
+ *          the specified rate, the frame rate will not be achieved. Setting the
+ *          frame rate within `setup()` is recommended. The default rate is 25
+ *          frames per second. Calling `frameRate()` with no arguments returns
+ *          the currently set framerate.
  *
- * @cat    Environment
- * @method frameRate
- * @param  {Number} [fps] Frames per second.
- * @return {Number} Currently set frame rate.
+ * @cat     Environment
+ * @method  frameRate
+ *
+ * @param   {Number} [fps] Frames per second.
+ * @return  {Number} Currently set frame rate.
  */
 pub.frameRate = function(fps) {
   if(arguments.length) {
@@ -164,10 +170,11 @@ pub.frameRate = function(fps) {
 };
 
 /**
- * @description Stops basil from continuously executing the code within loop() and quits the script.
+ * @description Stops basil from continuously executing the code within `loop()`
+ *          and quits the script.
  *
- * @cat    Environment
- * @method noLoop
+ * @cat     Environment
+ * @method  noLoop
  */
 pub.noLoop = function(printFinished) {
   var allIdleTasks = app.idleTasks;
@@ -182,14 +189,36 @@ pub.noLoop = function(printFinished) {
 };
 
 /**
- * @description Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, `mode()` should be placed in the beginning of the script. In basil there are three different performance modes:<br>
- * `VISIBLE` is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.<br>
- * `HIDDEN` allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use `println("yourMessage")` in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.<br>
- * `SILENT` processes the document without redrawing the screen. The document will stay visible and only update once the script is finished or once the mode is changed back to `VISIBLE`.
+ * @description Used to set the performance mode. While modes can be switched
+ *          during script execution, to use a mode for the entire script
+ *          execution, `mode()` should be placed in the beginning of the script.
+ *          In basil there are three different performance modes:
  *
- * @cat    Environment
- * @method mode
- * @param  {String} mode The performance mode to switch to.
+ *      - `VISIBLE`
+ *          is the default mode. In this mode, during script execution the
+ *          document will be processed with screen redraw, allowing to see
+ *          direct results during the process. As the screen needs to redraw
+ *          continuously, this is slower than the other modes.
+ *      - `HIDDEN`
+ *          allows to process the document in background mode. The document is
+ *          not visible in this mode, which speeds up the script execution. In
+ *          this mode you will likely look at InDesign with no open document for
+ *          quite some time – do not work in InDesign during this time. You may
+ *          want to use `println("yourMessage")` in your script and look at the
+ *          console to get information about the process. Note: In order to
+ *          enter this mode either a saved document needs to be open or no
+ *          document at all. If you have an unsaved document open, basil will
+ *          automatically save it for you. If it has not been saved before, you
+ *          will be prompted to save it to your hard drive.
+ *      - `SILENT`
+ *          processes the document without redrawing the screen. The document
+ *          will stay visible and only update once the script is finished or
+ *          once the mode is changed back to `VISIBLE`.
+ *
+ * @cat     Environment
+ * @method  mode
+ *
+ * @param   {String} mode The performance mode to switch to.
  */
 pub.mode = function(mode) {
 

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -142,11 +142,11 @@ var prepareLoop = function() {
 }
 
 /**
- * Sets the framerate per second to determine how often loop() is called per second. If the processor is not fast enough to maintain the specified rate, the frame rate will not be achieved. Setting the frame rate within setup() is recommended. The default rate is 25 frames per second. Calling frameRate() with no arguments returns the currently set framerate.
+ * @description Sets the framerate per second to determine how often loop() is called per second. If the processor is not fast enough to maintain the specified rate, the frame rate will not be achieved. Setting the frame rate within setup() is recommended. The default rate is 25 frames per second. Calling frameRate() with no arguments returns the currently set framerate.
  *
- * @cat Environment
+ * @cat    Environment
  * @method frameRate
- * @param {Number} [fps] Frames per second.
+ * @param  {Number} [fps] Frames per second.
  * @return {Number} Currently set frame rate.
  */
 pub.frameRate = function(fps) {
@@ -164,9 +164,9 @@ pub.frameRate = function(fps) {
 };
 
 /**
- * Stops basil from continuously executing the code within loop() and quits the script.
+ * @description Stops basil from continuously executing the code within loop() and quits the script.
  *
- * @cat Environment
+ * @cat    Environment
  * @method noLoop
  */
 pub.noLoop = function(printFinished) {
@@ -182,12 +182,12 @@ pub.noLoop = function(printFinished) {
 };
 
 /**
- * Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, <code>mode()</code> should be placed in the beginning of the script. In basil there are three different performance modes:
- * <code>VISIBLE</code> is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.
- * <code>HIDDEN</code> allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use <code>println("yourMessage")</code> in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.
+ * @description Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, <code>mode()</code> should be placed in the beginning of the script. In basil there are three different performance modes:<br>
+ * <code>VISIBLE</code> is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.<br>
+ * <code>HIDDEN</code> allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use <code>println("yourMessage")</code> in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.<br>
  * <code>SILENT</code> processes the document without redrawing the screen. The document will stay visible and only update once the script is finished or once the mode is changed back to <code>VISIBLE</code>.
  *
- * @cat Environment
+ * @cat    Environment
  * @method mode
  * @param  {String} mode The performance mode to switch to.
  */

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -182,10 +182,10 @@ pub.noLoop = function(printFinished) {
 };
 
 /**
- * @description Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, <code>mode()</code> should be placed in the beginning of the script. In basil there are three different performance modes:<br>
- * <code>VISIBLE</code> is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.<br>
- * <code>HIDDEN</code> allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use <code>println("yourMessage")</code> in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.<br>
- * <code>SILENT</code> processes the document without redrawing the screen. The document will stay visible and only update once the script is finished or once the mode is changed back to <code>VISIBLE</code>.
+ * @description Used to set the performance mode. While modes can be switched during script execution, to use a mode for the entire script execution, `mode()` should be placed in the beginning of the script. In basil there are three different performance modes:<br>
+ * `VISIBLE` is the default mode. In this mode, during script execution the document will be processed with screen redraw, allowing to see direct results during the process. As the screen needs to redraw continuously, this is slower than the other modes.<br>
+ * `HIDDEN` allows to process the document in background mode. The document is not visible in this mode, which speeds up the script execution. In this mode you will likely look at InDesign with no open document for quite some time – do not work in InDesign during this time. You may want to use `println("yourMessage")` in your script and look at the console to get information about the process. Note: In order to enter this mode either a saved document needs to be open or no document at all. If you have an unsaved document open, basil will automatically save it for you. If it has not been saved before, you will be prompted to save it to your hard drive.<br>
+ * `SILENT` processes the document without redrawing the screen. The document will stay visible and only update once the script is finished or once the mode is changed back to `VISIBLE`.
  *
  * @cat    Environment
  * @method mode

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -4,11 +4,11 @@
 
 pub.JSON = {
   /**
-   * Function parses and validates a string as JSON-object. Usage:
+   * @description Function parses and validates a string as JSON-object. Usage:<br>
    * var obj = JSON.decode(str);
    * var str = JSON.encode(obj);
    *
-   * @cat Data
+   * @cat    Data
    * @subcat JSON
    * @method JSON.decode
    * @param  {String} String to be parsed as JSON-object.
@@ -34,11 +34,11 @@ pub.JSON = {
     error("JSON.decode(), invalid JSON: " + data);
   },
   /**
-   * Function convert an javascript object to a JSON-string. Usage:
+   * Function convert an javascript object to a JSON-string. Usage:<br>
    * var str = JSON.encode(obj);
    * var obj = JSON.decode(str);
    *
-   * @cat Data
+   * @cat    Data
    * @subcat JSON
    * @method JSON.encode
    * @param  {Object} Object to be converted to a JSON-string
@@ -86,9 +86,9 @@ function CSV() {
   }
 
   /**
-   * Sets the delimiter of the CSV decode and encode function.
+   * @description Sets the delimiter of the CSV decode and encode function.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat CSV
    * @method CSV.delimiter
    * @param  {String} [delimiter] Optional Sets the delimiter for CSV parsing
@@ -104,11 +104,11 @@ function CSV() {
   };
 
   /**
-   * Function parses a string as CSV-object Array. Usage:
+   * @description Function parses a string as CSV-object Array. Usage:<br>
    * var arr = CSV.decode(str);
    * var str = CSV.encode(arr);
    *
-   * @cat Data
+   * @cat    Data
    * @subcat CSV
    * @method CSV.decode
    * @param  {String} String to be parsed as CSV-object.
@@ -129,11 +129,11 @@ function CSV() {
   };
 
   /**
-   * Function convert an javascript array of objects to a CSV-string. Usage:
+   * @description Function convert an javascript array of objects to a CSV-string. Usage:<br>
    * var str = CSV.encode(arr);
    * var arr = CSV.decode(str);
    *
-   * @cat Data
+   * @cat    Data
    * @subcat CSV
    * @method CSV.encode
    * @param  {Array} Array to be converted to a CSV-string
@@ -232,17 +232,17 @@ function CSV() {
 
 
 /**
- * Converts a byte, char, int, or color to a String containing the
+ * @description Converts a byte, char, int, or color to a String containing the
  * equivalent binary notation. For example color(0, 102, 153, 255)
  * will convert to the String "11111111000000000110011010011001". This
  * function can help make your geeky debugging sessions much happier.
  *
 
- * @cat Data
+ * @cat    Data
  * @subcat Conversion
  * @method binary
- * @param {Number} num value to convert
- * @param {Number} [numBits] number of digits to return
+ * @param  {Number} num value to convert
+ * @param  {Number} [numBits] number of digits to return
  * @return {String} A formatted string
  */
  // From: http://processingjs.org/reference/binary_/
@@ -262,14 +262,14 @@ pub.binary = function(num, numBits) {
 };
 
 /**
- * Converts a String representation of a binary number to its
+ * @description Converts a String representation of a binary number to its
  * equivalent integer value. For example, unbinary("00001000") will
  * return 8.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Conversion
  * @method unbinary
- * @param {String} binaryString value to convert
+ * @param  {String} binaryString value to convert
  * @return {Number} The integer representation
  */
  // From: http://processingjs.org/reference/unbinary_/
@@ -297,13 +297,13 @@ var decimalToHex = function(d, padding) {
 };
 
 /**
- * Convert a number to a hex representation.
+ * @description Convert a number to a hex representation.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Conversion
  * @method hex
- * @param {Number} value The number to convert
- * @param {Number} [len] The length of the hex number to be created, default: 8
+ * @param  {Number} value The number to convert
+ * @param  {Number} [len] The length of the hex number to be created, default: 8
  * @return {String} The hex representation as a string
  */
 pub.hex = function(value, len) {
@@ -318,12 +318,12 @@ var unhexScalar = function(hex) {
 };
 
 /**
- * Convert a hex representation to a number.
+ * @description Convert a hex representation to a number.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Conversion
  * @method unhex
- * @param {String} hex The hex representation
+ * @param  {String} hex The hex representation
  * @return {Number} The number
  */
 pub.unhex = function(hex) {
@@ -341,12 +341,12 @@ pub.unhex = function(hex) {
 
 
 /**
- * Removes multiple, leading or trailing spaces and punctuation from "words". E.g. converts "word!" to "word". Especially useful together with words();
+ * @description Removes multiple, leading or trailing spaces and punctuation from "words". E.g. converts "word!" to "word". Especially useful together with words();
  *
- * @method trimWord
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
- * @param {String} s The String to trim
+ * @method trimWord
+ * @param  {String} s The String to trim
  * @return {String} The trimmed string
  */
  // from: https://stackoverflow.com/a/25575009/3399765
@@ -358,16 +358,16 @@ pub.trimWord = function(s) {
 };
 
 /**
- * Combines an array of Strings into one String, each separated by
+ * @description Combines an array of Strings into one String, each separated by
  * the character(s) used for the separator parameter. To join arrays
  * of ints or floats, it's necessary to first convert them to strings
  * using nf() or nfs().
  *
- * @method join
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
- * @param {Array} array A string array
- * @param {String} separator The separator to be inserted
+ * @method join
+ * @param  {Array} array A string array
+ * @param  {String} separator The separator to be inserted
  * @return {String} The joined string
  */
  // http://processingjs.org/reference/join_/
@@ -376,24 +376,24 @@ pub.join = function(array, separator) {
 };
 
 /**
- * The split() function breaks a string into pieces using a
+ * @description The split() function breaks a string into pieces using a
  * character or string as the divider. The delim parameter specifies the
  * character or characters that mark the boundaries between each piece. A
  * String[] array is returned that contains each of the pieces.
- *
+ * <br><br>
  * If the result is a set of numbers, you can convert the String[] array
  * to to a float[] or int[] array using the datatype conversion functions
  * int() and float() (see example above).
- *
+ * <br><br>
  * The splitTokens() function works in a similar fashion, except that it
  * splits using a range of characters instead of a specific character or
  * sequence.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method split
- * @param {String} str the String to be split
- * @param {String} [delim] The string used to separate the data
+ * @param  {String} str the String to be split
+ * @param  {String} [delim] The string used to separate the data
  * @return {Array} Array of strings
  */
  // http://processingjs.org/reference/split_/
@@ -402,21 +402,21 @@ pub.split = function(str, delim) {
 };
 
 /**
- * The splitTokens() function splits a String at one or many character
+ * @description The splitTokens() function splits a String at one or many character
  * "tokens." The tokens parameter specifies the character or characters
  * to be used as a boundary.
- *
+ * <br><br>
  * If no tokens character is specified, any whitespace character is used
  * to split. Whitespace characters include tab (\t), line feed (\n),
  * carriage return (\r), form feed (\f), and space. To convert a String
  * to an array of integers or floats, use the datatype conversion functions
  * int() and float() to convert the array of Strings.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method splitTokens
- * @param {String} str the String to be split
- * @param {String} [tokens] list of individual characters that will be used as separators
+ * @param  {String} str the String to be split
+ * @param  {String} [tokens] list of individual characters that will be used as separators
  * @return {Array} Array of strings
  */
  // From: http://processingjs.org/reference/splitTokens_/
@@ -503,22 +503,22 @@ function nfCore(value, plus, minus, leftDigits, rightDigits, group) {
 }
 
 /**
- * Utility function for formatting numbers into strings. There
+ * @description Utility function for formatting numbers into strings. There
  * are two versions, one for formatting floats and one for formatting
  * ints. The values for the digits, left, and right parameters should
  * always be positive integers.
-
+ * <br><br>
  * As shown in the above example, nf() is used to add zeros to the
  * left and/or right of a number. This is typically for aligning a list
  * of numbers. To remove digits from a floating-point number, use the
  * int(), ceil(), floor(), or round() functions.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method nf
- * @param {Number} value The Number to convert
- * @param {Number} leftDigits
- * @param {Number} rightDigits
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
  * @return {String} The formatted string
  */
  // From: http://processingjs.org/reference/nf_/
@@ -527,19 +527,19 @@ pub.nf = function(value, leftDigits, rightDigits) {
 };
 
 /**
- * Utility function for formatting numbers into strings. Similar to nf()
+ * @description Utility function for formatting numbers into strings. Similar to nf()
  * but leaves a blank space in front of positive numbers so they align
  * with negative numbers in spite of the minus symbol. There are two
  * versions, one for formatting floats and one for formatting ints. The
  * values for the digits, left, and right parameters should always be
  * positive integers.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method nfs
- * @param {Number} value The Number to convert
- * @param {Number} leftDigits
- * @param {Number} rightDigits
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
  * @return {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfs_/
@@ -548,18 +548,18 @@ pub.nfs = function(value, leftDigits, rightDigits) {
 };
 
 /**
- * Utility function for formatting numbers into strings. Similar to nf()
+ * @description Utility function for formatting numbers into strings. Similar to nf()
  * but puts a "+" in front of positive numbers and a "-" in front of
  * negative numbers. There are two versions, one for formatting floats
  * and one for formatting ints. The values for the digits, left, and right
  * parameters should always be positive integers.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method nfp
- * @param {Number} value The Number to convert
- * @param {Number} leftDigits
- * @param {Number} rightDigits
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
  * @return {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfp_/
@@ -568,17 +568,17 @@ pub.nfp = function(value, leftDigits, rightDigits) {
 };
 
 /**
- * Utility function for formatting numbers into strings and placing
+ * @description Utility function for formatting numbers into strings and placing
  * appropriate commas to mark units of 1000. There are two versions, one
  * for formatting ints and one for formatting an array of ints. The value
  * for the digits parameter should always be a positive integer.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method nfc
- * @param {Number} value The Number to convert
- * @param {Number} leftDigits
- * @param {Number} rightDigits
+ * @param  {Number} value The Number to convert
+ * @param  {Number} leftDigits
+ * @param  {Number} rightDigits
  * @return {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfc_/
@@ -588,14 +588,14 @@ pub.nfc = function(value, leftDigits, rightDigits) {
 
 
 /**
- * Removes whitespace characters from the beginning and end of a String.
+ * @description Removes whitespace characters from the beginning and end of a String.
  * In addition to standard whitespace characters such as space, carriage
  * return, and tab, this function also removes the Unicode "nbsp" character.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method trim
- * @param {String|Array} str A string or an array of strings to be trimmed
+ * @param  {String|Array} str A string or an array of strings to be trimmed
  * @return {String|Array} Returns the input in a trimmed way
  */
  // From: http://processingjs.org/reference/trim_/
@@ -609,12 +609,12 @@ pub.trim = function(str) {
 };
 
 /**
- * Checks whether an URL string is valid.
+ * @description Checks whether an URL string is valid.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method isURL
- * @param {String} url An url string to be checked
+ * @param  {String} url An url string to be checked
  * @return {Boolean} Returns either true or false
  */
 var isURL = pub.isURL = function(url) {
@@ -623,13 +623,13 @@ var isURL = pub.isURL = function(url) {
 };
 
 /**
- * Checks whether a string ends with a specific character or string.
+ * @description Checks whether a string ends with a specific character or string.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method endsWith
- * @param {String} str A string to be checked
- * @param {String} suffix The string to look for
+ * @param  {String} str A string to be checked
+ * @param  {String} suffix The string to look for
  * @return {Boolean} Returns either true or false
  */
 var endsWith = pub.endsWith = function(str, suffix) {
@@ -640,13 +640,13 @@ var endsWith = pub.endsWith = function(str, suffix) {
 };
 
 /**
- * Checks whether a string starts with a specific character or string.
+ * @description Checks whether a string starts with a specific character or string.
  *
- * @cat Data
+ * @cat    Data
  * @subcat String Functions
  * @method startsWith
- * @param {String} str A string to be checked
- * @param {String} prefix The string to look for
+ * @param  {String} str A string to be checked
+ * @param  {String} prefix The string to look for
  * @return {Boolean} Returns either true or false
  */
 var startsWith = pub.startsWith = function(str, prefix) {
@@ -658,9 +658,9 @@ var startsWith = pub.startsWith = function(str, prefix) {
 
 
 /**
- * Checks whether a var is an Array, returns true if this is the case
+ * @description Checks whether a var is an Array, returns true if this is the case
  *
- * @cat Data
+ * @cat    Data
  * @subcat Type-Check
  * @method isArray
  * @param  {Object|String|Number|Boolean} obj The object to check
@@ -671,9 +671,9 @@ var isArray = pub.isArray = function(obj) {
 };
 
 /**
- * Checks whether a var is a number, returns true if this is the case
+ * @description Checks whether a var is a number, returns true if this is the case
  *
- * @cat Data
+ * @cat    Data
  * @subcat Type-Check
  * @method isNumber
  * @param  {Object|String|Number|Boolean}  num The number to check
@@ -691,9 +691,9 @@ var isNumber = pub.isNumber = function(num) {
 
 
 /**
- * Checks whether a var is an integer, returns true if this is the case.
+ * @description Checks whether a var is an integer, returns true if this is the case.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Type-Check
  * @method isInteger
  * @param  {Object|String|Number|Boolean}  num The number to check.
@@ -704,9 +704,9 @@ var isInteger = pub.isInteger = function(num) {
 };
 
 /**
- * Checks whether a var is a string, returns true if this is the case
+ * @description Checks whether a var is a string, returns true if this is the case
  *
- * @cat Data
+ * @cat    Data
  * @subcat Type-Check
  * @method isString
  * @param  {Object|String|Number|Boolean} str The string to check
@@ -717,11 +717,11 @@ var isString = pub.isString = function(str) {
 };
 
 /**
- * Checks whether a var is an InDesign text object, returns true if this is the case
+ * @description Checks whether a var is an InDesign text object, returns true if this is the case
  * NB: a InDesign TextFrame will return false as it is just a container holding text.
  * So you could say that isText() refers to all the things inside a TextFrame.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Type-Check
  * @method isText
  * @param  {Character|InsertionPoint|Line|Paragraph|TextColumn|TextStyleRange|Word}  obj The object to check
@@ -844,9 +844,9 @@ var initExportFile = function(file) {
 };
 
 /**
- * Get the folder of the active document as a Folder object. Use .absoluteURI to access a string representation of the folder path.
+ * @description Get the folder of the active document as a Folder object. Use .absoluteURI to access a string representation of the folder path.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Misc
  * @method projectFolder
  * @return {Folder} The folder of the the active document
@@ -860,11 +860,11 @@ pub.projectFolder = function() {
 
 
 /**
- * Executes a shell command and returns the result, currently Mac only.
- *
+ * @description Executes a shell command and returns the result, currently Mac only.
+ * <br><br>
  * BE CAREFUL!
  *
- * @cat Data
+ * @cat    Data
  * @subcat Input
  * @method shellExecute
  * @param  {String} cmd The shell command to execute
@@ -883,10 +883,10 @@ pub.shellExecute = function(cmd) {
 };
 
 /**
- * Reads the contents of a file or loads an URL into a String.
+ * @description Reads the contents of a file or loads an URL into a String.
  * If the file is specified by name as String, it must be located in the document's data directory.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Input
  * @method loadString
  * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
@@ -918,10 +918,10 @@ var getURL = function(url) {
 };
 
 /**
- * Reads the contents of a file or loads an URL and creates a String array of its individual lines.
+ * @description Reads the contents of a file or loads an URL and creates a String array of its individual lines.
  * If the file is specified by name as String, it must be located in the document's data directory.
  *
- * @cat Data
+ * @cat    Data
  * @subcat Input
  * @method loadStrings
  * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
@@ -948,7 +948,7 @@ pub.loadStrings = function(file) {
 // Output
 
 /**
- * Prints a message line to the console output in the ExtendScript editor.
+ * @description Prints a message line to the console output in the ExtendScript editor.
  *
  * @cat Output
  * @method println
@@ -962,11 +962,11 @@ var println = pub.println = function() {
 };
 
 /**
- * Prints a message to the console output in the ExtendScript editor, but unlike println() it doesn't return the carriage to a new line at the end.
+ * @description Prints a message to the console output in the ExtendScript editor, but unlike println() it doesn't return the carriage to a new line at the end.
  *
- * @cat Output
+ * @cat    Output
  * @method print
- * @param {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
+ * @param  {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
  */
 pub.print = function() {
   var msg = Array.prototype.slice.call(arguments).join(" ");
@@ -976,9 +976,9 @@ pub.print = function() {
 };
 
 /**
- * Print numerous information about the current environment to the console
+ * @description Print numerous information about the current environment to the console
  *
- * @cat Output
+ * @cat    Output
  * @method printInfo
  */
 pub.printInfo = function() {
@@ -994,10 +994,10 @@ pub.printInfo = function() {
 };
 
 /**
- * Writes an array of strings to a file, one line per string.
+ * @description Writes an array of strings to a file, one line per string.
  * If the given file exists it gets overridden.
  *
- * @cat Output
+ * @cat    Output
  * @method saveStrings
  * @param  {String|File} file The file name or a File instance
  * @param  {Array} strings The string array to be written
@@ -1019,10 +1019,10 @@ pub.saveStrings = function(file, strings) {
 };
 
 /**
- * Writes a string to a file.
+ * @description Writes a string to a file.
  * If the given file exists it gets overridden.
  *
- * @cat Output
+ * @cat    Output
  * @method saveString
  * @param  {String|File} file The file name or a File instance.
  * @param  {String} string The string to be written.
@@ -1042,9 +1042,9 @@ pub.saveString = function(file, string) {
 };
 
 /**
- * Exports the current document as PDF to the documents folder. Please note, that export options default to the last used export settings.
+ * @description Exports the current document as PDF to the documents folder. Please note, that export options default to the last used export settings.
  *
- * @cat Output
+ * @cat    Output
  * @method savePDF
  * @param  {String|File} file The file name or a File instance.
  * @param  {Boolean} [showOptions] Whether to show the export dialog.
@@ -1063,12 +1063,12 @@ pub.savePDF = function(file, showOptions) {
 };
 
 /**
- * Exports the current document as PNG (or sequence of PNG files) to the documents folder. Please note, that export options default to the last used export settings.
+ * @description Exports the current document as PNG (or sequence of PNG files) to the documents folder. Please note, that export options default to the last used export settings.
  *
- * @cat Output
+ * @cat    Output
  * @method savePNG
- * @param {String|File} file The file name or a File instance
- * @param {Boolean} [showOptions] Whether to show the export dialog
+ * @param  {String|File} file The file name or a File instance
+ * @param  {Boolean} [showOptions] Whether to show the export dialog
  * @return {File} The exported PNG file.
  */
 pub.savePNG = function(file, showOptions) {
@@ -1084,12 +1084,12 @@ pub.savePNG = function(file, showOptions) {
 };
 
 /**
- * Downloads an URL to a file, currently Mac only.
+ * @description Downloads an URL to a file, currently Mac only.
  *
- * @cat Output
+ * @cat    Output
  * @method download
- * @param {String} url The download url
- * @param {String|File} [file] A relative file path in the project folder or a File instance
+ * @param  {String} url The download url
+ * @param  {String|File} [file] A relative file path in the project folder or a File instance
  */
 pub.download = function(url, file) {
   var projPath = pub.projectFolder().fsName.replace(" ", "\\ ");

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -4,16 +4,20 @@
 
 pub.JSON = {
   /**
-   * @description Function parses and validates a string as JSON-object. Usage:<br>
+   * @description Function parses and validates a string as JSON-object.
+   *
+   * @cat     Data
+   * @subcat  JSON
+   * @method  JSON.decode
+   *
+   * @param   {String} String to be parsed as JSON-object.
+   * @return  {Object} Returns JSON-object or throws an error if invalid JSON
+   *          has been provided.
+   *
+   * @example
    * var obj = JSON.decode(str);
    * var str = JSON.encode(obj);
-   *
-   * @cat    Data
-   * @subcat JSON
-   * @method JSON.decode
-   * @param  {String} String to be parsed as JSON-object.
-   * @return {Object} Returns JSON-object or throws an error if invalid JSON has been provided.
-  */
+   */
   // From: jQuery JavaScript Library v1.7.1 http://jquery.com/
   decode: function(data) {
     if (typeof data !== "string" || !data) {
@@ -34,15 +38,18 @@ pub.JSON = {
     error("JSON.decode(), invalid JSON: " + data);
   },
   /**
-   * Function convert an javascript object to a JSON-string. Usage:<br>
+   * Function convert an javascript object to a JSON-string.
+   *
+   * @cat     Data
+   * @subcat  JSON
+   * @method  JSON.encode
+   *
+   * @param   {Object} Object to be converted to a JSON-string
+   * @return  {String} Returns JSON-string
+   *
+   * @example
    * var str = JSON.encode(obj);
    * var obj = JSON.decode(str);
-   *
-   * @cat    Data
-   * @subcat JSON
-   * @method JSON.encode
-   * @param  {Object} Object to be converted to a JSON-string
-   * @return {String} Returns JSON-string
    */
   // From: https://gist.github.com/754454
   encode: function(obj) {
@@ -88,12 +95,13 @@ function CSV() {
   /**
    * @description Sets the delimiter of the CSV decode and encode function.
    *
-   * @cat    Data
-   * @subcat CSV
-   * @method CSV.delimiter
-   * @param  {String} [delimiter] Optional Sets the delimiter for CSV parsing
-   * @return {String} Returns the current delimiter if called without argument
-  */
+   * @cat     Data
+   * @subcat  CSV
+   * @method  CSV.delimiter
+   *
+   * @param   {String} [delimiter] Optional Sets the delimiter for CSV parsing
+   * @return  {String} Returns the current delimiter if called without argument
+   */
   this.delimiter = function(delimiter) {
     if (arguments.length === 0) return delimiterStr;
     if (typeof delimiter === "string") {
@@ -104,16 +112,19 @@ function CSV() {
   };
 
   /**
-   * @description Function parses a string as CSV-object Array. Usage:<br>
+   * @description Function parses a string as CSV-object Array.
+   *
+   * @cat     Data
+   * @subcat  CSV
+   * @method  CSV.decode
+   *
+   * @param   {String} String to be parsed as CSV-object.
+   * @return  {Array} Returns CSV-object Array
+   *
+   * @example
    * var arr = CSV.decode(str);
    * var str = CSV.encode(arr);
-   *
-   * @cat    Data
-   * @subcat CSV
-   * @method CSV.decode
-   * @param  {String} String to be parsed as CSV-object.
-   * @return {Array} Returns CSV-object Array
-  */
+   */
   this.decode = function(text) {
     var header;
     return parseRows(text, function(row, i) {
@@ -129,15 +140,19 @@ function CSV() {
   };
 
   /**
-   * @description Function convert an javascript array of objects to a CSV-string. Usage:<br>
+   * @description Function convert an javascript array of objects to a
+   *          CSV-string.
+   *
+   * @cat     Data
+   * @subcat  CSV
+   * @method  CSV.encode
+   *
+   * @param   {Array} Array to be converted to a CSV-string
+   * @return  {String} Returns CSV-string
+   *
+   * @example
    * var str = CSV.encode(arr);
    * var arr = CSV.decode(str);
-   *
-   * @cat    Data
-   * @subcat CSV
-   * @method CSV.encode
-   * @param  {Array} Array to be converted to a CSV-string
-   * @return {String} Returns CSV-string
    */
   this.encode = function(rows) {
     var csvStrings = [];
@@ -233,17 +248,19 @@ function CSV() {
 
 /**
  * @description Converts a byte, char, int, or color to a String containing the
- * equivalent binary notation. For example color(0, 102, 153, 255)
- * will convert to the String "11111111000000000110011010011001". This
- * function can help make your geeky debugging sessions much happier.
+ *          equivalent binary notation. For example `color(0, 102, 153, 255)`
+ *          will convert to the String `"11111111000000000110011010011001"`.
+ *          This function can help make your geeky debugging sessions much
+ *          happier.
  *
-
- * @cat    Data
- * @subcat Conversion
- * @method binary
- * @param  {Number} num value to convert
- * @param  {Number} [numBits] number of digits to return
- * @return {String} A formatted string
+ *
+ * @cat     Data
+ * @subcat  Conversion
+ * @method  binary
+ *
+ * @param   {Number} num value to convert
+ * @param   {Number} [numBits] number of digits to return
+ * @return  {String} A formatted string
  */
  // From: http://processingjs.org/reference/binary_/
 pub.binary = function(num, numBits) {
@@ -263,14 +280,15 @@ pub.binary = function(num, numBits) {
 
 /**
  * @description Converts a String representation of a binary number to its
- * equivalent integer value. For example, unbinary("00001000") will
- * return 8.
+ *          equivalent integer value. For example, `unbinary("00001000")` will
+ *          return `8`.
  *
- * @cat    Data
- * @subcat Conversion
- * @method unbinary
- * @param  {String} binaryString value to convert
- * @return {Number} The integer representation
+ * @cat     Data
+ * @subcat  Conversion
+ * @method  unbinary
+ *
+ * @param   {String} binaryString value to convert
+ * @return  {Number} The integer representation
  */
  // From: http://processingjs.org/reference/unbinary_/
 pub.unbinary = function(binaryString) {
@@ -299,12 +317,14 @@ var decimalToHex = function(d, padding) {
 /**
  * @description Convert a number to a hex representation.
  *
- * @cat    Data
- * @subcat Conversion
- * @method hex
- * @param  {Number} value The number to convert
- * @param  {Number} [len] The length of the hex number to be created, default: 8
- * @return {String} The hex representation as a string
+ * @cat     Data
+ * @subcat  Conversion
+ * @method  hex
+ *
+ * @param   {Number} value The number to convert
+ * @param   {Number} [len] The length of the hex number to be created, default:
+ *          `8`
+ * @return  {String} The hex representation as a string
  */
 pub.hex = function(value, len) {
   if (arguments.length === 1) len = 8;
@@ -320,11 +340,12 @@ var unhexScalar = function(hex) {
 /**
  * @description Convert a hex representation to a number.
  *
- * @cat    Data
- * @subcat Conversion
- * @method unhex
- * @param  {String} hex The hex representation
- * @return {Number} The number
+ * @cat     Data
+ * @subcat  Conversion
+ * @method  unhex
+ *
+ * @param   {String} hex The hex representation
+ * @return  {Number} The number
  */
 pub.unhex = function(hex) {
   if (hex instanceof Array) {
@@ -341,13 +362,16 @@ pub.unhex = function(hex) {
 
 
 /**
- * @description Removes multiple, leading or trailing spaces and punctuation from "words". E.g. converts "word!" to "word". Especially useful together with words();
+ * @description Removes multiple, leading or trailing spaces and punctuation
+ *          from "words". E.g. converts `"word!"` to `"word"`. Especially useful
+ *          together with `words()`;
  *
- * @cat    Data
- * @subcat String Functions
- * @method trimWord
- * @param  {String} s The String to trim
- * @return {String} The trimmed string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  trimWord
+ *
+ * @param   {String} s The String to trim
+ * @return  {String} The trimmed string
  */
  // from: https://stackoverflow.com/a/25575009/3399765
 pub.trimWord = function(s) {
@@ -359,16 +383,17 @@ pub.trimWord = function(s) {
 
 /**
  * @description Combines an array of Strings into one String, each separated by
- * the character(s) used for the separator parameter. To join arrays
- * of ints or floats, it's necessary to first convert them to strings
- * using nf() or nfs().
+ *          the character(s) used for the separator parameter. To join arrays of
+ *          ints or floats, it's necessary to first convert them to strings
+ *          using `nf()` or `nfs()`.
  *
- * @cat    Data
- * @subcat String Functions
- * @method join
- * @param  {Array} array A string array
- * @param  {String} separator The separator to be inserted
- * @return {String} The joined string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  join
+ *
+ * @param   {Array} array A string array
+ * @param   {String} separator The separator to be inserted
+ * @return  {String} The joined string
  */
  // http://processingjs.org/reference/join_/
 pub.join = function(array, separator) {
@@ -376,25 +401,23 @@ pub.join = function(array, separator) {
 };
 
 /**
- * @description The split() function breaks a string into pieces using a
- * character or string as the divider. The delim parameter specifies the
- * character or characters that mark the boundaries between each piece. A
- * String[] array is returned that contains each of the pieces.
- * <br><br>
- * If the result is a set of numbers, you can convert the String[] array
- * to to a float[] or int[] array using the datatype conversion functions
- * int() and float() (see example above).
- * <br><br>
- * The splitTokens() function works in a similar fashion, except that it
- * splits using a range of characters instead of a specific character or
- * sequence.
+ * @description The `split()` function breaks a string into pieces using a
+ *          character or string as the divider. The `delim` parameter specifies
+ *          the character or characters that mark the boundaries between each
+ *          piece. An array of strings is returned that contains each of the
+ *          pieces.
+ *          <br><br>
+ *          The `splitTokens()` function works in a similar fashion, except that
+ *          it splits using a range of characters instead of a specific
+ *          character or sequence.
  *
- * @cat    Data
- * @subcat String Functions
- * @method split
- * @param  {String} str the String to be split
- * @param  {String} [delim] The string used to separate the data
- * @return {Array} Array of strings
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  split
+ *
+ * @param   {String} str the String to be split
+ * @param   {String} [delim] The string used to separate the data
+ * @return  {Array} Array of strings
  */
  // http://processingjs.org/reference/split_/
 pub.split = function(str, delim) {
@@ -402,22 +425,23 @@ pub.split = function(str, delim) {
 };
 
 /**
- * @description The splitTokens() function splits a String at one or many character
- * "tokens." The tokens parameter specifies the character or characters
- * to be used as a boundary.
- * <br><br>
- * If no tokens character is specified, any whitespace character is used
- * to split. Whitespace characters include tab (\t), line feed (\n),
- * carriage return (\r), form feed (\f), and space. To convert a String
- * to an array of integers or floats, use the datatype conversion functions
- * int() and float() to convert the array of Strings.
+ * @description The `splitTokens()` function splits a string at one or many
+ *          character "tokens." The tokens parameter specifies the character or
+ *          characters to be used as a boundary.
+ *          <br><br>
+ *          If no tokens character
+ *          is specified, any whitespace character is used to split. Whitespace
+ *          characters include tab (`\t`), line feed (`\n`), carriage return
+ *          (`\r`), form feed (`\f`), and space.
  *
- * @cat    Data
- * @subcat String Functions
- * @method splitTokens
- * @param  {String} str the String to be split
- * @param  {String} [tokens] list of individual characters that will be used as separators
- * @return {Array} Array of strings
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  splitTokens
+ *
+ * @param   {String} str the String to be split
+ * @param   {String} [tokens] list of individual characters that will be used as
+ *          separators
+ * @return  {Array} Array of strings
  */
  // From: http://processingjs.org/reference/splitTokens_/
 pub.splitTokens = function(str, tokens) {
@@ -503,23 +527,24 @@ function nfCore(value, plus, minus, leftDigits, rightDigits, group) {
 }
 
 /**
- * @description Utility function for formatting numbers into strings. There
- * are two versions, one for formatting floats and one for formatting
- * ints. The values for the digits, left, and right parameters should
- * always be positive integers.
- * <br><br>
- * As shown in the above example, nf() is used to add zeros to the
- * left and/or right of a number. This is typically for aligning a list
- * of numbers. To remove digits from a floating-point number, use the
- * int(), ceil(), floor(), or round() functions.
+ * @description Utility function for formatting numbers into strings. There are
+ *          two versions, one for formatting floats and one for formatting ints.
+ *          The values for the digits, left, and right parameters should always
+ *          be positive integers.
+ *          <br><br>
+ *          `nf()` is used to add zeros to the
+ *          left and/or right of a number. This is typically for aligning a list
+ *          of numbers. To remove digits from a floating-point number, use the
+ *          `ceil()`, `floor()`, or `round()` functions.
  *
- * @cat    Data
- * @subcat String Functions
- * @method nf
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  nf
+ *
+ * @param   {Number} value The Number to convert
+ * @param   {Number} leftDigits { parameter_description }
+ * @param   {Number} rightDigits { parameter_description }
+ * @return  {String} The formatted string
  */
  // From: http://processingjs.org/reference/nf_/
 pub.nf = function(value, leftDigits, rightDigits) {
@@ -527,20 +552,21 @@ pub.nf = function(value, leftDigits, rightDigits) {
 };
 
 /**
- * @description Utility function for formatting numbers into strings. Similar to nf()
- * but leaves a blank space in front of positive numbers so they align
- * with negative numbers in spite of the minus symbol. There are two
- * versions, one for formatting floats and one for formatting ints. The
- * values for the digits, left, and right parameters should always be
- * positive integers.
+ * @description Utility function for formatting numbers into strings. Similar to
+ *          `nf()` but leaves a blank space in front of positive numbers so they
+ *          align with negative numbers in spite of the minus symbol. There are
+ *          two versions, one for formatting floats and one for formatting ints.
+ *          The values for the digits, left, and right parameters should always
+ *          be positive integers.
  *
- * @cat    Data
- * @subcat String Functions
- * @method nfs
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  nfs
+ *
+ * @param   {Number} value The Number to convert
+ * @param   {Number} leftDigits { parameter_description }
+ * @param   {Number} rightDigits { parameter_description }
+ * @return  {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfs_/
 pub.nfs = function(value, leftDigits, rightDigits) {
@@ -548,19 +574,21 @@ pub.nfs = function(value, leftDigits, rightDigits) {
 };
 
 /**
- * @description Utility function for formatting numbers into strings. Similar to nf()
- * but puts a "+" in front of positive numbers and a "-" in front of
- * negative numbers. There are two versions, one for formatting floats
- * and one for formatting ints. The values for the digits, left, and right
- * parameters should always be positive integers.
+ * @description Utility function for formatting numbers into strings. Similar to
+ *          `nf()` but puts a `+` in front of positive numbers and a `-` in
+ *          front of negative numbers. There are two versions, one for
+ *          formatting floats and one for formatting ints. The values for the
+ *          digits, left, and right parameters should always be positive
+ *          integers.
  *
- * @cat    Data
- * @subcat String Functions
- * @method nfp
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  nfp
+ *
+ * @param   {Number} value The Number to convert
+ * @param   {Number} leftDigits { parameter_description }
+ * @param   {Number} rightDigits { parameter_description }
+ * @return  {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfp_/
 pub.nfp = function(value, leftDigits, rightDigits) {
@@ -569,17 +597,18 @@ pub.nfp = function(value, leftDigits, rightDigits) {
 
 /**
  * @description Utility function for formatting numbers into strings and placing
- * appropriate commas to mark units of 1000. There are two versions, one
- * for formatting ints and one for formatting an array of ints. The value
- * for the digits parameter should always be a positive integer.
+ *          appropriate commas to mark units of 1000. There are two versions,
+ *          one for formatting ints and one for formatting an array of ints. The
+ *          value for the digits parameter should always be a positive integer.
  *
- * @cat    Data
- * @subcat String Functions
- * @method nfc
- * @param  {Number} value The Number to convert
- * @param  {Number} leftDigits
- * @param  {Number} rightDigits
- * @return {String} The formatted string
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  nfc
+ *
+ * @param   {Number} value The Number to convert
+ * @param   {Number} leftDigits { parameter_description }
+ * @param   {Number} rightDigits { parameter_description }
+ * @return  {String} The formatted string
  */
  // From: http://processingjs.org/reference/nfc_/
 pub.nfc = function(value, leftDigits, rightDigits) {
@@ -588,15 +617,17 @@ pub.nfc = function(value, leftDigits, rightDigits) {
 
 
 /**
- * @description Removes whitespace characters from the beginning and end of a String.
- * In addition to standard whitespace characters such as space, carriage
- * return, and tab, this function also removes the Unicode "nbsp" character.
+ * @description Removes whitespace characters from the beginning and end of a
+ *          String. In addition to standard whitespace characters such as space,
+ *          carriage return, and tab, this function also removes the Unicode
+ *          "nbsp" character.
  *
- * @cat    Data
- * @subcat String Functions
- * @method trim
- * @param  {String|Array} str A string or an array of strings to be trimmed
- * @return {String|Array} Returns the input in a trimmed way
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  trim
+ *
+ * @param   {String|Array} str A string or an array of strings to be trimmed
+ * @return  {String|Array} Returns the input in a trimmed way
  */
  // From: http://processingjs.org/reference/trim_/
 pub.trim = function(str) {
@@ -611,11 +642,12 @@ pub.trim = function(str) {
 /**
  * @description Checks whether an URL string is valid.
  *
- * @cat    Data
- * @subcat String Functions
- * @method isURL
- * @param  {String} url An url string to be checked
- * @return {Boolean} Returns either true or false
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  isURL
+ *
+ * @param   {String} url An url string to be checked
+ * @return  {Boolean} Returns either true or false
  */
 var isURL = pub.isURL = function(url) {
   var pattern = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
@@ -623,14 +655,16 @@ var isURL = pub.isURL = function(url) {
 };
 
 /**
- * @description Checks whether a string ends with a specific character or string.
+ * @description Checks whether a string ends with a specific character or
+ *          string.
  *
- * @cat    Data
- * @subcat String Functions
- * @method endsWith
- * @param  {String} str A string to be checked
- * @param  {String} suffix The string to look for
- * @return {Boolean} Returns either true or false
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  endsWith
+ *
+ * @param   {String} str A string to be checked
+ * @param   {String} suffix The string to look for
+ * @return  {Boolean} Returns either true or false
  */
 var endsWith = pub.endsWith = function(str, suffix) {
   if(!isString(str) || !isString(suffix)) {
@@ -640,14 +674,16 @@ var endsWith = pub.endsWith = function(str, suffix) {
 };
 
 /**
- * @description Checks whether a string starts with a specific character or string.
+ * @description Checks whether a string starts with a specific character or
+ *          string.
  *
- * @cat    Data
- * @subcat String Functions
- * @method startsWith
- * @param  {String} str A string to be checked
- * @param  {String} prefix The string to look for
- * @return {Boolean} Returns either true or false
+ * @cat     Data
+ * @subcat  String Functions
+ * @method  startsWith
+ *
+ * @param   {String} str A string to be checked
+ * @param   {String} prefix The string to look for
+ * @return  {Boolean} Returns either true or false
  */
 var startsWith = pub.startsWith = function(str, prefix) {
   if(!isString(str) || !isString(prefix)) {
@@ -658,26 +694,30 @@ var startsWith = pub.startsWith = function(str, prefix) {
 
 
 /**
- * @description Checks whether a var is an Array, returns true if this is the case
+ * @description Checks whether a var is an array, returns `true` if this is the
+ *          case.
  *
- * @cat    Data
- * @subcat Type-Check
- * @method isArray
- * @param  {Object|String|Number|Boolean} obj The object to check
- * @return {Boolean} returns true if this is the case
+ * @cat     Data
+ * @subcat  Type-Check
+ * @method  isArray
+ *
+ * @param   {Object|String|Number|Boolean} obj The object to check
+ * @return  {Boolean} returns true if this is the case
  */
 var isArray = pub.isArray = function(obj) {
   return Object.prototype.toString.call(obj) === "[object Array]";
 };
 
 /**
- * @description Checks whether a var is a number, returns true if this is the case
+ * @description Checks whether a var is a number, returns `true if this is the
+ *          case.
  *
- * @cat    Data
- * @subcat Type-Check
- * @method isNumber
- * @param  {Object|String|Number|Boolean}  num The number to check
- * @return {Boolean} returns true if this is the case
+ * @cat     Data
+ * @subcat  Type-Check
+ * @method  isNumber
+ *
+ * @param   {Object|String|Number|Boolean} num The number to check
+ * @return  {Boolean} returns true if this is the case
  */
 var isNumber = pub.isNumber = function(num) {
   if (num === null) {
@@ -691,41 +731,48 @@ var isNumber = pub.isNumber = function(num) {
 
 
 /**
- * @description Checks whether a var is an integer, returns true if this is the case.
+ * @description Checks whether a var is an integer, returns `true` if this is
+ *          the case.
  *
- * @cat    Data
- * @subcat Type-Check
- * @method isInteger
- * @param  {Object|String|Number|Boolean}  num The number to check.
- * @return {Boolean} Returns true if the given argument is an integer.
+ * @cat     Data
+ * @subcat  Type-Check
+ * @method  isInteger
+ *
+ * @param   {Object|String|Number|Boolean} num The number to check.
+ * @return  {Boolean} Returns true if the given argument is an integer.
  */
 var isInteger = pub.isInteger = function(num) {
   return Object.prototype.toString.call(num) === "[object Number]" && num % 1 === 0;
 };
 
 /**
- * @description Checks whether a var is a string, returns true if this is the case
+ * @description Checks whether a var is a string, returns `true` if this is the
+ *          case
  *
- * @cat    Data
- * @subcat Type-Check
- * @method isString
- * @param  {Object|String|Number|Boolean} str The string to check
- * @return {Boolean} returns true if this is the case
+ * @cat     Data
+ * @subcat  Type-Check
+ * @method  isString
+ *
+ * @param   {Object|String|Number|Boolean} str The string to check
+ * @return  {Boolean} returns true if this is the case
  */
 var isString = pub.isString = function(str) {
   return Object.prototype.toString.call(str) === "[object String]";
 };
 
 /**
- * @description Checks whether a var is an InDesign text object, returns true if this is the case
- * NB: a InDesign TextFrame will return false as it is just a container holding text.
- * So you could say that isText() refers to all the things inside a TextFrame.
+ * @description Checks whether a var is an InDesign text object, returns `true`
+ *          if this is the case. NB: a InDesign text frame will return `false`
+ *          as it is just a container holding text. So you could say that
+ *          `isText()` refers to all the things inside a text frame.
  *
- * @cat    Document
- * @subcat Type-Check
- * @method isText
- * @param  {Character|InsertionPoint|Line|Paragraph|TextColumn|TextStyleRange|Word}  obj The object to check
- * @return {Boolean} returns true if this is the case
+ * @cat     Document
+ * @subcat  Type-Check
+ * @method  isText
+ *
+ * @param   {Character|InsertionPoint|Line|Paragraph|TextColumn|TextStyleRange|Word} obj The
+ *          object to check
+ * @return  {Boolean} returns true if this is the case
  */
 var isText = pub.isText = function(obj) {
 
@@ -844,12 +891,14 @@ var initExportFile = function(file) {
 };
 
 /**
- * @description Get the folder of the active document as a Folder object. Use .absoluteURI to access a string representation of the folder path.
+ * @description Get the folder of the active document as a Folder object. Use
+ *          .absoluteURI to access a string representation of the folder path.
  *
- * @cat    Document
- * @subcat Misc
- * @method projectFolder
- * @return {Folder} The folder of the the active document
+ * @cat     Document
+ * @subcat  Misc
+ * @method  projectFolder
+ *
+ * @return  {Folder} The folder of the the active document
  */
 pub.projectFolder = function() {
   if(!currentDoc().saved) {
@@ -860,15 +909,17 @@ pub.projectFolder = function() {
 
 
 /**
- * @description Executes a shell command and returns the result, currently Mac only.
- * <br><br>
- * BE CAREFUL!
+ * @description Executes a shell command and returns the result, currently Mac
+ *          only.
+ *          <br><br>
+ *          BE CAREFUL!
  *
- * @cat    Data
- * @subcat Input
- * @method shellExecute
- * @param  {String} cmd The shell command to execute
- * @return {String}
+ * @cat     Data
+ * @subcat  Input
+ * @method  shellExecute
+ *
+ * @param   {String} cmd The shell command to execute
+ * @return  {String} { description_of_the_return_value }
  */
 pub.shellExecute = function(cmd) {
   if (Folder.fs === "Macintosh") {
@@ -883,14 +934,17 @@ pub.shellExecute = function(cmd) {
 };
 
 /**
- * @description Reads the contents of a file or loads an URL into a String.
- * If the file is specified by name as String, it must be located in the document's data directory.
+ * @description Reads the contents of a file or loads an URL into a String. If
+ *          the file is specified by name as String, it must be located in the
+ *          document's data directory.
  *
- * @cat    Data
- * @subcat Input
- * @method loadString
- * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
- * @return {String}  String file or URL content.
+ * @cat     Data
+ * @subcat  Input
+ * @method  loadString
+ *
+ * @param   {String|File} file The text file name in the document's data
+ *          directory or a File instance or an URL
+ * @return  {String} String file or URL content.
  */
 pub.loadString = function(file) {
   if (isURL(file)) {
@@ -918,14 +972,17 @@ var getURL = function(url) {
 };
 
 /**
- * @description Reads the contents of a file or loads an URL and creates a String array of its individual lines.
- * If the file is specified by name as String, it must be located in the document's data directory.
+ * @description Reads the contents of a file or loads an URL and creates a
+ *          string array of its individual lines. If the file is specified by
+ *          name as string, it must be located in the document's data directory.
  *
- * @cat    Data
- * @subcat Input
- * @method loadStrings
- * @param  {String|File} file The text file name in the document's data directory or a File instance or an URL
- * @return {Array}  Array of the individual lines in the given File or URL
+ * @cat     Data
+ * @subcat  Input
+ * @method  loadStrings
+ *
+ * @param   {String|File} file The text file name in the document's data
+ *          directory or a file instance or an URL
+ * @return  {Array} Array of the individual lines in the given file or URL
  */
 pub.loadStrings = function(file) {
   if (isURL(file)) {
@@ -948,11 +1005,14 @@ pub.loadStrings = function(file) {
 // Output
 
 /**
- * @description Prints a message line to the console output in the ExtendScript editor.
+ * @description Prints a message line to the console output in the ExtendScript
+ *          editor.
  *
- * @cat Output
- * @method println
- * @param {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
+ * @cat     Output
+ * @method  println
+ *
+ * @param   {Any} msg Any combination of Number, String, Object, Boolean, Array
+ *          to print.
  */
 var println = pub.println = function() {
   var msg = Array.prototype.slice.call(arguments).join(" ");
@@ -962,11 +1022,15 @@ var println = pub.println = function() {
 };
 
 /**
- * @description Prints a message to the console output in the ExtendScript editor, but unlike println() it doesn't return the carriage to a new line at the end.
+ * @description Prints a message to the console output in the ExtendScript
+ *          editor, but unlike `println()` it doesn't return the carriage to a
+ *          new line at the end.
  *
- * @cat    Output
- * @method print
- * @param  {Any} msg Any combination of Number, String, Object, Boolean, Array to print.
+ * @cat     Output
+ * @method  print
+ *
+ * @param   {Any} msg Any combination of Number, String, Object, Boolean, Array
+ *          to print.
  */
 pub.print = function() {
   var msg = Array.prototype.slice.call(arguments).join(" ");
@@ -976,10 +1040,11 @@ pub.print = function() {
 };
 
 /**
- * @description Print numerous information about the current environment to the console
+ * @description Print numerous information about the current environment to the
+ *          console.
  *
- * @cat    Output
- * @method printInfo
+ * @cat     Output
+ * @method  printInfo
  */
 pub.printInfo = function() {
 
@@ -994,14 +1059,15 @@ pub.printInfo = function() {
 };
 
 /**
- * @description Writes an array of strings to a file, one line per string.
- * If the given file exists it gets overridden.
+ * @description Writes an array of strings to a file, one line per string. If
+ *          the given file exists it gets overridden.
  *
- * @cat    Output
- * @method saveStrings
- * @param  {String|File} file The file name or a File instance
- * @param  {Array} strings The string array to be written
- * @return {File} The file the strings were written to.
+ * @cat     Output
+ * @method  saveStrings
+ *
+ * @param   {String|File} file The file name or a File instance
+ * @param   {Array} strings The string array to be written
+ * @return  {File} The file the strings were written to.
  */
 pub.saveStrings = function(file, strings) {
   if(!isArray(strings)) {
@@ -1019,14 +1085,15 @@ pub.saveStrings = function(file, strings) {
 };
 
 /**
- * @description Writes a string to a file.
- * If the given file exists it gets overridden.
+ * @description Writes a string to a file. If the given file exists it gets
+ *          overridden.
  *
- * @cat    Output
- * @method saveString
- * @param  {String|File} file The file name or a File instance.
- * @param  {String} string The string to be written.
- * @return {File} The file the string was written to.
+ * @cat     Output
+ * @method  saveString
+ *
+ * @param   {String|File} file The file name or a File instance.
+ * @param   {String} string The string to be written.
+ * @return  {File} The file the string was written to.
  */
 pub.saveString = function(file, string) {
   if(!isString(string)) {
@@ -1042,13 +1109,16 @@ pub.saveString = function(file, string) {
 };
 
 /**
- * @description Exports the current document as PDF to the documents folder. Please note, that export options default to the last used export settings.
+ * @description Exports the current document as PDF to the documents folder.
+ *          Please note that export options default to the last used export
+ *          settings.
  *
- * @cat    Output
- * @method savePDF
- * @param  {String|File} file The file name or a File instance.
- * @param  {Boolean} [showOptions] Whether to show the export dialog.
- * @return {File} The exported PDF file.
+ * @cat     Output
+ * @method  savePDF
+ *
+ * @param   {String|File} file The file name or a File instance.
+ * @param   {Boolean} [showOptions] Whether to show the export dialog.
+ * @return  {File} The exported PDF file.
  */
 pub.savePDF = function(file, showOptions) {
   var outputFile = initExportFile(file);
@@ -1063,13 +1133,16 @@ pub.savePDF = function(file, showOptions) {
 };
 
 /**
- * @description Exports the current document as PNG (or sequence of PNG files) to the documents folder. Please note, that export options default to the last used export settings.
+ * @description Exports the current document as PNG (or sequence of PNG files)
+ *          to the documents folder. Please note, that export options default to
+ *          the last used export settings.
  *
- * @cat    Output
- * @method savePNG
- * @param  {String|File} file The file name or a File instance
- * @param  {Boolean} [showOptions] Whether to show the export dialog
- * @return {File} The exported PNG file.
+ * @cat     Output
+ * @method  savePNG
+ *
+ * @param   {String|File} file The file name or a File instance
+ * @param   {Boolean} [showOptions] Whether to show the export dialog
+ * @return  {File} The exported PNG file.
  */
 pub.savePNG = function(file, showOptions) {
   var outputFile = initExportFile(file);
@@ -1086,10 +1159,12 @@ pub.savePNG = function(file, showOptions) {
 /**
  * @description Downloads an URL to a file, currently Mac only.
  *
- * @cat    Output
- * @method download
- * @param  {String} url The download url
- * @param  {String|File} [file] A relative file path in the project folder or a File instance
+ * @cat     Output
+ * @method  download
+ *
+ * @param   {String} url The download url
+ * @param   {String|File} [file] A relative file path in the project folder or a
+ *          File instance
  */
 pub.download = function(url, file) {
   var projPath = pub.projectFolder().fsName.replace(" ", "\\ ");

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -3,14 +3,16 @@
 // ----------------------------------------
 
 /**
- * @description Sets or possibly creates the current document and returns it.
- * If the param doc is not given the current document gets set to the active document
- * in the application. If no document at all is open, a new document gets created.
+ * @description Sets or possibly creates the current document and returns it. If
+ *          the `doc` parameter is not given, the current document gets set to
+ *          the active document in the application. If no document at all is
+ *          open, a new document gets created.
  *
- * @cat    Document
- * @method doc
- * @param  {Document} [doc] The document to set the current document to.
- * @return {Document} The current document instance.
+ * @cat     Document
+ * @method  doc
+ *
+ * @param   {Document} [doc] The document to set the current document to.
+ * @return  {Document} The current document instance.
  */
 pub.doc = function(doc) {
   if (doc instanceof Document) {
@@ -23,16 +25,25 @@ pub.doc = function(doc) {
 
 /**
  * @description Sets the size of the current document, if arguments are given.
- * If only one argument is given, both the width and the height are set to this value.
- * Alternatively, a string can be given as the first argument to apply an existing page size preset ("A4", "Letter" etc.).
- * In this case, either PORTRAIT or LANDSCAPE can be used as a second argument to determine the orientation of the page.
- * If no argument is given, an object containing the current document's width and height is returned.
+ *          If only one argument is given, both the width and the height are set
+ *          to this value. Alternatively, a string can be given as the first
+ *          argument to apply an existing page size preset (`"A4"`, `"Letter"`
+ *          etc.). In this case, either `PORTRAIT` or `LANDSCAPE` can be used as
+ *          a second argument to determine the orientation of the page. If no
+ *          argument is given, an object containing the current document's width
+ *          and height is returned.
  *
- * @cat    Document
- * @method size
- * @param  {Number|String} [widthOrPageSize] The desired width of the current document or the name of a page size preset.
- * @param  {Number|String} [heightOrOrientation] The desired height of the current document. If not provided the width will be used as the height. If the first argument is a page size preset, the second argument can be used to set the orientation.
- * @return {Object} Object containing the current `width` and `height` of the document.
+ * @cat     Document
+ * @method  size
+ *
+ * @param   {Number|String} [widthOrPageSize] The desired width of the current
+ *          document or the name of a page size preset.
+ * @param   {Number|String} [heightOrOrientation] The desired height of the
+ *          current document. If not provided the width will be used as the
+ *          height. If the first argument is a page size preset, the second
+ *          argument can be used to set the orientation.
+ * @return  {Object} Object containing the current `width` and `height` of the
+ *          document.
  *
  * @example <caption>Sets the document size to 70 x 100 units</caption>
  * size(70, 100);
@@ -40,10 +51,12 @@ pub.doc = function(doc) {
  * @example <caption>Sets the document size to 70 x 70</caption>
  * size(70);
  *
- * @example <caption>Sets the document size to A4, keeps the current orientation in place</caption>
+ * @example <caption>Sets the document size to A4, keeps the current orientation
+ *          in place</caption>
  * size("A4");
  *
- * @example <caption>Sets the document size to A4, set the orientation to landscape</caption>
+ * @example <caption>Sets the document size to A4, set the orientation to
+ *          landscape</caption>
  * size("A4", LANDSCAPE);
  */
 pub.size = function(widthOrPageSize, heightOrOrientation) {
@@ -92,12 +105,16 @@ pub.size = function(widthOrPageSize, heightOrOrientation) {
 };
 
 /**
- * @description Closes the current document. If no saveOptions argument is used, the user will be asked if they want to save or not.
+ * @description Closes the current document. If no `saveOptions` argument is
+ *          used, the user will be asked if they want to save or not.
  *
- * @cat    Document
- * @method close
- * @param  {Object|Boolean} [saveOptions] The InDesign SaveOptions constant or either true for triggering saving before closing or false for closing without saving.
- * @param  {File} [file] The InDesign file instance to save the document to.
+ * @cat     Document
+ * @method  close
+ *
+ * @param   {Object|Boolean} [saveOptions] The InDesign SaveOptions constant or
+ *          either true for triggering saving before closing or false for
+ *          closing without saving.
+ * @param   {File} [file] The InDesign file instance to save the document to.
  */
 pub.close = function(saveOptions, file) {
   if (currDoc) {
@@ -126,11 +143,16 @@ pub.close = function(saveOptions, file) {
 };
 
 /**
- * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
+ * @description Reverts the document to its last saved state. If the current
+ *          document is not saved yet, this function will close the document
+ *          without saving it and reopen a fresh document so as to "revert" the
+ *          unsaved document. This function is helpful during development stage
+ *          to start from a new or default document each time the script is run.
  *
- * @cat    Document
- * @method revert
- * @return {Document} The reverted document.
+ * @cat     Document
+ * @method  revert
+ *
+ * @return  {Document} The reverted document.
  */
 pub.revert = function() {
 
@@ -151,14 +173,21 @@ pub.revert = function() {
 };
 
 /**
- * @description Use this to set the dimensions of the canvas. Choose between PAGE (default), MARGIN, BLEED resp. FACING_PAGES, FACING_MARGINS and FACING_BLEEDS for book setups with facing page. Please note: Setups with more than two facing pages are not yet supported.<br>
- * Please note that you will loose your current MatrixTransformation. You should set the canvasMode before you attempt to use translate(), rotate() and scale();
+ * @description Use this to set the dimensions of the canvas. Choose between
+ *          `PAGE` (default), `MARGIN`, `BLEED` resp. `FACING_PAGES`,
+ *          `FACING_MARGINS` and `FACING_BLEEDS` for book setups with facing
+ *          page. Please note: Setups with more than two facing pages are not
+ *          yet supported.<br>
+ *          Please note that you will loose your current
+ *          MatrixTransformation. You should set the canvasMode before you
+ *          attempt to use `translate()`, `rotate()` and `scale()`.
  *
- * @cat    Document
- * @subcat Page
- * @method canvasMode
- * @param  {String} mode The canvas mode to set.
- * @return {String} The current canvas mode.
+ * @cat     Document
+ * @subcat  Page
+ * @method  canvasMode
+ *
+ * @param   {String} mode The canvas mode to set.
+ * @return  {String} The current canvas mode.
  */
 pub.canvasMode = function (m) {
   if(arguments.length === 0) {
@@ -179,14 +208,16 @@ pub.canvasMode = function (m) {
 
 
 /**
- * @description Returns the current horizontal and vertical pasteboard margins and sets them if both arguements are given.
+ * @description Returns the current horizontal and vertical pasteboard margins
+ *          and sets them if both arguements are given.
  *
- * @cat    Document
- * @subcat Page
- * @method pasteboard
- * @param  {Number} h The desired horizontal pasteboard margin.
- * @param  {Number} v The desired vertical pasteboard margin.
- * @return {Array} The current horizontal, vertical pasteboard margins.
+ * @cat     Document
+ * @subcat  Page
+ * @method  pasteboard
+ *
+ * @param   {Number} h The desired horizontal pasteboard margin.
+ * @param   {Number} v The desired vertical pasteboard margin.
+ * @return  {Array} The current horizontal, vertical pasteboard margins.
  */
 pub.pasteboard = function (h, v) {
   if(arguments.length == 0) {
@@ -202,13 +233,17 @@ pub.pasteboard = function (h, v) {
 };
 
 /**
- * @description Returns the current page and sets it if argument page is given. Numbering starts with 1.
+ * @description Returns the current page and sets it if argument page is given.
+ *          Numbering starts with 1.
  *
- * @cat    Document
- * @subcat Page
- * @method page
- * @param  {Page|Number|PageItem} [page] The page object or page number to set the current page to. If you pass a PageItem the current page will be set to it's containing page.
- * @return {Page} The current page instance.
+ * @cat     Document
+ * @subcat  Page
+ * @method  page
+ *
+ * @param   {Page|Number|PageItem} [page] The page object or page number to set
+ *          the current page to. If you pass a page item the current page will
+ *          be set to its containing page.
+ * @return  {Page} The current page instance.
  */
 pub.page = function(page) {
   if (page instanceof Page) {
@@ -239,13 +274,17 @@ pub.page = function(page) {
 };
 
 /**
- * @description Adds a new page to the document. Set the optional location parameter to either AT_END (default), AT_BEGINNING, AFTER or BEFORE. AFTER and BEFORE will use the current page as insertion point.
+ * @description Adds a new page to the document. Set the optional location
+ *          parameter to either `AT_END` (default), `AT_BEGINNING`, `AFTER` or
+ *          `BEFORE`. `AFTER` and `BEFORE` will use the current page as
+ *          insertion point.
  *
- * @cat    Document
- * @subcat Page
- * @method addPage
- * @param  {String} [location] The location placement mode.
- * @return {Page} The new page.
+ * @cat     Document
+ * @subcat  Page
+ * @method  addPage
+ *
+ * @param   {String} [location] The location placement mode.
+ * @return  {Page} The new page.
  */
 pub.addPage = function(location) {
 
@@ -291,12 +330,16 @@ pub.addPage = function(location) {
 
 
 /**
- * @description Removes a page from the current document. This will either be the current Page if the parameter page is left empty, or the given Page object or page number.
+ * @description Removes a page from the current document. This will either be
+ *          the current page if the parameter page is left empty, or the given
+ *          page object or page number.
  *
- * @cat    Document
- * @subcat Page
- * @method removePage
- * @param  {Page|Number} [page] The page to be removed as Page object or page number.
+ * @cat     Document
+ * @subcat  Page
+ *
+ * @method  removePage
+ * @param   {Page|Number} [page] The page to be removed as Page object or page
+ *          number.
  */
 pub.removePage = function (page) {
   checkNull(page);
@@ -311,13 +354,15 @@ pub.removePage = function (page) {
 };
 
 /**
- * @description Returns the current page number of either the current page or the given Page object.
+ * @description Returns the current page number of either the current page or
+ *          the given page object.
  *
- * @cat    Document
- * @subcat Page
- * @method pageNumber
- * @param  {Page} [pageObj] The page you want to know the number of.
- * @return {Number} The page number within the document.
+ * @cat     Document
+ * @subcat  Page
+ * @method  pageNumber
+ *
+ * @param   {Page} [pageObj] The page you want to know the number of.
+ * @return  {Number} The page number within the document.
  */
 pub.pageNumber = function (pageObj) {
   checkNull(pageObj);
@@ -331,12 +376,14 @@ pub.pageNumber = function (pageObj) {
 };
 
 /**
- * @description Set the next page of the document to be the active one. Returns new active page.
+ * @description Set the next page of the document to be the active one. Returns
+ *          new active page.
  *
- * @cat    Document
- * @subcat Page
- * @method nextPage
- * @return {Page} The active page.
+ * @cat     Document
+ * @subcat  Page
+ * @method  nextPage
+ *
+ * @return  {Page} The active page.
  */
 pub.nextPage = function () {
   var p = pub.doc().pages.nextItem(currentPage());
@@ -345,12 +392,14 @@ pub.nextPage = function () {
 
 
 /**
- * @description Set the previous page of the document to be the active one. Returns new active page.
+ * @description Set the previous page of the document to be the active one.
+ *          Returns new active page.
  *
- * @cat    Document
- * @subcat Page
- * @method previousPage
- * @return {Page} The active page.
+ * @cat     Document
+ * @subcat  Page
+ * @method  previousPage
+ *
+ * @return  {Page} The active page.
  */
 pub.previousPage = function () {
   var p = pub.doc().pages.previousItem(currentPage());
@@ -359,16 +408,19 @@ pub.previousPage = function () {
 
 
 /**
- * @description Returns the number of all pages in the current document. If a number is given as an argument,
- * it will set the document's page count to the given number by either adding pages or removing
- * pages until the number is reached. If pages are added, the master page of the document's last
- * page will be applied to the new pages.
+ * @description Returns the number of all pages in the current document. If a
+ *          number is given as an argument, it will set the document's page
+ *          count to the given number by either adding pages or removing pages
+ *          until the number is reached. If pages are added, the master page of
+ *          the document's last page will be applied to the new pages.
  *
- * @cat    Document
- * @subcat Page
- * @method pageCount
- * @param  {Number} [pageCount] New page count of the document (integer between 1 and 9999).
- * @return {Number} The amount of pages.
+ * @cat     Document
+ * @subcat  Page
+ * @method  pageCount
+ *
+ * @param   {Number} [pageCount] New page count of the document (integer between
+ *          1 and 9999).
+ * @return  {Number} The amount of pages.
  */
 pub.pageCount = function(pageCount) {
   if(arguments.length) {
@@ -385,24 +437,30 @@ pub.pageCount = function(pageCount) {
 /**
  * @description The number of all stories in the current document.
  *
- * @cat    Document
- * @subcat Story
- * @method storyCount
- * @return {Number} count The amount of stories.
+ * @cat     Document
+ * @subcat  Story
+ * @method  storyCount
+ *
+ * @return  {Number} count The amount of stories.
  */
 pub.storyCount = function() {
   return currentDoc().stories.count();
 };
 
 /**
- * @description Adds a page item or a string to an existing story. You can control the position of the insert via the last parameter. It accepts either an InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
+ * @description Adds a page item or a string to an existing story. You can
+ *          control the position of the insert via the last parameter. It
+ *          accepts either an insertion point or one the following constants:
+ *          `AT_BEGINNING` and `AT_END`.
  *
- * @cat    Document
- * @subcat Story
- * @method addToStory
- * @param  {Story} story The story.
- * @param  {PageItem|String} itemOrString The itemOrString either a PageItem, a String or one the following constants: AT_BEGINNING and AT_END.
- * @param  {InsertionPoint|String} insertionPointOrMode InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
+ * @cat     Document
+ * @subcat  Story
+ * @method  addToStory
+ *
+ * @param   {Story} story The story.
+ * @param   {PageItem|String} itemOrString Either a page item or a string.
+ * @param   {InsertionPoint|String} insertionPointOrMode Insertion point object
+ *          or one the following constants: `AT_BEGINNING` and `AT_END`.
  */
 pub.addToStory = function(story, itemOrString, insertionPointorMode) {
 
@@ -457,13 +515,17 @@ pub.addToStory = function(story, itemOrString, insertionPointorMode) {
 
 
 /**
- * @description Returns the current layer if no argument is given. Sets active layer if layer object or name of existing layer is given. Newly creates layer and sets it to active if new name is given.
+ * @description Returns the current layer if no argument is given. Sets active
+ *          layer if layer object or name of existing layer is given. Newly
+ *          creates layer and sets it to active if new name is given.
  *
- * @cat    Document
- * @subcat Page
- * @method layer
- * @param  {Layer|String} [layer] The layer or layer name to set the current layer to.
- * @return {Layer} The current layer instance.
+ * @cat     Document
+ * @subcat  Page
+ * @method  layer
+ *
+ * @param   {Layer|String} [layer] The layer or layer name to set the current
+ *          layer to.
+ * @return  {Layer} The current layer instance.
  */
 pub.layer = function(layer) {
   checkNull(layer);
@@ -486,15 +548,24 @@ pub.layer = function(layer) {
 
 
 /**
- * @description Arranges a page item or a layer before or behind other page items or layers. If using the constants `FORWARD` or `BACKWARD` the object is sent forward or back one step. The constants `FRONT` or `BACK` send the object to the very front or very back. Using `FRONT` or `BACK` together with the optional reference object, sends the object in front or behind this reference object.
+ * @description Arranges a page item or a layer before or behind other page
+ *          items or layers. If using the constants `FORWARD` or `BACKWARD` the
+ *          object is sent forward or back one step. The constants `FRONT` or
+ *          `BACK` send the object to the very front or very back. Using `FRONT`
+ *          or `BACK` together with the optional reference object, sends the
+ *          object in front or behind this reference object.
  *
- * @cat    Document
- * @subcat Page
- * @method arrange
- * @param  {PageItem|Layer} pItemOrLayer The page item or layer to be moved to a new position.
- * @param  {String} positionOrDirection The position or direction to move the page item or layer. Can be `FRONT`, `BACK`, `FORWARD` or `BACKWARD`.
- * @param  {PageItem|Layer} [reference] A reference object to move the page item or layer behind or in front of.
- * @return {PageItem|Layer} The newly arranged page item or layer.
+ * @cat     Document
+ * @subcat  Page
+ * @method  arrange
+ *
+ * @param   {PageItem|Layer} pItemOrLayer The page item or layer to be moved to
+ *          a new position.
+ * @param   {String} positionOrDirection The position or direction to move the
+ *          page item or layer. Can be `FRONT`, `BACK`, `FORWARD` or `BACKWARD`.
+ * @param   {PageItem|Layer} [reference] A reference object to move the page
+ *          item or layer behind or in front of.
+ * @return  {PageItem|Layer} The newly arranged page item or layer.
  */
 pub.arrange = function(pItemOrLayer, positionOrDirection, reference) {
   checkNull(pItemOrLayer);
@@ -542,16 +613,20 @@ pub.arrange = function(pItemOrLayer, positionOrDirection, reference) {
 
 
 /**
- *  @description Returns the Group instance and sets it if argument Group is given.
- *  Groups items to a new group. Returns the resulting group instance. If a string is given as the only
- *  argument, the group by the given name will be returned.
+ * @description Returns the Group instance and sets it if argument Group is
+ *          given. Groups items to a new group. Returns the resulting group
+ *          instance. If a string is given as the only argument, the group by
+ *          the given name will be returned.
  *
- *  @cat    Document
- *  @subCat Page
- *  @method group
- *  @param  {Array} pItems An array of page items (must contain at least two items) or name of group instance.
- *  @param  {String} [name] The name of the group, only when creating a group from page items.
- *  @return {Group} The group instance.
+ * @cat     Document
+ * @subCat  Page
+ * @method  group
+ *
+ * @param   {Array} pItems An array of page items (must contain at least two
+ *          items) or name of group instance.
+ * @param   {String} [name] The name of the group, only when creating a group
+ *          from page items.
+ * @return  {Group} The group instance.
  */
 pub.group = function (pItems, name) {
   checkNull(pItems);
@@ -580,13 +655,16 @@ pub.group = function (pItems, name) {
 
 
 /**
- *  @description Ungroups an existing group. Returns an array of the items that were within the group before ungroup() was called.
+ * @description Ungroups an existing group. Returns an array of the items that
+ *          were within the group before ungroup() was called.
  *
- *  @cat    Document
- *  @subCat Page
- *  @method ungroup
- *  @param  {Group|String} group The group instance or name of the group to ungroup.
- *  @return {Array} An array of the ungrouped page items.
+ * @cat     Document
+ * @subCat  Page
+ * @method  ungroup
+ *
+ * @param   {Group|String} group The group instance or name of the group to
+ *          ungroup.
+ * @return  {Array} An array of the ungrouped page items.
  */
 pub.ungroup = function(group) {
   checkNull(group);
@@ -610,14 +688,19 @@ pub.ungroup = function(group) {
 
 
 /**
- * @description Returns items tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label).
+ * @description Returns items tagged with the given label in the InDesign Script
+ *          Label pane (`Window -> Utilities -> Script Label`).
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method labels
- * @param  {String} label The label identifier.
- * @param  {Function} [cb] The callback function to call with each item in the search result. When this function returns false the loop stops. Passed arguments: item, loopCount.
- * @return {Array} Array of concrete PageItem instances, e.g. TextFrame or SplineItem.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  labels
+ *
+ * @param   {String} label The label identifier.
+ * @param   {Function} [cb] The callback function to call with each item in the
+ *          search result. When this function returns `false`, the loop stops.
+ *          Passed arguments: `item`, `loopCount`.
+ * @return  {Array} Array of concrete page item instances, e.g. text frame or
+ *          spline item.
  */
 pub.labels = function(label, cb) {
   checkNull(label);
@@ -641,13 +724,18 @@ pub.labels = function(label, cb) {
 
 
 /**
- * @description Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of `labels()`, when you know you just have one thing with that label and don't want to deal with a single-element array.
+ * @description Returns the first item that is tagged with the given label in
+ *          the InDesign Script Label pane (`Window -> Utilities -> Script
+ *          Label`). Use this instead of `labels()`, when you know you just have
+ *          one thing with that label and don't want to deal with a
+ *          single-element array.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method label
- * @param  {String} label The label identifier.
- * @return {PageItem} The first PageItem with the given label.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  label
+ *
+ * @param   {String} label The label identifier.
+ * @return  {PageItem} The first page item with the given label.
  */
 pub.label = function(label) {
   checkNull(label);
@@ -663,12 +751,15 @@ pub.label = function(label) {
 
 
 /**
- * @description Returns the first currently selected object. Use this if you know you only have one selected item and don't want to deal with an array.
+ * @description Returns the first currently selected object. Use this if you
+ *          know you only have one selected item and don't want to deal with an
+ *          array.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method selection
- * @return {Object} The first selected object.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  selection
+ *
+ * @return  {Object} The first selected object.
  */
 pub.selection = function() {
   if(app.selection.length === 0) {
@@ -680,11 +771,14 @@ pub.selection = function() {
 /**
  * @description Returns the currently selected object(s)
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method selections
- * @param  {Function} [cb] The callback function to call with each item in the selection. When this function returns false the loop stops. Passed arguments: item, loopCount.
- * @return {Array} Array of selected object(s).
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  selections
+ *
+ * @param   {Function} [cb] The callback function to call with each item in the
+ *          selection. When this function returns false the loop stops. Passed
+ *          arguments: item, loopCount.
+ * @return  {Array} Array of selected object(s).
  */
 pub.selections = function(cb) {
   if(app.selection.length === 0) {
@@ -697,12 +791,14 @@ pub.selections = function(cb) {
 };
 
 /**
- * @description Returns the first item on the active page that is named by the given name in the Layers pane (Window -> Layer).
+ * @description Returns the first item on the active page that is named by the
+ *          given name in the Layers pane (`Window -> Layer`).
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method nameOnPage
- * @return {Object} The first object on the active page with the given name.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  nameOnPage
+ *
+ * @return  {Object} The first object on the active page with the given name.
  */
 pub.nameOnPage = function(name) {
   checkNull(name);
@@ -723,12 +819,15 @@ pub.nameOnPage = function(name) {
 
 
 /**
- * @description Sets the units of the document (like right clicking the rulers). By default basil uses the units of the user's document or the user's default units.
+ * @description Sets the units of the document (like right clicking the rulers).
+ *          By default basil uses the units of the user's document or the user's
+ *          default units.
  *
- * @cat    Document
- * @method units
- * @param  {String} [units] Supported units: PT, PX, CM, MM or IN.
- * @return {String} Current unit setting.
+ * @cat     Document
+ * @method  units
+ *
+ * @param   {String} [units] Supported units: PT, PX, CM, MM or IN.
+ * @return  {String} Current unit setting.
  */
 var unitsCalledCounter = 0;
 pub.units = function (units) {
@@ -775,12 +874,14 @@ pub.units = function (units) {
 };
 
 /**
- * @description Creates a vertical guide line at the current spread and current layer.
+ * @description Creates a vertical guide line at the current spread and current
+ *          layer.
  *
- * @cat    Document
- * @method guideX
- * @param  {Number} x Position of the new guide line.
- * @return {Guide} New guide line.
+ * @cat     Document
+ * @method  guideX
+ *
+ * @param   {Number} x Position of the new guide line.
+ * @return  {Guide} New guide line.
  */
 pub.guideX = function (x) {
   checkNull(x);
@@ -794,12 +895,14 @@ pub.guideX = function (x) {
 
 
 /**
- * @description Creates a horizontal guide line at the current spread and current layer.
+ * @description Creates a horizontal guide line at the current spread and
+ *          current layer.
  *
- * @cat    Document
- * @method guideY
- * @param  {Number} y Position of the new guide line.
- * @return {Guide} New guide line.
+ * @cat     Document
+ * @method  guideY
+ *
+ * @param   {Number} y Position of the new guide line.
+ * @return  {Guide} New guide line.
  */
 pub.guideY = function (y) {
   checkNull(y);
@@ -813,17 +916,24 @@ pub.guideY = function (y) {
 
 
 /**
- * @description Sets the margins of a given page. If 1 value is given, all 4 sides are set equally. If 4 values are given, the current page will be adjusted. Adding a 5th value will set the margin of a given page. Calling the function without any values, will return the margins for the current page.
+ * @description Sets the margins of a given page. If 1 value is given, all 4
+ *          sides are set equally. If 4 values are given, the current page will
+ *          be adjusted. Adding a 5th value will set the margin of a given page.
+ *          Calling the function without any values, will return the margins for
+ *          the current page.
  *
- * @cat    Document
- * @subcat Page
- * @method margins
- * @param  {Number} [top] Top margin or all if only one.
- * @param  {Number} [right] Right margin.
- * @param  {Number} [bottom] Bottom margin.
- * @param  {Number} [left] Left margin.
- * @param  {Number} [pageNumber] Sets margins to selected page, currentPage() if left blank.
- * @return {Object} Current page margins with the properties: top, right, bottom, left.
+ * @cat     Document
+ * @subcat  Page
+ * @method  margins
+ *
+ * @param   {Number} [top] Top margin or all if only one.
+ * @param   {Number} [right] Right margin.
+ * @param   {Number} [bottom] Bottom margin.
+ * @param   {Number} [left] Left margin.
+ * @param   {Number} [pageNumber] Sets margins to selected page, currentPage()
+ *          if left blank.
+ * @return  {Object} Current page margins with the properties: `top`, `right`,
+ *          `bottom`, `left`.
  */
 pub.margins = function(top, right, bottom, left, pageNumber) {
   if (arguments.length === 0) {
@@ -850,16 +960,20 @@ pub.margins = function(top, right, bottom, left, pageNumber) {
 
 
 /**
- * @description Sets the document bleeds. If one value is given, all 4 are set equally. If 4 values are given, the top/right/bottom/left document bleeds will be adjusted. Calling the function without any values, will return the document bleed settings.
+ * @description Sets the document bleeds. If one value is given, all 4 are set
+ *          equally. If 4 values are given, the top/right/bottom/left document
+ *          bleeds will be adjusted. Calling the function without any values,
+ *          will return the document bleed settings.
  *
- * @cat    Document
- * @subcat Page
- * @method bleeds
- * @param  {Number} [top] Top bleed or all if only one.
- * @param  {Number} [right] Right bleed.
- * @param  {Number} [bottom] Bottom bleed.
- * @param  {Number} [left] Left bleed.
- * @return {Object} Current document bleeds settings.
+ * @cat     Document
+ * @subcat  Page
+ * @method  bleeds
+ *
+ * @param   {Number} [top] Top bleed or all if only one.
+ * @param   {Number} [right] Right bleed.
+ * @param   {Number} [bottom] Bottom bleed.
+ * @param   {Number} [left] Left bleed.
+ * @return  {Object} Current document bleeds settings.
  */
 pub.bleeds = function(top, right, bottom, left) {
   if (arguments.length === 0) {
@@ -881,31 +995,48 @@ pub.bleeds = function(top, right, bottom, left) {
 
 
 /**
- * @description Inspects a given object or any other data item and prints the result to the console. This is useful for inspecting or debugging any kind of variable or data item. The optional settings object allows to control the function's output. The following parameters can be set in the settings object:<br>
- * `showProps`: Show or hide properties. Default: `true`<br>
- * `showValues`: Show or hide values. Default: `true`<br>
- * `showMethods`: Show or hide methods. Default: `false`<br>
- * `maxLevel`: Chooses how many levels of properties should be inspected recursively. Default: `1`<br>
- * `propList`: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: `[]` (no propList)<br>
- * If no settings object is set, the default values will be used.
+ * @description Inspects a given object or any other data item and prints the
+ *          result to the console. This is useful for inspecting or debugging
+ *          any kind of variable or data item. The optional settings object
+ *          allows to control the function's output. The following parameters
+ *          can be set in the settings object:
  *
- * @cat    Output
- * @method inspect
- * @param  {Object} obj An object or any other data item to be inspected.
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {Boolean} [settings.showProps] Show or hide properties. Default: `true`
- * @param  {Boolean} [settings.showValues] Show or hide values. Default: `true`
- * @param  {Boolean} [settings.showMethods] Show or hide methods. Default: `false`
- * @param  {Number} [settings.maxLevel] How many levels of properties should be inspected recursively. Default: `1`
- * @param  {Array} [settings.propList] Array of properties to show. Default: `[]` (no propList)
+ *      - `showProps`: Show or hide properties. Default: `true`
+ *      - `showValues`: Show or hide values. Default: `true`
+ *      - `showMethods`: Show or hide methods. Default: `false`
+ *      - `maxLevel`: Chooses how many levels of properties should be inspected
+ *        recursively. Default: `1`
+ *      - `propList`: Allows to pass an array of property names to show. If
+ *        `propList` is not set all properties will be shown. Default: `[]`
+ *        (no propList)
+ *
+ *      If no settings object is set, the default values will be used.
+ *
+ * @cat     Output
+ * @method  inspect
+ *
+ * @param   {Object} obj An object or any other data item to be inspected.
+ * @param   {Object} [settings] A settings object to control the function's
+ *          behavior.
+ * @param   {Boolean} [settings.showProps] Show or hide properties. Default:
+ *          `true`
+ * @param   {Boolean} [settings.showValues] Show or hide values. Default: `true`
+ * @param   {Boolean} [settings.showMethods] Show or hide methods. Default:
+ *          `false`
+ * @param   {Number} [settings.maxLevel] How many levels of properties should be
+ *          inspected recursively. Default: `1`
+ * @param   {Array} [settings.propList] Array of properties to show. Default:
+ *          `[]` (no propList)
  *
  * @example <caption>Inspecting a string</caption>
  * inspect("foo");
  *
- * @example <caption>Inspecting the current page, its methods and an additional level of properties</caption>
+ * @example <caption>Inspecting the current page, its methods and an additional
+ *          level of properties</caption>
  * inspect(page(), {showMethods: true, maxLevel: 2})
  *
- * @example <caption>Inspecting an ellipse, listing only the properties "geometricBounds" and "strokeWeight"</caption>
+ * @example <caption>Inspecting an ellipse, listing only the properties
+ *          "geometricBounds" and "strokeWeight"</caption>
  * var myEllipse = ellipse(0, 0, 10, 10);
  * inspect(myEllipse, {maxLevel: 2, propList: ["geometricBounds, strokeWeight"]});
  */
@@ -1074,14 +1205,19 @@ pub.inspect = function (obj, settings, level, branchArray, branchEnd) {
 
 /**
  * @description Returns a file object.<br>
- * Note that the resulting file object can either refer to an already existing file or if the file does not exist, it can create a preliminary "virtual" file that refers to a file that could be created later (i.e. by an export command).
+ *          Note that the resulting file object
+ *          can either refer to an already existing file or if the file does not
+ *          exist, it can create a preliminary "virtual" file that refers to a
+ *          file that could be created later (i.e. by an export command).
  *
- * @cat    Files
- * @method file
- * @param  {String} filePath The file path.
- * @return {File} File at the given path.
+ * @cat     Files
+ * @method  file
  *
- * @example <caption>Get an image file from the desktop and place it in the document</caption>
+ * @param   {String} filePath The file path.
+ * @return  {File} File at the given path.
+ *
+ * @example <caption>Get an image file from the desktop and place it in the
+ *          document</caption>
  * var myImage = file("~/Desktop/myImage.jpg");
  * image(myImage, 0, 0);
  *
@@ -1112,18 +1248,25 @@ pub.file = function(filePath) {
 
 /**
  * @description Returns a folder object.<br>
- * Note that the resulting folder object can either refer to an already existing folder or if the folder does not exist, it can create a preliminary "virtual" folder that refers to a folder that could be created later.
+ *          Note that the resulting folder
+ *          object can either refer to an already existing folder or if the
+ *          folder does not exist, it can create a preliminary "virtual" folder
+ *          that refers to a folder that could be created later.
  *
- * @cat    Files
- * @method folder
- * @param  {String} [folderPath] The path of the folder.
- * @return {Folder} Folder at the given path. If no path is given, but the document is already saved, the document's data folder will be returned.
+ * @cat     Files
+ * @method  folder
+ *
+ * @param   {String} [folderPath] The path of the folder.
+ * @return  {Folder} Folder at the given path. If no path is given, but the
+ *          document is already saved, the document's data folder will be
+ *          returned.
  *
  * @example <caption>Get a folder from the desktop and load its files</caption>
  * var myImageFolder = folder("~/Desktop/myImages/");
  * var myImageFiles = files(myImageFolder);
  *
- * @example <caption>Get the data folder, if the document is already saved</caption>
+ * @example <caption>Get the data folder, if the document is already
+ *          saved</caption>
  * var myDataFolder = folder();
  */
 pub.folder = function(folderPath) {
@@ -1155,23 +1298,34 @@ pub.folder = function(folderPath) {
 };
 
 /**
- * @description Gets all files of a folder and returns them in an array of file objects.
- * The settings object can be used to restrict the search to certain file types only, to include hidden files and to include files in subfolders.
+ * @description Gets all files of a folder and returns them in an array of file
+ *          objects. The settings object can be used to restrict the search to
+ *          certain file types only, to include hidden files and to include
+ *          files in subfolders.
  *
- * @cat    Files
- * @method files
- * @param  {Folder|String} [folder] The folder that holds the files or a string describing the path to that folder.
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String|Array} [settings.filter] Suffix(es) of file types to include. Default: `"*"` (include all file types)
- * @param  {Boolean} [settings.hidden] Hidden files will be included. Default: `false`
- * @param  {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: `false`
- * @return {Array} Array of the resulting file(s). If no files are found, an empty array will be returned.
+ * @cat     Files
+ * @method  files
  *
- * @example <caption>Get a folder from the desktop and load all its JPEG files</caption>
+ * @param   {Folder|String} [folder] The folder that holds the files or a string
+ *          describing the path to that folder.
+ * @param   {Object} [settings] A settings object to control the function's
+ *          behavior.
+ * @param   {String|Array} [settings.filter] Suffix(es) of file types to
+ *          include. Default: `"*"` (include all file types)
+ * @param   {Boolean} [settings.hidden] Hidden files will be included. Default:
+ *          `false`
+ * @param   {Boolean} [settings.recursive] Searches subfolders recursively for
+ *          matching files. Default: `false`
+ * @return  {Array} Array of the resulting file(s). If no files are found, an
+ *          empty array will be returned.
+ *
+ * @example <caption>Get a folder from the desktop and load all its JPEG
+ *          files</caption>
  * var myImageFolder = folder("~/Desktop/myImages/");
  * var myImageFiles = files(myImageFolder, {filter: ["jpeg", "jpg"]});
  *
- * @example <caption>If the document is saved, load all files from its data folder, including from its subfolders</caption>
+ * @example <caption>If the document is saved, load all files from its data
+ *          folder, including from its subfolders</caption>
  * var myDataFolder = folder();
  * var allMyDataFiles = files(myDataFolder, {recursive: true});
  */
@@ -1235,20 +1389,32 @@ pub.files = function(folder, settings, collectedFiles) {
 };
 
 /**
- * @description Opens a selection dialog that allows to select one file. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select one file. The
+ *          settings object can be used to add a prompt text at the top of the
+ *          dialog, to restrict the selection to certain file types and to set
+ *          the dialog's starting folder.
  *
- * @cat    Files
- * @method selectFile
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
- * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
- * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {File|Null} The selected file. If the user cancels, `null` will be returned.
+ * @cat     Files
+ * @method  selectFile
+ *
+ * @param   {Object} [settings] A settings object to control the function's
+ *          behavior.
+ * @param   {String} [settings.prompt] The prompt text at the top of the file
+ *          selection dialog. Default: `""` (no prompt)
+ * @param   {String|Array} [settings.filter] String or an array containing
+ *          strings of file endings to include in the dialog. Default: `""`
+ *          (include all)
+ * @param   {Folder|String} [settings.folder] Folder or a folder path string
+ *          defining the start location of the dialog. Default: most recent
+ *          dialog folder or main user folder.
+ * @return  {File|Null} The selected file. If the user cancels, `null` will be
+ *          returned.
  *
  * @example <caption>Open file selection dialog with a prompt text</caption>
  * selectFile({prompt: "Please select a file."});
  *
- * @example <caption>Open selection dialog starting at the user's desktop, allowing to only select PNG or JPEG files</caption>
+ * @example <caption>Open selection dialog starting at the user's desktop,
+ *          allowing to only select PNG or JPEG files</caption>
  * selectFile({folder: "~/Desktop/", filter: ["jpeg", "jpg", "png"]});
  */
 pub.selectFile = function(settings) {
@@ -1256,20 +1422,32 @@ pub.selectFile = function(settings) {
 };
 
 /**
- * @description Opens a selection dialog that allows to select one or multiple files. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select one or multiple
+ *          files. The settings object can be used to add a prompt text at the
+ *          top of the dialog, to restrict the selection to certain file types
+ *          and to set the dialog's starting folder.
  *
- * @cat    Files
- * @method selectFiles
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
- * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
- * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {Array} Array of the selected file(s). If the user cancels, an empty array will be returned.
+ * @cat     Files
+ * @method  selectFiles
+ *
+ * @param   {Object} [settings] A settings object to control the function's
+ *          behavior.
+ * @param   {String} [settings.prompt] The prompt text at the top of the file
+ *          selection dialog. Default: `""` (no prompt)
+ * @param   {String|Array} [settings.filter] String or an array containing
+ *          strings of file endings to include in the dialog. Default: `""`
+ *          (include all)
+ * @param   {Folder|String} [settings.folder] Folder or a folder path string
+ *          defining the start location of the dialog. Default: most recent
+ *          dialog folder or main user folder.
+ * @return  {Array} Array of the selected file(s). If the user cancels, an empty
+ *          array will be returned.
  *
  * @example <caption>Open file selection dialog with a prompt text</caption>
  * selectFiles({prompt: "Please select your files."});
  *
- * @example <caption>Open selection dialog starting at the user's desktop, allowing to only select PNG or JPEG files</caption>
+ * @example <caption>Open selection dialog starting at the user's desktop,
+ *          allowing to only select PNG or JPEG files</caption>
  * selectFiles({folder: "~/Desktop/", filter: ["jpeg", "jpg", "png"]});
  */
 pub.selectFiles = function(settings) {
@@ -1282,19 +1460,28 @@ pub.selectFiles = function(settings) {
 };
 
 /**
- * @description Opens a selection dialog that allows to select a folder. The settings object can be used to add a prompt text at the top of the dialog and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select a folder. The
+ *          settings object can be used to add a prompt text at the top of the
+ *          dialog and to set the dialog's starting folder.
  *
- * @cat    Files
- * @method selectFolder
- * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: `""` (no prompt)
- * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {Folder|Null} The selected folder. If the user cancels, `null` will be returned.
+ * @cat     Files
+ * @method  selectFolder
+ *
+ * @param   {Object} [settings] A settings object to control the function's
+ *          behavior.
+ * @param   {String} [settings.prompt] The prompt text at the top of the folder
+ *          selection dialog. Default: `""` (no prompt)
+ * @param   {Folder|String} [settings.folder] Folder or a folder path string
+ *          defining the start location of the dialog. Default: most recent
+ *          dialog folder or main user folder.
+ * @return  {Folder|Null} The selected folder. If the user cancels, `null` will
+ *          be returned.
  *
  * @example <caption>Open folder selection dialog with a prompt text</caption>
  * selectFolder({prompt: "Please select a folder."});
  *
- * @example <caption>Open folder selection dialog starting at the user's desktop</caption>
+ * @example <caption>Open folder selection dialog starting at the user's
+ *          desktop</caption>
  * selectFolder({folder: "~/Desktop/"});
  */
 pub.selectFolder = function(settings) {
@@ -1311,12 +1498,14 @@ pub.selectFolder = function(settings) {
 // Date
 
 /**
- * @description The year() function returns the current year as an integer (2012, 2013 etc).
+ * @description The `year()` function returns the current year as a number
+ *          (`2018`, `2019` etc).
  *
- * @cat    Environment
- * @subcat Date
- * @method year
- * @return {Number} The current year.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  year
+ *
+ * @return  {Number} The current year.
  */
 pub.year = function() {
   return (new Date()).getFullYear();
@@ -1324,12 +1513,14 @@ pub.year = function() {
 
 
 /**
- * @description The month() function returns the current month as a value from 1 - 12.
+ * @description The `month()` function returns the current month as a value from
+ *          `1`-`12`.
  *
- * @cat    Environment
- * @subcat Date
- * @method month
- * @return {Number} The current month number.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  month
+ *
+ * @return  {Number} The current month number.
  */
 pub.month = function() {
   return (new Date()).getMonth() + 1;
@@ -1337,12 +1528,14 @@ pub.month = function() {
 
 
 /**
- * @description The day() function returns the current day as a value from 1 - 31.
+ * @description The `day()` function returns the current day as a value from
+ *          `1`-`31`.
  *
- * @cat    Environment
- * @subcat Date
- * @method day
- * @return {Number} The current day number.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  day
+ *
+ * @return  {Number} The current day number.
  */
 pub.day = function() {
   return (new Date()).getDate();
@@ -1350,12 +1543,14 @@ pub.day = function() {
 
 
 /**
- * @description The weekday() function returns the current weekday as a string from Sunday, Monday, Tuesday...
+ * @description The `weekday()` function returns the current weekday as a string
+ *          from `Sunday`, `Monday`, `Tuesday` ...
  *
- * @cat    Environment
- * @subcat Date
- * @method weekday
- * @return {String} The current weekday name.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  weekday
+ *
+ * @return  {String} The current weekday name.
  */
 pub.weekday = function() {
   var weekdays = new Array("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday");
@@ -1364,12 +1559,14 @@ pub.weekday = function() {
 
 
 /**
- * @description The hour() function returns the current hour as a value from 0 - 23.
+ * @description The `hour()` function returns the current hour as a value from
+ *          `0` - `23`.
  *
- * @cat    Environment
- * @subcat Date
- * @method hour
- * @return {Number} The current hour.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  hour
+ *
+ * @return  {Number} The current hour.
  */
 pub.hour = function() {
   return (new Date()).getHours();
@@ -1377,12 +1574,14 @@ pub.hour = function() {
 
 
 /**
- * @description The minute() function returns the current minute as a value from 0 - 59.
+ * @description The `minute()` function returns the current minute as a value
+ *          from `0` - `59`.
  *
- * @cat    Environment
- * @subcat Date
- * @method minute
- * @return {Number} The current minute.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  minute
+ *
+ * @return  {Number} The current minute.
  */
 pub.minute = function() {
   return (new Date()).getMinutes();
@@ -1390,12 +1589,14 @@ pub.minute = function() {
 
 
 /**
- * @description The second() function returns the current second as a value from 0 - 59.
+ * @description The `second()` function returns the current second as a value
+ *          from `0` - `59`.
  *
- * @cat    Environment
- * @subcat Date
- * @method second
- * @return {Number} The current second.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  second
+ *
+ * @return  {Number} The current second.
  */
 pub.second = function() {
   return (new Date()).getSeconds();
@@ -1403,12 +1604,14 @@ pub.second = function() {
 
 
 /**
- * @description Returns the number of milliseconds (thousandths of a second) since starting an applet.
+ * @description Returns the number of milliseconds (thousandths of a second)
+ *          since starting the script.
  *
- * @cat    Environment
- * @subcat Date
- * @method millis
- * @return {Number} The current milli.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  millis
+ *
+ * @return  {Number} The current milli.
  */
 pub.millis = function() {
   return Date.now() - startTime;
@@ -1416,12 +1619,15 @@ pub.millis = function() {
 
 
 /**
- * @description The millisecond() function differs from millis(), in that it returns the exact millisecond (thousandths of a second) of the current time.
+ * @description The `millisecond()` function differs from `millis()`, in that it
+ *          returns the exact millisecond (thousandths of a second) of the
+ *          current time.
  *
- * @cat    Environment
- * @subcat Date
- * @method millisecond
- * @return {Number} The current millisecond.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  millisecond
+ *
+ * @return  {Number} The current millisecond.
  */
 pub.millisecond = function() {
   return (new Date()).getMilliseconds();
@@ -1429,12 +1635,14 @@ pub.millisecond = function() {
 
 
 /**
- * @description The timestamp() function returns the current date formatted as YYYYMMDD_HHMMSS for useful unique filenaming.
+ * @description The `timestamp()` function returns the current date formatted as
+ *          `YYYYMMDD_HHMMSS` for useful unique filenaming.
  *
- * @cat    Environment
- * @subcat Date
- * @method timestamp
- * @return {String} The current time in YYYYMMDD_HHMMSS.
+ * @cat     Environment
+ * @subcat  Date
+ * @method  timestamp
+ *
+ * @return  {String} The current time in `YYYYMMDD_HHMMSS`.
  */
 pub.timestamp = function() {
   var dt = new Date();

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -3,11 +3,11 @@
 // ----------------------------------------
 
 /**
- * Sets or possibly creates the current document and returns it.
+ * @description Sets or possibly creates the current document and returns it.
  * If the param doc is not given the current document gets set to the active document
  * in the application. If no document at all is open, a new document gets created.
  *
- * @cat Document
+ * @cat    Document
  * @method doc
  * @param  {Document} [doc] The document to set the current document to.
  * @return {Document} The current document instance.
@@ -22,13 +22,13 @@ pub.doc = function(doc) {
 };
 
 /**
- * Sets the size of the current document, if arguments are given.
+ * @description Sets the size of the current document, if arguments are given.
  * If only one argument is given, both the width and the height are set to this value.
  * Alternatively, a string can be given as the first argument to apply an existing page size preset ("A4", "Letter" etc.).
  * In this case, either PORTRAIT or LANDSCAPE can be used as a second argument to determine the orientation of the page.
  * If no argument is given, an object containing the current document's width and height is returned.
  *
- * @cat Document
+ * @cat    Document
  * @method size
  * @param  {Number|String} [widthOrPageSize] The desired width of the current document or the name of a page size preset.
  * @param  {Number|String} [heightOrOrientation] The desired height of the current document. If not provided the width will be used as the height. If the first argument is a page size preset, the second argument can be used to set the orientation.
@@ -92,9 +92,9 @@ pub.size = function(widthOrPageSize, heightOrOrientation) {
 };
 
 /**
- * Closes the current document. If no saveOptions argument is used, the user will be asked if they want to save or not.
+ * @description Closes the current document. If no saveOptions argument is used, the user will be asked if they want to save or not.
  *
- * @cat Document
+ * @cat    Document
  * @method close
  * @param  {Object|Boolean} [saveOptions] The InDesign SaveOptions constant or either true for triggering saving before closing or false for closing without saving.
  * @param  {File} [file] The InDesign file instance to save the document to.
@@ -128,7 +128,7 @@ pub.close = function(saveOptions, file) {
 /**
  * @description Reverts the document to its last saved state. If the current document is not saved yet, this function will close the document without saving it and reopen a fresh document so as to "revert" the unsaved document. This function is helpful during development stage to start from a new or default document each time the script is run.
  *
- * @cat Document
+ * @cat    Document
  * @method revert
  * @return {Document} The reverted document.
  */
@@ -151,9 +151,10 @@ pub.revert = function() {
 };
 
 /**
- * Use this to set the dimensions of the canvas. Choose between PAGE (default), MARGIN, BLEED resp. FACING_PAGES, FACING_MARGINS and FACING_BLEEDS for book setups with facing page. Please note: Setups with more than two facing pages are not yet supported.
+ * @description Use this to set the dimensions of the canvas. Choose between PAGE (default), MARGIN, BLEED resp. FACING_PAGES, FACING_MARGINS and FACING_BLEEDS for book setups with facing page. Please note: Setups with more than two facing pages are not yet supported.<br>
  * Please note that you will loose your current MatrixTransformation. You should set the canvasMode before you attempt to use translate(), rotate() and scale();
- * @cat Document
+ *
+ * @cat    Document
  * @subcat Page
  * @method canvasMode
  * @param  {String} mode The canvas mode to set.
@@ -178,9 +179,9 @@ pub.canvasMode = function (m) {
 
 
 /**
- * Returns the current horizontal and vertical pasteboard margins and sets them if both arguements are given.
+ * @description Returns the current horizontal and vertical pasteboard margins and sets them if both arguements are given.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method pasteboard
  * @param  {Number} h The desired horizontal pasteboard margin.
@@ -201,9 +202,9 @@ pub.pasteboard = function (h, v) {
 };
 
 /**
- * Returns the current page and sets it if argument page is given. Numbering starts with 1.
+ * @description Returns the current page and sets it if argument page is given. Numbering starts with 1.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method page
  * @param  {Page|Number|PageItem} [page] The page object or page number to set the current page to. If you pass a PageItem the current page will be set to it's containing page.
@@ -238,9 +239,9 @@ pub.page = function(page) {
 };
 
 /**
- * Adds a new page to the document. Set the optional location parameter to either AT_END (default), AT_BEGINNING, AFTER or BEFORE. AFTER and BEFORE will use the current page as insertion point.
+ * @description Adds a new page to the document. Set the optional location parameter to either AT_END (default), AT_BEGINNING, AFTER or BEFORE. AFTER and BEFORE will use the current page as insertion point.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method addPage
  * @param  {String} [location] The location placement mode.
@@ -290,9 +291,9 @@ pub.addPage = function(location) {
 
 
 /**
- * Removes a page from the current document. This will either be the current Page if the parameter page is left empty, or the given Page object or page number.
+ * @description Removes a page from the current document. This will either be the current Page if the parameter page is left empty, or the given Page object or page number.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method removePage
  * @param  {Page|Number} [page] The page to be removed as Page object or page number.
@@ -310,9 +311,9 @@ pub.removePage = function (page) {
 };
 
 /**
- * Returns the current page number of either the current page or the given Page object.
+ * @description Returns the current page number of either the current page or the given Page object.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method pageNumber
  * @param  {Page} [pageObj] The page you want to know the number of.
@@ -330,9 +331,9 @@ pub.pageNumber = function (pageObj) {
 };
 
 /**
- * Set the next page of the document to be the active one. Returns new active page.
+ * @description Set the next page of the document to be the active one. Returns new active page.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method nextPage
  * @return {Page} The active page.
@@ -344,9 +345,9 @@ pub.nextPage = function () {
 
 
 /**
- * Set the previous page of the document to be the active one. Returns new active page.
+ * @description Set the previous page of the document to be the active one. Returns new active page.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method previousPage
  * @return {Page} The active page.
@@ -358,12 +359,12 @@ pub.previousPage = function () {
 
 
 /**
- * Returns the number of all pages in the current document. If a number is given as an argument,
+ * @description Returns the number of all pages in the current document. If a number is given as an argument,
  * it will set the document's page count to the given number by either adding pages or removing
  * pages until the number is reached. If pages are added, the master page of the document's last
  * page will be applied to the new pages.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method pageCount
  * @param  {Number} [pageCount] New page count of the document (integer between 1 and 9999).
@@ -382,9 +383,9 @@ pub.pageCount = function(pageCount) {
 
 
 /**
- * The number of all stories in the current document.
+ * @description The number of all stories in the current document.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Story
  * @method storyCount
  * @return {Number} count The amount of stories.
@@ -394,14 +395,14 @@ pub.storyCount = function() {
 };
 
 /**
- * Adds a page item or a string to an existing story. You can control the position of the insert via the last parameter. It accepts either an InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
+ * @description Adds a page item or a string to an existing story. You can control the position of the insert via the last parameter. It accepts either an InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Story
  * @method addToStory
- * @param {Story} story The story.
- * @param {PageItem|String} itemOrString The itemOrString either a PageItem, a String or one the following constants: AT_BEGINNING and AT_END.
- * @param {InsertionPoint|String} insertionPointOrMode InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
+ * @param  {Story} story The story.
+ * @param  {PageItem|String} itemOrString The itemOrString either a PageItem, a String or one the following constants: AT_BEGINNING and AT_END.
+ * @param  {InsertionPoint|String} insertionPointOrMode InsertionPoint or one the following constants: AT_BEGINNING and AT_END.
  */
 pub.addToStory = function(story, itemOrString, insertionPointorMode) {
 
@@ -456,9 +457,9 @@ pub.addToStory = function(story, itemOrString, insertionPointorMode) {
 
 
 /**
- * Returns the current layer if no argument is given. Sets active layer if layer object or name of existing layer is given. Newly creates layer and sets it to active if new name is given.
+ * @description Returns the current layer if no argument is given. Sets active layer if layer object or name of existing layer is given. Newly creates layer and sets it to active if new name is given.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method layer
  * @param  {Layer|String} [layer] The layer or layer name to set the current layer to.
@@ -487,12 +488,12 @@ pub.layer = function(layer) {
 /**
  * @description Arranges a page item or a layer before or behind other page items or layers. If using the constants <code>FORWARD</code> or <code>BACKWARD</code> the object is sent forward or back one step. The constants <code>FRONT</code> or <code>BACK</code> send the object to the very front or very back. Using <code>FRONT</code> or <code>BACK</code> together with the optional reference object, sends the object in front or behind this reference object.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method arrange
- * @param {PageItem|Layer} pItemOrLayer The page item or layer to be moved to a new position.
- * @param {String} positionOrDirection The position or direction to move the page item or layer. Can be <code>FRONT</code>, <code>BACK</code>, <code>FORWARD</code> or <code>BACKWARD</code>.
- * @param {PageItem|Layer} [reference] A reference object to move the page item or layer behind or in front of.
+ * @param  {PageItem|Layer} pItemOrLayer The page item or layer to be moved to a new position.
+ * @param  {String} positionOrDirection The position or direction to move the page item or layer. Can be <code>FRONT</code>, <code>BACK</code>, <code>FORWARD</code> or <code>BACKWARD</code>.
+ * @param  {PageItem|Layer} [reference] A reference object to move the page item or layer behind or in front of.
  * @return {PageItem|Layer} The newly arranged page item or layer.
  */
 pub.arrange = function(pItemOrLayer, positionOrDirection, reference) {
@@ -541,15 +542,15 @@ pub.arrange = function(pItemOrLayer, positionOrDirection, reference) {
 
 
 /**
- *  Returns the Group instance and sets it if argument Group is given.
+ *  @description Returns the Group instance and sets it if argument Group is given.
  *  Groups items to a new group. Returns the resulting group instance. If a string is given as the only
  *  argument, the group by the given name will be returned.
  *
- *  @cat Document
+ *  @cat    Document
  *  @subCat Page
  *  @method group
- *  @param {Array} pItems An array of page items (must contain at least two items) or name of group instance.
- *  @param {String} [name] The name of the group, only when creating a group from page items.
+ *  @param  {Array} pItems An array of page items (must contain at least two items) or name of group instance.
+ *  @param  {String} [name] The name of the group, only when creating a group from page items.
  *  @return {Group} The group instance.
  */
 pub.group = function (pItems, name) {
@@ -579,12 +580,12 @@ pub.group = function (pItems, name) {
 
 
 /**
- *  Ungroups an existing group. Returns an array of the items that were within the group before ungroup() was called.
+ *  @description Ungroups an existing group. Returns an array of the items that were within the group before ungroup() was called.
  *
- *  @cat Document
+ *  @cat    Document
  *  @subCat Page
  *  @method ungroup
- *  @param {Group|String} group The group instance or name of the group to ungroup.
+ *  @param  {Group|String} group The group instance or name of the group to ungroup.
  *  @return {Array} An array of the ungrouped page items.
  */
 pub.ungroup = function(group) {
@@ -609,9 +610,9 @@ pub.ungroup = function(group) {
 
 
 /**
- * Returns items tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label).
+ * @description Returns items tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label).
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method labels
  * @param  {String} label The label identifier.
@@ -640,9 +641,9 @@ pub.labels = function(label, cb) {
 
 
 /**
- * Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of <code>labels()</code>, when you know you just have one thing with that label and don't want to deal with a single-element array.
+ * @description Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of <code>labels()</code>, when you know you just have one thing with that label and don't want to deal with a single-element array.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method label
  * @param  {String} label The label identifier.
@@ -662,9 +663,9 @@ pub.label = function(label) {
 
 
 /**
- * Returns the first currently selected object. Use this if you know you only have one selected item and don't want to deal with an array.
+ * @description Returns the first currently selected object. Use this if you know you only have one selected item and don't want to deal with an array.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method selection
  * @return {Object} The first selected object.
@@ -677,9 +678,9 @@ pub.selection = function() {
 };
 
 /**
- * Returns the currently selected object(s)
+ * @description Returns the currently selected object(s)
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method selections
  * @param  {Function} [cb] The callback function to call with each item in the selection. When this function returns false the loop stops. Passed arguments: item, loopCount.
@@ -696,9 +697,9 @@ pub.selections = function(cb) {
 };
 
 /**
- * Returns the first item on the active page that is named by the given name in the Layers pane (Window -> Layer).
+ * @description Returns the first item on the active page that is named by the given name in the Layers pane (Window -> Layer).
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method nameOnPage
  * @return {Object} The first object on the active page with the given name.
@@ -722,9 +723,9 @@ pub.nameOnPage = function(name) {
 
 
 /**
- * Sets the units of the document (like right clicking the rulers). By default basil uses the units of the user's document or the user's default units.
+ * @description Sets the units of the document (like right clicking the rulers). By default basil uses the units of the user's document or the user's default units.
  *
- * @cat Document
+ * @cat    Document
  * @method units
  * @param  {String} [units] Supported units: PT, PX, CM, MM or IN.
  * @return {String} Current unit setting.
@@ -774,9 +775,9 @@ pub.units = function (units) {
 };
 
 /**
- * Creates a vertical guide line at the current spread and current layer.
+ * @description Creates a vertical guide line at the current spread and current layer.
  *
- * @cat Document
+ * @cat    Document
  * @method guideX
  * @param  {Number} x Position of the new guide line.
  * @return {Guide} New guide line.
@@ -793,9 +794,9 @@ pub.guideX = function (x) {
 
 
 /**
- * Creates a horizontal guide line at the current spread and current layer.
+ * @description Creates a horizontal guide line at the current spread and current layer.
  *
- * @cat Document
+ * @cat    Document
  * @method guideY
  * @param  {Number} y Position of the new guide line.
  * @return {Guide} New guide line.
@@ -812,16 +813,16 @@ pub.guideY = function (y) {
 
 
 /**
- * Sets the margins of a given page. If 1 value is given, all 4 sides are set equally. If 4 values are given, the current page will be adjusted. Adding a 5th value will set the margin of a given page. Calling the function without any values, will return the margins for the current page.
+ * @description Sets the margins of a given page. If 1 value is given, all 4 sides are set equally. If 4 values are given, the current page will be adjusted. Adding a 5th value will set the margin of a given page. Calling the function without any values, will return the margins for the current page.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method margins
- * @param {Number} [top] Top margin or all if only one.
- * @param {Number} [right] Right margin.
- * @param {Number} [bottom] Bottom margin.
- * @param {Number} [left] Left margin.
- * @param {Number} [pageNumber] Sets margins to selected page, currentPage() if left blank.
+ * @param  {Number} [top] Top margin or all if only one.
+ * @param  {Number} [right] Right margin.
+ * @param  {Number} [bottom] Bottom margin.
+ * @param  {Number} [left] Left margin.
+ * @param  {Number} [pageNumber] Sets margins to selected page, currentPage() if left blank.
  * @return {Object} Current page margins with the properties: top, right, bottom, left.
  */
 pub.margins = function(top, right, bottom, left, pageNumber) {
@@ -849,15 +850,15 @@ pub.margins = function(top, right, bottom, left, pageNumber) {
 
 
 /**
- * Sets the document bleeds. If one value is given, all 4 are set equally. If 4 values are given, the top/right/bottom/left document bleeds will be adjusted. Calling the function without any values, will return the document bleed settings.
+ * @description Sets the document bleeds. If one value is given, all 4 are set equally. If 4 values are given, the top/right/bottom/left document bleeds will be adjusted. Calling the function without any values, will return the document bleed settings.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Page
  * @method bleeds
- * @param {Number} [top] Top bleed or all if only one.
- * @param {Number} [right] Right bleed.
- * @param {Number} [bottom] Bottom bleed.
- * @param {Number} [left] Left bleed.
+ * @param  {Number} [top] Top bleed or all if only one.
+ * @param  {Number} [right] Right bleed.
+ * @param  {Number} [bottom] Bottom bleed.
+ * @param  {Number} [left] Left bleed.
  * @return {Object} Current document bleeds settings.
  */
 pub.bleeds = function(top, right, bottom, left) {
@@ -880,15 +881,15 @@ pub.bleeds = function(top, right, bottom, left) {
 
 
 /**
- * @description Inspects a given object or any other data item and prints the result to the console. This is useful for inspecting or debugging any kind of variable or data item. The optional settings object allows to control the function's output. The following parameters can be set in the settings object:
- * <code>showProps</code>: Show or hide properties. Default: <code>true</code>
- * <code>showValues</code>: Show or hide values. Default: <code>true</code>
- * <code>showMethods</code>: Show or hide methods. Default: <code>false</code>
- * <code>maxLevel</code>: Chooses how many levels of properties should be inspected recursively. Default: <code>1</code>
- * <code>propList</code>: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: <code>[]</code> (no propList)
+ * @description Inspects a given object or any other data item and prints the result to the console. This is useful for inspecting or debugging any kind of variable or data item. The optional settings object allows to control the function's output. The following parameters can be set in the settings object:<br>
+ * <code>showProps</code>: Show or hide properties. Default: <code>true</code><br>
+ * <code>showValues</code>: Show or hide values. Default: <code>true</code><br>
+ * <code>showMethods</code>: Show or hide methods. Default: <code>false</code><br>
+ * <code>maxLevel</code>: Chooses how many levels of properties should be inspected recursively. Default: <code>1</code><br>
+ * <code>propList</code>: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: <code>[]</code> (no propList)<br>
  * If no settings object is set, the default values will be used.
  *
- * @cat Output
+ * @cat    Output
  * @method inspect
  * @param  {Object} obj An object or any other data item to be inspected.
  * @param  {Object} [settings] A settings object to control the function's behavior.
@@ -1072,12 +1073,12 @@ pub.inspect = function (obj, settings, level, branchArray, branchEnd) {
 // Files & Folders
 
 /**
- * Returns a file object.
+ * @description Returns a file object.<br>
  * Note that the resulting file object can either refer to an already existing file or if the file does not exist, it can create a preliminary "virtual" file that refers to a file that could be created later (i.e. by an export command).
  *
- * @cat Files
+ * @cat    Files
  * @method file
- * @param {String} filePath The file path.
+ * @param  {String} filePath The file path.
  * @return {File} File at the given path.
  *
  * @example <caption>Get an image file from the desktop and place it in the document</caption>
@@ -1110,12 +1111,12 @@ pub.file = function(filePath) {
 };
 
 /**
- * Returns a folder object.
+ * @description Returns a folder object.<br>
  * Note that the resulting folder object can either refer to an already existing folder or if the folder does not exist, it can create a preliminary "virtual" folder that refers to a folder that could be created later.
  *
- * @cat Files
+ * @cat    Files
  * @method folder
- * @param {String} [folderPath] The path of the folder.
+ * @param  {String} [folderPath] The path of the folder.
  * @return {Folder} Folder at the given path. If no path is given, but the document is already saved, the document's data folder will be returned.
  *
  * @example <caption>Get a folder from the desktop and load its files</caption>
@@ -1154,16 +1155,16 @@ pub.folder = function(folderPath) {
 };
 
 /**
- * Gets all files of a folder and returns them in an array of file objects.
+ * @description Gets all files of a folder and returns them in an array of file objects.
  * The settings object can be used to restrict the search to certain file types only, to include hidden files and to include files in subfolders.
  *
- * @cat Files
+ * @cat    Files
  * @method files
- * @param {Folder|String} [folder] The folder that holds the files or a string describing the path to that folder.
- * @param {Object} [settings] A settings object to control the function's behavior.
- * @param {String|Array} [settings.filter] Suffix(es) of file types to include. Default: <code>"*"</code> (include all file types)
- * @param {Boolean} [settings.hidden] Hidden files will be included. Default: <code>false</code>
- * @param {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: <code>false</code>
+ * @param  {Folder|String} [folder] The folder that holds the files or a string describing the path to that folder.
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String|Array} [settings.filter] Suffix(es) of file types to include. Default: <code>"*"</code> (include all file types)
+ * @param  {Boolean} [settings.hidden] Hidden files will be included. Default: <code>false</code>
+ * @param  {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: <code>false</code>
  * @return {Array} Array of the resulting file(s). If no files are found, an empty array will be returned.
  *
  * @example <caption>Get a folder from the desktop and load all its JPEG files</caption>
@@ -1234,14 +1235,14 @@ pub.files = function(folder, settings, collectedFiles) {
 };
 
 /**
- * Opens a selection dialog that allows to select one file. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select one file. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
  *
- * @cat Files
+ * @cat    Files
  * @method selectFile
- * @param {Object} [settings] A settings object to control the function's behavior.
- * @param {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
- * @param {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
- * @param {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
+ * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
+ * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
  * @return {File|Null} The selected file. If the user cancels, <code>null</code> will be returned.
  *
  * @example <caption>Open file selection dialog with a prompt text</caption>
@@ -1255,14 +1256,14 @@ pub.selectFile = function(settings) {
 };
 
 /**
- * Opens a selection dialog that allows to select one or multiple files. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select one or multiple files. The settings object can be used to add a prompt text at the top of the dialog, to restrict the selection to certain file types and to set the dialog's starting folder.
  *
- * @cat Files
+ * @cat    Files
  * @method selectFiles
- * @param {Object} [settings] A settings object to control the function's behavior.
- * @param {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
- * @param {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
- * @param {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
+ * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
+ * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
  * @return {Array} Array of the selected file(s). If the user cancels, an empty array will be returned.
  *
  * @example <caption>Open file selection dialog with a prompt text</caption>
@@ -1281,13 +1282,13 @@ pub.selectFiles = function(settings) {
 };
 
 /**
- * Opens a selection dialog that allows to select a folder. The settings object can be used to add a prompt text at the top of the dialog and to set the dialog's starting folder.
+ * @description Opens a selection dialog that allows to select a folder. The settings object can be used to add a prompt text at the top of the dialog and to set the dialog's starting folder.
  *
- * @cat Files
+ * @cat    Files
  * @method selectFolder
- * @param {Object} [settings] A settings object to control the function's behavior.
- * @param {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: <code>""</code> (no prompt)
- * @param {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
+ * @param  {Object} [settings] A settings object to control the function's behavior.
+ * @param  {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: <code>""</code> (no prompt)
+ * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
  * @return {Folder|Null} The selected folder. If the user cancels, <code>null</code> will be returned.
  *
  * @example <caption>Open folder selection dialog with a prompt text</caption>
@@ -1310,9 +1311,9 @@ pub.selectFolder = function(settings) {
 // Date
 
 /**
- * The year() function returns the current year as an integer (2012, 2013 etc).
+ * @description The year() function returns the current year as an integer (2012, 2013 etc).
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method year
  * @return {Number} The current year.
@@ -1323,9 +1324,9 @@ pub.year = function() {
 
 
 /**
- * The month() function returns the current month as a value from 1 - 12.
+ * @description The month() function returns the current month as a value from 1 - 12.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method month
  * @return {Number} The current month number.
@@ -1336,9 +1337,9 @@ pub.month = function() {
 
 
 /**
- * The day() function returns the current day as a value from 1 - 31.
+ * @description The day() function returns the current day as a value from 1 - 31.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method day
  * @return {Number} The current day number.
@@ -1349,9 +1350,9 @@ pub.day = function() {
 
 
 /**
- * The weekday() function returns the current weekday as a string from Sunday, Monday, Tuesday...
+ * @description The weekday() function returns the current weekday as a string from Sunday, Monday, Tuesday...
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method weekday
  * @return {String} The current weekday name.
@@ -1363,9 +1364,9 @@ pub.weekday = function() {
 
 
 /**
- * The hour() function returns the current hour as a value from 0 - 23.
+ * @description The hour() function returns the current hour as a value from 0 - 23.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method hour
  * @return {Number} The current hour.
@@ -1376,9 +1377,9 @@ pub.hour = function() {
 
 
 /**
- * The minute() function returns the current minute as a value from 0 - 59.
+ * @description The minute() function returns the current minute as a value from 0 - 59.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method minute
  * @return {Number} The current minute.
@@ -1389,9 +1390,9 @@ pub.minute = function() {
 
 
 /**
- * The second() function returns the current second as a value from 0 - 59.
+ * @description The second() function returns the current second as a value from 0 - 59.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method second
  * @return {Number} The current second.
@@ -1402,9 +1403,9 @@ pub.second = function() {
 
 
 /**
- * Returns the number of milliseconds (thousandths of a second) since starting an applet.
+ * @description Returns the number of milliseconds (thousandths of a second) since starting an applet.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method millis
  * @return {Number} The current milli.
@@ -1415,9 +1416,9 @@ pub.millis = function() {
 
 
 /**
- * The millisecond() function differs from millis(), in that it returns the exact millisecond (thousandths of a second) of the current time.
+ * @description The millisecond() function differs from millis(), in that it returns the exact millisecond (thousandths of a second) of the current time.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method millisecond
  * @return {Number} The current millisecond.
@@ -1428,9 +1429,9 @@ pub.millisecond = function() {
 
 
 /**
- * The timestamp() function returns the current date formatted as YYYYMMDD_HHMMSS for useful unique filenaming.
+ * @description The timestamp() function returns the current date formatted as YYYYMMDD_HHMMSS for useful unique filenaming.
  *
- * @cat Environment
+ * @cat    Environment
  * @subcat Date
  * @method timestamp
  * @return {String} The current time in YYYYMMDD_HHMMSS.

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -32,7 +32,7 @@ pub.doc = function(doc) {
  * @method size
  * @param  {Number|String} [widthOrPageSize] The desired width of the current document or the name of a page size preset.
  * @param  {Number|String} [heightOrOrientation] The desired height of the current document. If not provided the width will be used as the height. If the first argument is a page size preset, the second argument can be used to set the orientation.
- * @return {Object} Object containing the current <code>width</code> and <code>height</code> of the document.
+ * @return {Object} Object containing the current `width` and `height` of the document.
  *
  * @example <caption>Sets the document size to 70 x 100 units</caption>
  * size(70, 100);
@@ -486,13 +486,13 @@ pub.layer = function(layer) {
 
 
 /**
- * @description Arranges a page item or a layer before or behind other page items or layers. If using the constants <code>FORWARD</code> or <code>BACKWARD</code> the object is sent forward or back one step. The constants <code>FRONT</code> or <code>BACK</code> send the object to the very front or very back. Using <code>FRONT</code> or <code>BACK</code> together with the optional reference object, sends the object in front or behind this reference object.
+ * @description Arranges a page item or a layer before or behind other page items or layers. If using the constants `FORWARD` or `BACKWARD` the object is sent forward or back one step. The constants `FRONT` or `BACK` send the object to the very front or very back. Using `FRONT` or `BACK` together with the optional reference object, sends the object in front or behind this reference object.
  *
  * @cat    Document
  * @subcat Page
  * @method arrange
  * @param  {PageItem|Layer} pItemOrLayer The page item or layer to be moved to a new position.
- * @param  {String} positionOrDirection The position or direction to move the page item or layer. Can be <code>FRONT</code>, <code>BACK</code>, <code>FORWARD</code> or <code>BACKWARD</code>.
+ * @param  {String} positionOrDirection The position or direction to move the page item or layer. Can be `FRONT`, `BACK`, `FORWARD` or `BACKWARD`.
  * @param  {PageItem|Layer} [reference] A reference object to move the page item or layer behind or in front of.
  * @return {PageItem|Layer} The newly arranged page item or layer.
  */
@@ -641,7 +641,7 @@ pub.labels = function(label, cb) {
 
 
 /**
- * @description Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of <code>labels()</code>, when you know you just have one thing with that label and don't want to deal with a single-element array.
+ * @description Returns the first item that is tagged with the given label in the InDesign Script Label pane (Window -> Utilities -> Script Label). Use this instead of `labels()`, when you know you just have one thing with that label and don't want to deal with a single-element array.
  *
  * @cat    Document
  * @subcat Multi-Getters
@@ -882,22 +882,22 @@ pub.bleeds = function(top, right, bottom, left) {
 
 /**
  * @description Inspects a given object or any other data item and prints the result to the console. This is useful for inspecting or debugging any kind of variable or data item. The optional settings object allows to control the function's output. The following parameters can be set in the settings object:<br>
- * <code>showProps</code>: Show or hide properties. Default: <code>true</code><br>
- * <code>showValues</code>: Show or hide values. Default: <code>true</code><br>
- * <code>showMethods</code>: Show or hide methods. Default: <code>false</code><br>
- * <code>maxLevel</code>: Chooses how many levels of properties should be inspected recursively. Default: <code>1</code><br>
- * <code>propList</code>: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: <code>[]</code> (no propList)<br>
+ * `showProps`: Show or hide properties. Default: `true`<br>
+ * `showValues`: Show or hide values. Default: `true`<br>
+ * `showMethods`: Show or hide methods. Default: `false`<br>
+ * `maxLevel`: Chooses how many levels of properties should be inspected recursively. Default: `1`<br>
+ * `propList`: Allows to pass an array of property names to show. If propList is not set all properties will be shown. Default: `[]` (no propList)<br>
  * If no settings object is set, the default values will be used.
  *
  * @cat    Output
  * @method inspect
  * @param  {Object} obj An object or any other data item to be inspected.
  * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {Boolean} [settings.showProps] Show or hide properties. Default: <code>true</code>
- * @param  {Boolean} [settings.showValues] Show or hide values. Default: <code>true</code>
- * @param  {Boolean} [settings.showMethods] Show or hide methods. Default: <code>false</code>
- * @param  {Number} [settings.maxLevel] How many levels of properties should be inspected recursively. Default: <code>1</code>
- * @param  {Array} [settings.propList] Array of properties to show. Default: <code>[]</code> (no propList)
+ * @param  {Boolean} [settings.showProps] Show or hide properties. Default: `true`
+ * @param  {Boolean} [settings.showValues] Show or hide values. Default: `true`
+ * @param  {Boolean} [settings.showMethods] Show or hide methods. Default: `false`
+ * @param  {Number} [settings.maxLevel] How many levels of properties should be inspected recursively. Default: `1`
+ * @param  {Array} [settings.propList] Array of properties to show. Default: `[]` (no propList)
  *
  * @example <caption>Inspecting a string</caption>
  * inspect("foo");
@@ -1162,9 +1162,9 @@ pub.folder = function(folderPath) {
  * @method files
  * @param  {Folder|String} [folder] The folder that holds the files or a string describing the path to that folder.
  * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String|Array} [settings.filter] Suffix(es) of file types to include. Default: <code>"*"</code> (include all file types)
- * @param  {Boolean} [settings.hidden] Hidden files will be included. Default: <code>false</code>
- * @param  {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: <code>false</code>
+ * @param  {String|Array} [settings.filter] Suffix(es) of file types to include. Default: `"*"` (include all file types)
+ * @param  {Boolean} [settings.hidden] Hidden files will be included. Default: `false`
+ * @param  {Boolean} [settings.recursive] Searches subfolders recursively for matching files. Default: `false`
  * @return {Array} Array of the resulting file(s). If no files are found, an empty array will be returned.
  *
  * @example <caption>Get a folder from the desktop and load all its JPEG files</caption>
@@ -1240,10 +1240,10 @@ pub.files = function(folder, settings, collectedFiles) {
  * @cat    Files
  * @method selectFile
  * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
- * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
+ * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
+ * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
  * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {File|Null} The selected file. If the user cancels, <code>null</code> will be returned.
+ * @return {File|Null} The selected file. If the user cancels, `null` will be returned.
  *
  * @example <caption>Open file selection dialog with a prompt text</caption>
  * selectFile({prompt: "Please select a file."});
@@ -1261,8 +1261,8 @@ pub.selectFile = function(settings) {
  * @cat    Files
  * @method selectFiles
  * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: <code>""</code> (no prompt)
- * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: <code>""</code> (include all)
+ * @param  {String} [settings.prompt] The prompt text at the top of the file selection dialog. Default: `""` (no prompt)
+ * @param  {String|Array} [settings.filter] String or an array containing strings of file endings to include in the dialog. Default: `""` (include all)
  * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
  * @return {Array} Array of the selected file(s). If the user cancels, an empty array will be returned.
  *
@@ -1287,9 +1287,9 @@ pub.selectFiles = function(settings) {
  * @cat    Files
  * @method selectFolder
  * @param  {Object} [settings] A settings object to control the function's behavior.
- * @param  {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: <code>""</code> (no prompt)
+ * @param  {String} [settings.prompt] The prompt text at the top of the folder selection dialog. Default: `""` (no prompt)
  * @param  {Folder|String} [settings.folder] Folder or a folder path string defining the start location of the dialog. Default: most recent dialog folder or main user folder.
- * @return {Folder|Null} The selected folder. If the user cancels, <code>null</code> will be returned.
+ * @return {Folder|Null} The selected folder. If the user cancels, `null` will be returned.
  *
  * @example <caption>Open folder selection dialog with a prompt text</caption>
  * selectFolder({prompt: "Please select a folder."});

--- a/src/includes/global-functions.js
+++ b/src/includes/global-functions.js
@@ -68,7 +68,7 @@ if (!Array.prototype.map) {
 }
 
 /**
-* @description Used to run a function on all elements of an array. Please note the existance of the convenience methods <code>stories()</code>, <code>paragraphs()</code>, <code>lines()</code>, <code>words()</code> and <code>characters()</code> that are used to iterate through all instances of the given type in the given document.
+* @description Used to run a function on all elements of an array. Please note the existance of the convenience methods `stories()`, `paragraphs()`, `lines()`, `words()` and `characters()` that are used to iterate through all instances of the given type in the given document.
 *
 * @cat    Data
 * @subcat Array

--- a/src/includes/global-functions.js
+++ b/src/includes/global-functions.js
@@ -68,14 +68,21 @@ if (!Array.prototype.map) {
 }
 
 /**
-* @description Used to run a function on all elements of an array. Please note the existance of the convenience methods `stories()`, `paragraphs()`, `lines()`, `words()` and `characters()` that are used to iterate through all instances of the given type in the given document.
-*
-* @cat    Data
-* @subcat Array
-* @method Array.forEach
-* @param  {Array} collection The array to be processed.
-* @param  {Function} cb The function that will be called on each element. The call will be like function(item,i) where i is the current index of the item within the array.
-*/
+ * @description Used to run a function on all elements of an array. Please note
+ *          the existance of the convenience methods `stories()`,
+ *          `paragraphs()`, `lines()`, `words()` and `characters()` that are
+ *          used to iterate through all instances of the given type in the given
+ *          document.
+ *
+ * @cat     Data
+ * @subcat  Array
+ * @method  Array.forEach
+ *
+ * @param   {Array} collection The array to be processed.
+ * @param   {Function} cb The function that will be called on each element. The
+ *          call will be like function(item,i) where i is the current index of
+ *          the item within the array.
+ */
 forEach = function(collection, cb) {
   for (var i = 0, len = collection.length; i < len; i++) {
 
@@ -92,12 +99,15 @@ forEach = function(collection, cb) {
 };
 
 /**
- * @description HashList is a data container that allows you to store information as key - value pairs. As usual in JavaScript mixed types of keys and values are accepted in one HashList instance.
+ * @description HashList is a data container that allows you to store
+ *          information as key - value pairs. As usual in JavaScript mixed types
+ *          of keys and values are accepted in one HashList instance.
  *
- * @cat    Data
- * @subcat HashList
- * @method HashList
- * @constructor
+ * @cat     Data
+ * @subcat  HashList
+ * @method  HashList
+ *
+ * @class
  */
 // taken from http://pbrajkumar.wordpress.com/2011/01/17/hashmap-in-javascript/
 HashList = function () {
@@ -117,14 +127,14 @@ HashList = function () {
   }
 
   /**
-   *
    * @description This removes a key - value pair by its key.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.remove
-   * @param  {String} key The key to delete.
-   * @return {Object} The value before deletion.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.remove
+   *
+   * @param   {String} key The key to delete.
+   * @return  {Object} The value before deletion.
    */
   that.remove = function(key) {
     var tmp_previous;
@@ -139,25 +149,29 @@ HashList = function () {
   /**
    * @description This gets a value by its key.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.get
-   * @param  {String} key The key to look for.
-   * @return {Object} The value.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.get
+   *
+   * @param   {String} key The key to look for.
+   * @return  {Object} The value.
    */
   that.get = function(key) {
     return that.items[key];
   };
 
   /**
-   * @description This sets a key - value pair. If a key is already existing, the value will be updated. Please note that Functions are currently not supported as values.
+   * @description This sets a key - value pair. If a key is already existing,
+   *          the value will be updated. Please note that Functions are
+   *          currently not supported as values.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.set
-   * @param  {String} key The key to use.
-   * @param  {Object|String|Number|Boolean} value The value to set.
-   * @return {Object} The value after setting.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.set
+   *
+   * @param   {String} key The key to use.
+   * @param   {Object|String|Number|Boolean} value The value to set.
+   * @return  {Object} The value after setting.
    */
   that.set = function(key, value) {
 
@@ -175,11 +189,12 @@ HashList = function () {
   /**
    * @description Checks for the existence of a given key.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.hasKey
-   * @param  {String} key The key to check.
-   * @return {Boolean} Returns true or false.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.hasKey
+   *
+   * @param   {String} key The key to check.
+   * @return  {Boolean} Returns true or false.
    */
   that.hasKey = function(key) {
     checkKey(key);
@@ -187,13 +202,15 @@ HashList = function () {
   };
 
   /**
-   * @description Checks if a certain value exists at least once in all of the key - value pairs.
+   * @description Checks if a certain value exists at least once in all of the
+   *          key - value pairs.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.hasValue
-   * @param  {Object|String|Number|Boolean} value The value to check.
-   * @return {Boolean} Returns true or false.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.hasValue
+   *
+   * @param   {Object|String|Number|Boolean} value The value to check.
+   * @return  {Boolean} Returns true or false.
    */
   that.hasValue = function(value) {
     var obj = that.items;
@@ -208,12 +225,15 @@ HashList = function () {
   };
 
   /**
-   * @description Returns an array of all keys that are sorted by their values from highest to lowest. Please note that this only works if you have conistently used Numbers for values.
+   * @description Returns an array of all keys that are sorted by their values
+   *          from highest to lowest. Please note that this only works if you
+   *          have conistently used Numbers for values.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getKeysByValues
-   * @return {Array} An array with all the keys.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.getKeysByValues
+   *
+   * @return  {Array} An array with all the keys.
    */
   that.getKeysByValues = function() {
     var obj = that.items;
@@ -227,12 +247,14 @@ HashList = function () {
   };
 
   /**
-   * @description Returns an array with all keys in a sorted order from higher to lower magnitude.
+   * @description Returns an array with all keys in a sorted order from higher
+   *          to lower magnitude.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getSortedKeys
-   * @return {Array} An array with all the keys sorted.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.getSortedKeys
+   *
+   * @return  {Array} An array with all the keys sorted.
    */
   that.getSortedKeys = function () {
     return that.getKeys().sort(); // ["a", "b", "z"]
@@ -241,10 +263,11 @@ HashList = function () {
   /**
    * @description Returns an array with all keys.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getKeys
-   * @return {Array} An array with all the keys.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.getKeys
+   *
+   * @return  {Array} An array with all the keys.
    */
   that.getKeys = function () {
     var keys = [];
@@ -262,10 +285,11 @@ HashList = function () {
   /**
    * @description Returns an array with all values.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.getValues
-   * @return {Array} An array with all the values.
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.getValues
+   *
+   * @return  {Array} An array with all the values.
    */
   that.getValues = function () {
 
@@ -282,9 +306,9 @@ HashList = function () {
   /**
    * @description Deletes all the key - value pairs in this HashList.
    *
-   * @cat    Data
-   * @subcat HashList
-   * @method HashList.clear
+   * @cat     Data
+   * @subcat  HashList
+   * @method  HashList.clear
    */
   that.clear = function() {
     for (var i in that.items) {

--- a/src/includes/global-functions.js
+++ b/src/includes/global-functions.js
@@ -4,7 +4,8 @@
 
 /**
  * @description The <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/filter">filter()</a> method creates a new array with all elements that pass the test implemented by the provided function.
- * @cat Data
+ *
+ * @cat    Data
  * @subcat Array
  * @method Array.filter
  * @param  {Function} callback The Function is a predicate, to test each element of the array. Return true to keep the element, false otherwise.
@@ -30,7 +31,8 @@ if (!Array.prototype.filter) {
 
 /**
  * @description The <a href="https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array/map">map()</a> method creates a new array with the results of calling a provided function on every element in this array.
- * @cat Data
+ *
+ * @cat    Data
  * @subcat Array
  * @method Array.map
  * @param  {Function} callback Function that produces an element of the new Array.
@@ -66,13 +68,13 @@ if (!Array.prototype.map) {
 }
 
 /**
-* Used to run a function on all elements of an array. Please note the existance of the convenience methods <code>stories()</code>, <code>paragraphs()</code>, <code>lines()</code>, <code>words()</code> and <code>characters()</code> that are used to iterate through all instances of the given type in the given document.
+* @description Used to run a function on all elements of an array. Please note the existance of the convenience methods <code>stories()</code>, <code>paragraphs()</code>, <code>lines()</code>, <code>words()</code> and <code>characters()</code> that are used to iterate through all instances of the given type in the given document.
 *
-* @cat Data
+* @cat    Data
 * @subcat Array
 * @method Array.forEach
-* @param {Array} collection The array to be processed.
-* @param {Function} cb The function that will be called on each element. The call will be like function(item,i) where i is the current index of the item within the array.
+* @param  {Array} collection The array to be processed.
+* @param  {Function} cb The function that will be called on each element. The call will be like function(item,i) where i is the current index of the item within the array.
 */
 forEach = function(collection, cb) {
   for (var i = 0, len = collection.length; i < len; i++) {
@@ -90,12 +92,12 @@ forEach = function(collection, cb) {
 };
 
 /**
- * HashList is a data container that allows you to store information as key - value pairs. As usual in JavaScript mixed types of keys and values are accepted in one HashList instance.
+ * @description HashList is a data container that allows you to store information as key - value pairs. As usual in JavaScript mixed types of keys and values are accepted in one HashList instance.
  *
- * @constructor
- * @cat Data
+ * @cat    Data
  * @subcat HashList
  * @method HashList
+ * @constructor
  */
 // taken from http://pbrajkumar.wordpress.com/2011/01/17/hashmap-in-javascript/
 HashList = function () {
@@ -116,12 +118,12 @@ HashList = function () {
 
   /**
    *
-   * This removes a key - value pair by its key.
+   * @description This removes a key - value pair by its key.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.remove
-   * @param {String} key The key to delete.
+   * @param  {String} key The key to delete.
    * @return {Object} The value before deletion.
    */
   that.remove = function(key) {
@@ -135,12 +137,12 @@ HashList = function () {
   };
 
   /**
-   * This gets a value by its key.
+   * @description This gets a value by its key.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.get
-   * @param {String} key The key to look for.
+   * @param  {String} key The key to look for.
    * @return {Object} The value.
    */
   that.get = function(key) {
@@ -148,13 +150,13 @@ HashList = function () {
   };
 
   /**
-   * This sets a key - value pair. If a key is already existing, the value will be updated. Please note that Functions are currently not supported as values.
+   * @description This sets a key - value pair. If a key is already existing, the value will be updated. Please note that Functions are currently not supported as values.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.set
-   * @param {String} key The key to use.
-   * @param {Object|String|Number|Boolean} value The value to set.
+   * @param  {String} key The key to use.
+   * @param  {Object|String|Number|Boolean} value The value to set.
    * @return {Object} The value after setting.
    */
   that.set = function(key, value) {
@@ -171,12 +173,12 @@ HashList = function () {
   };
 
   /**
-   * Checks for the existence of a given key.
+   * @description Checks for the existence of a given key.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.hasKey
-   * @param {String} key The key to check.
+   * @param  {String} key The key to check.
    * @return {Boolean} Returns true or false.
    */
   that.hasKey = function(key) {
@@ -185,12 +187,12 @@ HashList = function () {
   };
 
   /**
-   * Checks if a certain value exists at least once in all of the key - value pairs.
+   * @description Checks if a certain value exists at least once in all of the key - value pairs.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.hasValue
-   * @param {Object|String|Number|Boolean} value The value to check.
+   * @param  {Object|String|Number|Boolean} value The value to check.
    * @return {Boolean} Returns true or false.
    */
   that.hasValue = function(value) {
@@ -206,9 +208,9 @@ HashList = function () {
   };
 
   /**
-   * Returns an array of all keys that are sorted by their values from highest to lowest. Please note that this only works if you have conistently used Numbers for values.
+   * @description Returns an array of all keys that are sorted by their values from highest to lowest. Please note that this only works if you have conistently used Numbers for values.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.getKeysByValues
    * @return {Array} An array with all the keys.
@@ -225,9 +227,9 @@ HashList = function () {
   };
 
   /**
-   * Returns an array with all keys in a sorted order from higher to lower magnitude.
+   * @description Returns an array with all keys in a sorted order from higher to lower magnitude.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.getSortedKeys
    * @return {Array} An array with all the keys sorted.
@@ -237,9 +239,9 @@ HashList = function () {
   };
 
   /**
-   * Returns an array with all keys.
+   * @description Returns an array with all keys.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.getKeys
    * @return {Array} An array with all the keys.
@@ -258,9 +260,9 @@ HashList = function () {
   };
 
   /**
-   * Returns an array with all values.
+   * @description Returns an array with all values.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.getValues
    * @return {Array} An array with all the values.
@@ -278,9 +280,9 @@ HashList = function () {
   };
 
   /**
-   * Deletes all the key - value pairs in this HashList.
+   * @description Deletes all the key - value pairs in this HashList.
    *
-   * @cat Data
+   * @cat    Data
    * @subcat HashList
    * @method HashList.clear
    */

--- a/src/includes/image.js
+++ b/src/includes/image.js
@@ -3,14 +3,14 @@
 // ----------------------------------------
 
 /**
- * Adds an image to the document. If the image argument is given as a string the image file must be in the document's
+ * @description Adds an image to the document. If the image argument is given as a string the image file must be in the document's
  * data directory which is in the same directory where the document is saved in. The image argument can also be a File
  * instance which can be placed even before the document was saved.
  * The second argument can either be the x position of the frame to create or an instance of a rectangle,
  * oval or polygon to place the image in. If an x position is given, a y position must be given, too.
  * If x and y positions are given and width and height are not given, the frame's size gets set to the original image size.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Image
  * @method image
  * @param  {String|File} img The image file name in the document's data directory or a File instance.
@@ -100,13 +100,13 @@ pub.image = function(img, x, y, w, h) {
 };
 
 /**
- * Modifies the location from which images draw. The default mode is imageMode(CORNER), which specifies the location to be the upper left corner and uses the fourth and fifth parameters of image() to set the image's width and height. The syntax imageMode(CORNERS) uses the second and third parameters of image() to set the location of one corner of the image and uses the fourth and fifth parameters to set the opposite corner. Use imageMode(CENTER) to draw images centered at the given x and y position.
+ * @description Modifies the location from which images draw. The default mode is imageMode(CORNER), which specifies the location to be the upper left corner and uses the fourth and fifth parameters of image() to set the image's width and height. The syntax imageMode(CORNERS) uses the second and third parameters of image() to set the location of one corner of the image and uses the fourth and fifth parameters to set the opposite corner. Use imageMode(CENTER) to draw images centered at the given x and y position.
  * If no parameter is passed the currently set mode is returned as String.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Image
  * @method imageMode
- * @param {String} [mode] Either CORNER, CORNERS, or CENTER.
+ * @param  {String} [mode] Either CORNER, CORNERS, or CENTER.
  * @return {String} The current mode.
  */
 pub.imageMode = function(mode) {

--- a/src/includes/image.js
+++ b/src/includes/image.js
@@ -3,22 +3,32 @@
 // ----------------------------------------
 
 /**
- * @description Adds an image to the document. If the image argument is given as a string the image file must be in the document's
- * data directory which is in the same directory where the document is saved in. The image argument can also be a File
- * instance which can be placed even before the document was saved.
- * The second argument can either be the x position of the frame to create or an instance of a rectangle,
- * oval or polygon to place the image in. If an x position is given, a y position must be given, too.
- * If x and y positions are given and width and height are not given, the frame's size gets set to the original image size.
+ * @description Adds an image to the document. If the image argument is given as
+ *          a string the image file must be in the document's data directory
+ *          which is in the same directory where the document is saved in. The
+ *          image argument can also be a File instance which can be placed even
+ *          before the document was saved. The second argument can either be the
+ *          x position of the frame to create or an instance of a rectangle,
+ *          oval or polygon to place the image in. If an x position is given, a
+ *          y position must be given, too. If x and y positions are given and
+ *          width and height are not given, the frame's size gets set to the
+ *          original image size.
  *
- * @cat    Document
- * @subcat Image
- * @method image
- * @param  {String|File} img The image file name in the document's data directory or a File instance.
- * @param  {Number|Rectangle|Oval|Polygon} x The x position on the current page or the item instance to place the image in.
- * @param  {Number} [y] The y position on the current page. Ignored if x is not a number.
- * @param  {Number} [w] The width of the rectangle to add the image to. Ignored if x is not a number.
- * @param  {Number} [h] The height of the rectangle to add the image to. Ignored if x is not a number.
- * @return {Rectangle|Oval|Polygon} The item instance the image was placed in.
+ * @cat     Document
+ * @subcat  Image
+ * @method  image
+ *
+ * @param   {String|File} img The image file name in the document's data
+ *          directory or a File instance.
+ * @param   {Number|Rectangle|Oval|Polygon} x The x position on the current page
+ *          or the item instance to place the image in.
+ * @param   {Number} [y] The y position on the current page. Ignored if x is not
+ *          a number.
+ * @param   {Number} [w] The width of the rectangle to add the image to. Ignored
+ *          if x is not a number.
+ * @param   {Number} [h] The height of the rectangle to add the image to.
+ *          Ignored if x is not a number.
+ * @return  {Rectangle|Oval|Polygon} The item instance the image was placed in.
  */
 pub.image = function(img, x, y, w, h) {
   var file = initDataFile(img),
@@ -100,14 +110,22 @@ pub.image = function(img, x, y, w, h) {
 };
 
 /**
- * @description Modifies the location from which images draw. The default mode is imageMode(CORNER), which specifies the location to be the upper left corner and uses the fourth and fifth parameters of image() to set the image's width and height. The syntax imageMode(CORNERS) uses the second and third parameters of image() to set the location of one corner of the image and uses the fourth and fifth parameters to set the opposite corner. Use imageMode(CENTER) to draw images centered at the given x and y position.
- * If no parameter is passed the currently set mode is returned as String.
+ * @description Modifies the location from which images draw. The default mode
+ *          is `CORNER`, which specifies the location to be the upper left
+ *          corner and uses the fourth and fifth parameters of `image()` to set
+ *          the image's width and height. The syntax `imageMode(CORNERS)` uses
+ *          the second and third parameters of `image()` to set the location of
+ *          one corner of the image and uses the fourth and fifth parameters to
+ *          set the opposite corner. Use `imageMode(CENTER)` to draw images
+ *          centered at the given `x` and `y` position. If no parameter is
+ *          passed the currently set mode is returned as String.
  *
- * @cat    Document
- * @subcat Image
- * @method imageMode
- * @param  {String} [mode] Either CORNER, CORNERS, or CENTER.
- * @return {String} The current mode.
+ * @cat     Document
+ * @subcat  Image
+ * @method  imageMode
+ *
+ * @param   {String} [mode] Either CORNER, CORNERS, or CENTER.
+ * @return  {String} The current mode.
  */
 pub.imageMode = function(mode) {
   if (arguments.length === 0) return currImageMode;

--- a/src/includes/math.js
+++ b/src/includes/math.js
@@ -5,17 +5,32 @@
 var Vector = pub.Vector = function() {
 
   /**
-   * @description A class to describe a two or three dimensional vector. This datatype stores two or three variables that are commonly used as a position, velocity, and/or acceleration. Technically, position is a point and velocity and acceleration are vectors, but this is often simplified to consider all three as vectors. For example, if you consider a rectangle moving across the screen, at any given instant it has a position (the object's location, expressed as a point.), a velocity (the rate at which the object's position changes per time unit, expressed as a vector), and acceleration (the rate at which the object's velocity changes per time unit, expressed as a vector). Since vectors represent groupings of values, we cannot simply use traditional addition/multiplication/etc. Instead, we'll need to do some "vector" math, which is made easy by the methods inside the Vector class.
-   * <br><br>
-   * Constructor of Vector, can be two- or three-dimensional.
+   * @description A class to describe a two or three dimensional vector. This
+   *          data type stores two or three variables that are commonly used as
+   *          a position, velocity, and/or acceleration. Technically, position
+   *          is a point and velocity and acceleration are vectors, but this is
+   *          often simplified to consider all three as vectors. For example, if
+   *          you consider a rectangle moving across the screen, at any given
+   *          instant it has a position (the object's location, expressed as a
+   *          point.), a velocity (the rate at which the object's position
+   *          changes per time unit, expressed as a vector), and acceleration
+   *          (the rate at which the object's velocity changes per time unit,
+   *          expressed as a vector). Since vectors represent groupings of
+   *          values, we cannot simply use traditional
+   *          addition/multiplication/etc. Instead, we'll need to do some
+   *          "vector" math, which is made easy by the methods inside the Vector
+   *          class.
+   *          <br><br>
+   *          Constructor of Vector, can be two- or three-dimensional.
    *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector
-   * @param  {Number} x The first vector.
-   * @param  {Number} y The second vector.
-   * @param  {Number} [z] The third vector.
-   * @constructor
+   * @cat     Math
+   * @subcat  Vector
+   * @method  Vector
+   *
+   * @param   {Number} x The first vector.
+   * @param   {Number} y The second vector.
+   * @param   {Number} [z] The third vector.
+   * @class
    */
   function Vector(x, y, z) {
     this.x = x || 0;
@@ -23,15 +38,17 @@ var Vector = pub.Vector = function() {
     this.z = z || 0;
   }
   /**
-   * @description Static function. Calculates the Euclidean distance between two points (considering a point as a vector object).
-   * Is meant to be called "static" i.e. Vector.dist(v1, v2);
+   * @description Static function. Calculates the Euclidean distance between two
+   *          points (considering a point as a vector object). Is meant to be
+   *          called "static" i.e. `Vector.dist(v1, v2);`
    *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.dist
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The distance.
+   * @cat     Math
+   * @subcat  Vector
+   * @method  Vector.dist
+   *
+   * @param   {Vector} v1 The first vector.
+   * @param   {Vector} v2 The second vector.
+   * @return  {Number} The distance.
    * @static
    */
   Vector.dist = function(v1, v2) {
@@ -39,15 +56,16 @@ var Vector = pub.Vector = function() {
   };
 
   /**
-   * @description Static function. Calculates the dot product of two vectors.
-   * Is meant to be called "static" i.e. Vector.dot(v1, v2);
+   * @description Static function. Calculates the dot product of two vectors. Is
+   *          meant to be called "static" i.e. `Vector.dot(v1, v2);`
    *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.dot
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The dot product.
+   * @cat     Math
+   * @subcat  Vector
+   * @method  Vector.dot
+   *
+   * @param   {Vector} v1 The first vector.
+   * @param   {Vector} v2 The second vector.
+   * @return  {Number} The dot product.
    * @static
    */
   Vector.dot = function(v1, v2) {
@@ -56,14 +74,15 @@ var Vector = pub.Vector = function() {
 
   /**
    * @description Static function. Calculates the cross product of two vectors.
-   * Is meant to be called "static" i.e. Vector.cross(v1, v2);
+   *          Is meant to be called "static" i.e. `Vector.cross(v1, v2);`
    *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.cross
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The cross product.
+   * @cat     Math
+   * @subcat  Vector
+   * @method  Vector.cross
+   *
+   * @param   {Vector} v1 The first vector.
+   * @param   {Vector} v2 The second vector.
+   * @return  {Number} The cross product.
    * @static
    */
   Vector.cross = function(v1, v2) {
@@ -71,15 +90,16 @@ var Vector = pub.Vector = function() {
   };
 
   /**
-   * @description Static function. Calculates the angle between two vectors.
-   * Is meant to be called "static" i.e. Vector.angleBetween(v1, v2);
+   * @description Static function. Calculates the angle between two vectors. Is
+   *          meant to be called "static" i.e. `Vector.angleBetween(v1, v2);`
    *
-   * @cat    Math
-   * @subcat Vector
-   * @method Vector.angleBetween
-   * @param  {Vector} v1 The first vector.
-   * @param  {Vector} v2 The second vector.
-   * @return {Number} The angle.
+   * @cat     Math
+   * @subcat  Vector
+   * @method  Vector.angleBetween
+   *
+   * @param   {Vector} v1 The first vector.
+   * @param   {Vector} v2 The second vector.
+   * @return  {Number} The angle.
    * @static
    */
   Vector.angleBetween = function(v1, v2) {
@@ -89,14 +109,17 @@ var Vector = pub.Vector = function() {
   Vector.prototype = {
 
     /**
-     * @description Sets the x, y, and z component of the vector using three separate variables, the data from a Vector, or the values from a float array.
+     * @description Sets the `x`, `y`, and `z` component of the vector using
+     *          three separate variables, the data from a Vector, or the values
+     *          from a float array.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.set
-     * @param  {Number|Array|Vector} v Either a vector, array or x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.set
+     *
+     * @param   {Number|Array|Vector} v Either a vector, array or `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
      */
     set: function(v, y, z) {
       if (arguments.length === 1) this.set(v.x || v[0] || 0, v.y || v[1] || 0, v.z || v[2] || 0);
@@ -109,21 +132,24 @@ var Vector = pub.Vector = function() {
     /**
      * @description Gets a copy of the vector, returns a Vector object.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.get
-     * @return {Vector} A copy of the vector.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.get
+     *
+     * @return  {Vector} A copy of the vector.
      */
     get: function() {
       return new Vector(this.x, this.y, this.z);
     },
     /**
-     * @description Calculates the magnitude (length) of the vector and returns the result as a float
+     * @description Calculates the magnitude (length) of the vector and returns
+     *          the result as a float
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.mag
-     * @return {Number} The length.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.mag
+     *
+     * @return  {Number} The length.
      */
     mag: function() {
       var x = this.x,
@@ -132,14 +158,16 @@ var Vector = pub.Vector = function() {
       return Math.sqrt(x * x + y * y + z * z);
     },
     /**
-     * @description Adds x, y, and z components to a vector, adds one vector to another.
+     * @description Adds `x`, `y`, and `z` components to a vector, adds one
+     *          vector to another.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.add
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.add
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
      */
     add: function(v, y, z) {
       if (arguments.length === 1) {
@@ -153,14 +181,16 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * @description Substract x, y, and z components or a full vector from this vector
+     * @description Substract `x`, `y`, and `z` components or a full vector from
+     *          this vector
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.sub
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.sub
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
      */
     sub: function(v, y, z) {
       if (arguments.length === 1) {
@@ -174,14 +204,16 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * @description Multiplies this vector with x, y, and z components or another vector.
+     * @description Multiplies this vector with `x`, `y`, and `z` components or
+     *          another vector.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.mult
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.mult
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
      */
     mult: function(v) {
       if (typeof v === "number") {
@@ -195,14 +227,16 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * @description Divides this vector through x, y, and z components or another vector.
+     * @description Divides this vector through `x`, `y`, and `z` components or
+     *          another vector.`
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.div
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.div
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
      */
     div: function(v) {
       if (typeof v === "number") {
@@ -216,15 +250,17 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * @description Calculates the distance from this vector to another as x, y, and z components or full vector.
+     * @description Calculates the distance from this vector to another as `x`,
+     *          `y`, and `z` components or full vector.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.dist
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     * @return {Number} The distance.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.dist
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
+     * @return  {Number} The distance.
      */
     dist: function(v) {
       var dx = this.x - v.x,
@@ -233,30 +269,34 @@ var Vector = pub.Vector = function() {
       return Math.sqrt(dx * dx + dy * dy + dz * dz);
     },
     /**
-     * @description Calculates the dot product from this vector to another as x, y, and z components or full vector.
+     * @description Calculates the dot product from this vector to another as
+     *          `x`, `y`, and `z` components or full vector.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.dot
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     * @return {Number} The dot product.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.dot
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
+     * @return  {Number} The dot product.
      */
     dot: function(v, y, z) {
       if (arguments.length === 1) return this.x * v.x + this.y * v.y + this.z * v.z;
       return this.x * v + this.y * y + this.z * z;
     },
     /**
-     * @description Calculates the cross product from this vector to another as x, y, and z components or full vector.
+     * @description Calculates the cross product from this vector to another as
+     *          `x`, `y`, and `z` components or full vector.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.cross
-     * @param  {Vector|Number} v Either a full vector or an x component.
-     * @param  {Number} [y] The y component.
-     * @param  {Number} [z] The z component.
-     * @return {Number} The cross product.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.cross
+     *
+     * @param   {Vector|Number} v Either a full vector or an `x` component.
+     * @param   {Number} [y] The `y` component.
+     * @param   {Number} [z] The `z` component.
+     * @return  {Number} The cross product.
      */
     cross: function(v) {
       var x = this.x,
@@ -267,9 +307,9 @@ var Vector = pub.Vector = function() {
     /**
      * @description Normalizes the length of this vector to 1.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.normalize
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.normalize
      */
     normalize: function() {
       var m = this.mag();
@@ -278,10 +318,11 @@ var Vector = pub.Vector = function() {
     /**
      * @description Normalizes the length of this vector to the given parameter.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.limit
-     * @param  {Number} high The value to scale to.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.limit
+     *
+     * @param   {Number} high The value to scale to.
      */
     limit: function(high) {
       if (this.mag() > high) {
@@ -292,10 +333,11 @@ var Vector = pub.Vector = function() {
     /**
      * @description The 2D orientation (heading) of this vector in radian.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.heading
-     * @return {Number} A radian angle value.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.heading
+     *
+     * @return  {Number} A radian angle value.
      */
     heading: function() {
       return -Math.atan2(-this.y, this.x);
@@ -303,21 +345,24 @@ var Vector = pub.Vector = function() {
     /**
      * @description Returns data about this vector as a string.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.toString
-     * @return {String} The x, y and z components as a string.
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.toString
+     *
+     * @return  {String} The `x`, `y` and `z` components as a string.
      */
     toString: function() {
       return "[" + this.x + ", " + this.y + ", " + this.z + "]";
     },
     /**
-     * @description Returns this vector as an array [x,y,z].
+     * @description Returns this vector as an array `[x,y,z]`.
      *
-     * @cat    Math
-     * @subcat Vector
-     * @method Vector.array
-     * @return {Array} The x, y and z components as  an Array of [x,y,z].
+     * @cat     Math
+     * @subcat  Vector
+     * @method  Vector.array
+     *
+     * @return  {Array} The `x`, `y` and `z` components as an array of
+     *          `[x,y,z]`.
      */
     array: function() {
       return [this.x, this.y, this.z];
@@ -339,37 +384,43 @@ var Vector = pub.Vector = function() {
 // -- Calculation --
 
 /**
- * @description Calculates the absolute value (magnitude) of a number. The absolute value of a number is always positive.
+ * @description Calculates the absolute value (magnitude) of a number. The
+ *          absolute value of a number is always positive.
  *
- * @cat    Math
- * @subcat Calculation
- * @method abs
- * @param  {Number} val A number.
- * @return {Number} The absolute value of that number.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  abs
+ *
+ * @param   {Number} val A number.
+ * @return  {Number} The absolute value of that number.
  */
 pub.abs = Math.abs;
 
 /**
- * @description Calculates the closest int value that is greater than or equal to the value of the parameter. For example, ceil(9.03) returns the value 10.
+ * @description Calculates the closest integer value that is greater than or
+ *          equal to the value of the parameter. For example, `ceil(9.03)`
+ *          returns the value `10`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method ceil
- * @param  {Number} val An arbitrary number.
- * @return {Number} The next highest integer value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  ceil
+ *
+ * @param   {Number} val An arbitrary number.
+ * @return  {Number} The next highest integer value.
  */
 pub.ceil = Math.ceil;
 
 /**
  * @description Constrains a value to not exceed a maximum and minimum value.
  *
- * @cat    Math
- * @subcat Calculation
- * @method constrain
- * @param  {Number} aNumber The value to constrain.
- * @param  {Number} aMin Minimum limit.
- * @param  {Number} aMax Maximum limit.
- * @return {Number} The constrained value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  constrain
+ *
+ * @param   {Number} aNumber The value to constrain.
+ * @param   {Number} aMin Minimum limit.
+ * @param   {Number} aMax Maximum limit.
+ * @return  {Number} The constrained value.
  */
 pub.constrain = function(aNumber, aMin, aMax) {
   if(arguments.length !== 3) error("constrain(), wrong argument count.");
@@ -381,14 +432,15 @@ pub.constrain = function(aNumber, aMin, aMax) {
 /**
  * @description Calculates the distance between two points.
  *
- * @cat    Math
- * @subcat Calculation
- * @method dist
- * @param  {Number} x1 The x-coordinate of the first point.
- * @param  {Number} y1 The y-coordinate of the first point.
- * @param  {Number} x2 The x-coordinate of the second point.
- * @param  {Number} y2 The y-coordinate of the second point.
- * @return {Number} The distance.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  dist
+ *
+ * @param   {Number} x1 The x-coordinate of the first point.
+ * @param   {Number} y1 The y-coordinate of the first point.
+ * @param   {Number} x2 The x-coordinate of the second point.
+ * @param   {Number} y2 The y-coordinate of the second point.
+ * @return  {Number} The distance.
  */
 pub.dist = function() {
   var dx, dy, dz;
@@ -402,37 +454,48 @@ pub.dist = function() {
 };
 
 /**
- * @description The Math.exp() function returns ex, where x is the argument, and e is Euler's number (also known as Napier's constant), the base of the natural logarithms.
+ * @description The `exp()` function returns `ex`, where `x` is the argument,
+ *          and `e` is Euler's number (also known as Napier's constant), the
+ *          base of the natural logarithms.
  *
- * @cat    Math
- * @subcat Calculation
- * @method exp
- * @param  {Number} x A number.
- * @return {Number} A number representing ex.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  exp
+ *
+ * @param   {Number} x A number.
+ * @return  {Number} A number representing `ex`.
  */
 pub.exp = Math.exp;
 
 /**
- * @description Calculates the closest int value that is less than or equal to the value of the parameter.
+ * @description Calculates the closest integer value that is less than or equal
+ *          to the value of the parameter.
  *
- * @cat    Math
- * @subcat Calculation
- * @method floor
- * @param  {Number} a A number.
- * @return {Number} Integer number.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  floor
+ *
+ * @param   {Number} a A number.
+ * @return  {Number} Integer number.
  */
 pub.floor = Math.floor;
 
 /**
- * @description Calculates a number between two numbers at a specific increment. The amt parameter is the amount to interpolate between the two values where 0.0 equal to the first point, 0.1 is very near the first point, 0.5 is half-way in between, etc. The lerp function is convenient for creating motion along a straight path and for drawing dotted lines.
+ * @description Calculates a number between two numbers at a specific increment.
+ *          The `amt` parameter is the amount to interpolate between the two
+ *          values where `0.0` is equal to the first point, `0.1` is very near
+ *          the first point, `0.5` is half-way in between, etc. The lerp
+ *          function is convenient for creating motion along a straight path and
+ *          for drawing dotted lines.
  *
- * @cat    Math
- * @subcat Calculation
- * @method lerp
- * @param  {Number} value1 First value.
- * @param  {Number} value2 Second value.
- * @param  {Number} amt Amount between 0.0 and 1.0.
- * @return {Number} The mapped value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  lerp
+ *
+ * @param   {Number} value1 First value.
+ * @param   {Number} value2 Second value.
+ * @param   {Number} amt Amount between 0.0 and 1.0.
+ * @return  {Number} The mapped value.
  */
 pub.lerp = function(value1, value2, amt) {
   if(arguments.length !== 3) error("lerp(), wrong argument count.");
@@ -440,26 +503,34 @@ pub.lerp = function(value1, value2, amt) {
 };
 
 /**
- * @description Calculates the natural logarithm (the base-e logarithm) of a number. This function expects the values greater than 0.0.
+ * @description Calculates the natural logarithm (the base-e logarithm) of a
+ *          number. This function expects the values greater than `0`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method log
- * @param  {Number} x A number, must be greater then 0.0.
- * @return {Number} The natural logarithm.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  log
+ *
+ * @param   {Number} x A number, must be greater than `0`.
+ * @return  {Number} The natural logarithm.
  */
 pub.log = Math.log;
 
 /**
- * @description Calculates the magnitude (or length) of a vector. A vector is a direction in space commonly used in computer graphics and linear algebra. Because it has no "start" position, the magnitude of a vector can be thought of as the distance from coordinate (0,0) to its (x,y) value. Therefore, mag() is a shortcut for writing "dist(0, 0, x, y)".
+ * @description Calculates the magnitude (or length) of a vector. A vector is a
+ *          direction in space commonly used in computer graphics and linear
+ *          algebra. Because it has no "start" position, the magnitude of a
+ *          vector can be thought of as the distance from coordinate `(0,0)` to
+ *          its `(x,y)` value. Therefore, `mag()` is a shortcut for writing
+ *          `dist(0, 0, x, y)`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method mag
- * @param  {Number} x Coordinate.
- * @param  {Number} y Coordinate.
- * @param  {Number} [z] Coordinate, optional.
- * @return {Number} The magnitude.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  mag
+ *
+ * @param   {Number} x Coordinate.
+ * @param   {Number} y Coordinate.
+ * @param   {Number} [z] Coordinate, optional.
+ * @return  {Number} The magnitude.
  */
 pub.mag = function(a, b, c) {
   if(!(arguments.length === 2 || arguments.length === 3)) error("mag(), wrong argument count.");
@@ -469,17 +540,19 @@ pub.mag = function(a, b, c) {
 
 /**
  * @description Re-maps a number from one range to another.<br>
- * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
+ *          Numbers outside the range are not clamped to `0` and `1`, because
+ *          out-of-range values are often intentional and useful.
  *
- * @cat    Math
- * @subcat Calculation
- * @method map
- * @param  {Number} value The value to be mapped.
- * @param  {Number} istart The start of the input range.
- * @param  {Number} istop The end of the input range.
- * @param  {Number} ostart The start of the output range.
- * @param  {Number} ostop The end of the output range.
- * @return {Number} The mapped value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  map
+ *
+ * @param   {Number} value The value to be mapped.
+ * @param   {Number} istart The start of the input range.
+ * @param   {Number} istop The end of the input range.
+ * @param   {Number} ostart The start of the output range.
+ * @param   {Number} ostop The end of the output range.
+ * @return  {Number} The mapped value.
  */
 pub.map = function(value, istart, istop, ostart, ostop) {
   if(arguments.length !== 5) error("map(), wrong argument count. Use: map(value, istart, istop, ostart, ostop)");
@@ -489,13 +562,14 @@ pub.map = function(value, istart, istop, ostart, ostop) {
 /**
  * @description Determines the largest value in a sequence of numbers.
  *
- * @cat    Math
- * @subcat Calculation
- * @method max
- * @param  {Number|Array} a A value or an array of Numbers.
- * @param  {Number} [b] Another value to be compared.
- * @param  {Number} [c] Another value to be compared.
- * @return {Number} The highest value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  max
+ *
+ * @param   {Number|Array} a A value or an array of Numbers.
+ * @param   {Number} [b] Another value to be compared.
+ * @param   {Number} [c] Another value to be compared.
+ * @return  {Number} The highest value.
  */
 pub.max = function() {
   if (arguments.length === 2) return arguments[0] < arguments[1] ? arguments[1] : arguments[0];
@@ -510,13 +584,14 @@ pub.max = function() {
 /**
  * @description Determines the smallest value in a sequence of numbers.
  *
- * @cat    Math
- * @subcat Calculation
- * @method min
- * @param  {Number|Array} a A value or an array of Numbers.
- * @param  {Number} [b] Another value to be compared.
- * @param  {Number} [c] Another value to be compared.
- * @return {Number} The lowest value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  min
+ *
+ * @param   {Number|Array} a A value or an array of Numbers.
+ * @param   {Number} [b] Another value to be compared.
+ * @param   {Number} [c] Another value to be compared.
+ * @return  {Number} The lowest value.
  */
 pub.min = function() {
   if (arguments.length === 2) return arguments[0] < arguments[1] ? arguments[0] : arguments[1];
@@ -529,17 +604,20 @@ pub.min = function() {
 };
 
 /**
- * @description Normalizes a number from another range into a value between 0 and 1.<br>
- * Identical to map(value, low, high, 0, 1);<br>
- * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
+ * @description Normalizes a number from another range into a value between `0`
+ *          and `1`.<br>
+ *          Identical to `map(value, low, high, 0, 1);`<br>
+ *          Numbers outside the range are not clamped to `0` and `1`, because
+ *          out-of-range values are often intentional and useful.
  *
- * @cat    Math
- * @subcat Calculation
- * @method norm
- * @param  {Number} aNumber The value to be normed.
- * @param  {Number} low The lowest value to be expected.
- * @param  {Number} high The highest value to be expected.
- * @return {Number} The normalized value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  norm
+ *
+ * @param   {Number} aNumber The value to be normed.
+ * @param   {Number} low The lowest value to be expected.
+ * @param   {Number} high The highest value to be expected.
+ * @return  {Number} The normalized value.
  */
 pub.norm = function(aNumber, low, high) {
   if(arguments.length !== 3) error("norm(), wrong argument count.");
@@ -547,36 +625,46 @@ pub.norm = function(aNumber, low, high) {
 };
 
 /**
- * @description Facilitates exponential expressions. The pow() function is an efficient way of multiplying numbers by themselves (or their reciprocal) in large quantities. For example, pow(3, 5) is equivalent to the expression 3*3*3*3*3 and pow(3, -5) is equivalent to 1 / 3*3*3*3*3
+ * @description Facilitates exponential expressions. The `pow()` function is an
+ *          efficient way of multiplying numbers by themselves (or their
+ *          reciprocal) in large quantities. For example, `pow(3, 5)` is
+ *          equivalent to the expression `3 * 3 * 3 * 3 * 3` and `pow(3, -5)` is
+ *          equivalent to `1 / 3 * 3 * 3 * 3 * 3`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method pow
- * @param  {Number} num Base of the exponential expression.
- * @param  {Number} exponent Power of which to raise the base.
- * @return {Number} the result
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  pow
+ *
+ * @param   {Number} num Base of the exponential expression.
+ * @param   {Number} exponent Power of which to raise the base.
+ * @return  {Number} the result
  */
 pub.pow = Math.pow;
 
 /**
- * @description Calculates the integer closest to the value parameter. For example, round(9.2) returns the value 9.
+ * @description Calculates the integer closest to the value parameter. For
+ *          example, `round(9.2)` returns the value `9`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method round
- * @param  {Number} value The value to be rounded.
- * @return {Number} The rounded value.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  round
+ *
+ * @param   {Number} value The value to be rounded.
+ * @return  {Number} The rounded value.
  */
 pub.round = Math.round;
 
 /**
- * @description Squares a number (multiplies a number by itself). The result is always a positive number, as multiplying two negative numbers always yields a positive result. For example, -1 * -1 = 1.
+ * @description Squares a number (multiplies a number by itself). The result is
+ *          always a positive number, as multiplying two negative numbers always
+ *          yields a positive result. For example, `-1 * -1 = 1`.
  *
- * @cat    Math
- * @subcat Calculation
- * @method sq
- * @param  {Number} aNumber The value to be squared.
- * @return {Number} Squared number.
+ * @cat     Math
+ * @subcat  Calculation
+ * @method  sq
+ *
+ * @param   {Number} aNumber The value to be squared.
+ * @return  {Number} Squared number.
  */
 pub.sq = function(aNumber) {
   if(arguments.length !== 1) error("sq(), wrong argument count.");
@@ -586,117 +674,159 @@ pub.sq = function(aNumber) {
 // -- Trigonometry --
 
 /**
- * @description Calculates the square root of a number. The square root of a number is always positive, even though there may be a valid negative root. The square root s of number a is such that s*s = a. It is the opposite of squaring.
+ * @description Calculates the square root of a number. The square root of a
+ *          number is always positive, even though there may be a valid negative
+ *          root. The square root s of number a is such that `s * s = a`. It is
+ *          the opposite of squaring.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method sqrt
- * @param  {Number} val A value.
- * @return {Number} Square root.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  sqrt
+ *
+ * @param   {Number} val A value.
+ * @return  {Number} Square root.
  */
 pub.sqrt = Math.sqrt;
 
 /**
- * @description The inverse of cos(), returns the arc cosine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of `cos()`, returns the arc cosine of a value. This
+ *          function expects the values in the range of `-1` to `1` and values
+ *          are returned in the range `0` to `PI` (`3.1415927`).
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method acos
- * @param  {Number} value The value whose arc cosine is to be returned.
- * @return {Number} The arc cosine.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  acos
+ *
+ * @param   {Number} value The value whose arc cosine is to be returned.
+ * @return  {Number} The arc cosine.
  */
 pub.acos = Math.acos;
 
 /**
- * @description The inverse of sin(), returns the arc sine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of `sin()`, returns the arc sine of a value. This
+ *          function expects the values in the range of `-1` to `1` and values
+ *          are returned in the range `0` to `PI` (`3.1415927`).
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method asin
- * @param  {Number} value The value whose arc sine is to be returned.
- * @return {Number} The arc sine.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  asin
+ *
+ * @param   {Number} value The value whose arc sine is to be returned.
+ * @return  {Number} The arc sine.
  */
 pub.asin = Math.asin;
 
 /**
- * @description The inverse of tan(), returns the arc tangent of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of `tan()`, returns the arc tangent of a value. This
+ *          function expects the values in the range of `-1` to `1` and values
+ *          are returned in the range `0` to `PI` (`3.1415927`).
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method atan
- * @param  {Number} value The value whose arc tangent is to be returned.
- * @return {Number} The arc tangent.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  atan
+ *
+ * @param   {Number} value The value whose arc tangent is to be returned.
+ * @return  {Number} The arc tangent.
  */
 pub.atan = Math.atan;
 
 /**
- * @description Calculates the angle (in radians) from a specified point to the coordinate origin as measured from the positive x-axis. Values are returned as a float in the range from PI to -PI. The atan2() function is most often used for orienting geometry to the position of the cursor. Note: The y-coordinate of the point is the first parameter and the x-coordinate is the second due the the structure of calculating the tangent.
+ * @description Calculates the angle (in radians) from a specified point to the
+ *          coordinate origin as measured from the positive x-axis. Values are
+ *          returned as a float in the range from `PI` to `-PI`. The `atan2()`
+ *          function is most often used for orienting geometry to the position
+ *          of the cursor. Note: The y-coordinate of the point is the first
+ *          parameter and the x-coordinate is the second due the the structure
+ *          of calculating the tangent.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method atan2
- * @param  {Number} y The y coordinate.
- * @param  {Number} x The x coordinate.
- * @return {Number} The atan2 value.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  atan2
+ *
+ * @param   {Number} y The y coordinate.
+ * @param   {Number} x The x coordinate.
+ * @return  {Number} The atan2 value.
  */
 pub.atan2 = Math.atan2;
 
 /**
- * @description Calculates the cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range -1 to 1.
+ * @description Calculates the cosine of an angle. This function expects the
+ *          values of the angle parameter to be provided in radians (values from
+ *          `0` to `PI * 2`). Values are returned in the range `-1` to `1`.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method cos
- * @param  {Number} rad A value in radians.
- * @return {Number} The cosine.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  cos
+ *
+ * @param   {Number} rad A value in radians.
+ * @return  {Number} The cosine.
  */
 pub.cos = Math.cos;
 
 /**
- * @description Converts a radian measurement to its corresponding value in degrees. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
+ * @description Converts a radian measurement to its corresponding value in
+ *          degrees. Radians and degrees are two ways of measuring the same
+ *          thing. There are 360 degrees in a circle and `2 * PI` radians in a
+ *          circle. For example, `90° = PI / 2 = 1.5707964`. All trigonometric
+ *          methods in basil require their parameters to be specified in
+ *          radians.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method degrees
- * @param  {Number} aAngle An angle in radians.
- * @return {Number} The given angle in degree.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  degrees
+ *
+ * @param   {Number} aAngle An angle in radians.
+ * @return  {Number} The given angle in degree.
  */
 pub.degrees = function(aAngle) {
   return aAngle * 180 / Math.PI;
 };
 
 /**
- * @description Converts a degree measurement to its corresponding value in radians. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
+ * @description Converts a degree measurement to its corresponding value in
+ *          radians. Radians and degrees are two ways of measuring the same
+ *          thing. There are 360 degrees in a circle and `2 * PI` radians in a
+ *          circle. For example, `90° = PI / 2 = 1.5707964`. All trigonometric
+ *          methods in basil require their parameters to be specified in
+ *          radians.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method radians
- * @param  {Number} aAngle An angle in degree.
- * @return {Number} The given angle in radians.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  radians
+ *
+ * @param   {Number} aAngle An angle in degree.
+ * @return  {Number} The given angle in radians.
  */
 pub.radians = function(aAngle) {
   return aAngle / 180 * Math.PI;
 };
 
 /**
- * @description Calculates the sine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to 6.28). Values are returned in the range -1 to 1.
+ * @description Calculates the sine of an angle. This function expects the
+ *          values of the angle parameter to be provided in radians (values from
+ *          `0` to `6.28`). Values are returned in the range `-1` to `1`.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method sin
- * @param  {Number} rad A value in radians.
- * @return {Number} The sine value.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  sin
+ *
+ * @param   {Number} rad A value in radians.
+ * @return  {Number} The sine value.
  */
 pub.sin = Math.sin;
 
 /**
- * @description Calculates the ratio of the sine and cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range infinity to -infinity.
+ * @description Calculates the ratio of the sine and cosine of an angle. This
+ *          function expects the values of the angle parameter to be provided in
+ *          radians (values from `0` to `PI * 2`). Values are returned in the
+ *          range `infinity` to `-infinity`.
  *
- * @cat    Math
- * @subcat Trigonometry
- * @method tan
- * @param  {Number} rad A value in radians.
- * @return {Number} The tangent value.
+ * @cat     Math
+ * @subcat  Trigonometry
+ * @method  tan
+ *
+ * @param   {Number} rad A value in radians.
+ * @return  {Number} The tangent value.
  */
 pub.tan = Math.tan;
 
@@ -705,15 +835,25 @@ pub.tan = Math.tan;
 var currentRandom = Math.random;
 
 /**
- * @description Generates random numbers. Each time the random() function is called, it returns an unexpected value within the specified range. If one parameter is passed to the function it will return a float between zero and the value of the high parameter. The function call random(5) returns values between 0 and 5. If two parameters are passed, it will return a float with a value between the the parameters. The function call random(-5, 10.2) returns values between -5 and 10.2.<br>
- * One parameter sets the range from 0 to the given parameter, while with two parameters present you set the range from val1 - val2.
+ * @description Generates random numbers. Each time the `random()` function is
+ *          called, it returns an unexpected value within the specified range.
+ *          If one parameter is passed to the function it will return a float
+ *          between zero and the value of the high parameter. The function call
+ *          `random(5)` returns values between `0` and `5`. If two parameters
+ *          are passed, it will return a float with a value between the the
+ *          parameters. The function call `random(-5, 10.2)` returns values
+ *          between `-5` and `10.2`.<br>
+ *          One parameter sets the range from `0`
+ *          to the given parameter, while with two parameters present you set
+ *          the range from `val1` to `val2`.
  *
- * @cat    Math
- * @subcat Random
- * @method random
- * @param  {Number} [low] The low border of the range.
- * @param  {Number} [high] The high border of the range.
- * @return {Number} A random number.
+ * @cat     Math
+ * @subcat  Random
+ * @method  random
+ *
+ * @param   {Number} [low] The low border of the range.
+ * @param   {Number} [high] The high border of the range.
+ * @return  {Number} A random number.
  */
 pub.random = function() {
   if (arguments.length === 0) return currentRandom();
@@ -742,13 +882,16 @@ Marsaglia.createRandomized = function() {
   return new Marsaglia(now / 6E4 & 4294967295, now & 4294967295);
 };
 /**
- * @description Sets the seed value for random().<br>
- * By default, random() produces different results each time the program is run. Set the seed parameter to a constant to return the same pseudo-random numbers each time the software is run.
+ * @description Sets the seed value for `random()`.<br> By default, `random()`
+ *          produces different results each time the program is run. Set the
+ *          seed parameter to a constant to return the same pseudo-random
+ *          numbers each time the software is run.
  *
- * @cat    Math
- * @subcat Random
- * @method randomSeed
- * @param  {Number} seed The seed value.
+ * @cat     Math
+ * @subcat  Random
+ * @method  randomSeed
+ *
+ * @param   {Number} seed The seed value.
  */
 pub.randomSeed = function(seed) {
   currentRandom = (new Marsaglia(seed)).nextDouble;
@@ -756,18 +899,20 @@ pub.randomSeed = function(seed) {
 /**
  * @description Random Generator with Gaussian distribution.
  *
- * @cat    Math
- * @subcat Random
- * @method Random
- * @param  {Number} seed The seed value.
- * @constructor
+ * @cat     Math
+ * @subcat  Random
+ * @method  Random
+ *
+ * @param   {Number} seed The seed value.
+ * @class
  */
 pub.Random = function(seed) {
   var haveNextNextGaussian = false,
     nextNextGaussian, random;
   /**
-   * @method Random.nextGaussian
-   * @return {Number} The next Gaussian random value.
+   * @method  Random.nextGaussian
+   *
+   * @return  {Number} The next Gaussian random value.
    */
   this.nextGaussian = function() {
     if (haveNextNextGaussian) {
@@ -865,21 +1010,47 @@ var noiseProfile = {
 };
 
 /**
- * @description Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural ordered, harmonic succession of numbers compared to the standard random() function. It was invented by Ken Perlin in the 1980s and been used since in graphical applications to produce procedural textures, natural motion, shapes, terrains etc.
- * <br><br>
- * The main difference to the random() function is that Perlin noise is defined in an infinite n-dimensional space where each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. basil.js can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space. The 2nd and 3rd dimension can also be interpreted as time.
- * <br><br>
- * The actual noise is structured similar to an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, perlin noise is computed over several octaves which are added together for the final result.
- * <br><br>
- * Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space the value of the coordinates doesn't matter as such, only the distance between successive coordinates does (eg. when using noise() within a loop). As a general rule the smaller the difference between coordinates, the smoother the resulting noise sequence will be. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
+ * @description Returns the Perlin noise value at specified coordinates. Perlin
+ *          noise is a random sequence generator producing a more natural
+ *          ordered, harmonic succession of numbers compared to the standard
+ *          `random()` function. It was invented by Ken Perlin in the 1980s and
+ *          been used since in graphical applications to produce procedural
+ *          textures, natural motion, shapes, terrains etc.
+ *          <br><br>
+ *          The main
+ *          difference to the `random()` function is that Perlin noise is
+ *          defined in an infinite n-dimensional space where each pair of
+ *          coordinates corresponds to a fixed semi-random value (fixed only for
+ *          the lifespan of the program). The resulting value will always be
+ *          between `0` and `1`. basil.js can compute 1D, 2D and 3D noise,
+ *          depending on the number of coordinates given. The noise value can be
+ *          animated by moving through the noise space. The 2nd and 3rd
+ *          dimension can also be interpreted as time.
+ *          <br><br>
+ *          The actual noise
+ *          is structured similar to an audio signal, in respect to the
+ *          function's use of frequencies. Similar to the concept of harmonics
+ *          in physics, perlin noise is computed over several octaves which are
+ *          added together for the final result.
+ *          <br><br>
+ *          Another way to adjust
+ *          the character of the resulting sequence is the scale of the input
+ *          coordinates. As the function works within an infinite space the
+ *          value of the coordinates doesn't matter as such, only the distance
+ *          between successive coordinates does (eg. when using `noise()` within
+ *          a loop). As a general rule the smaller the difference between
+ *          coordinates, the smoother the resulting noise sequence will be.
+ *          Steps of `0.005`- `0.03` work best for most applications, but this
+ *          will differ depending on use.
  *
- * @cat    Math
- * @subcat Random
- * @method noise
- * @param  {Number} x Coordinate in x space.
- * @param  {Number} [y] Coordinate in y space.
- * @param  {Number} [z] Coordinate in z space.
- * @return {Number} The noise value.
+ * @cat     Math
+ * @subcat  Random
+ * @method  noise
+ *
+ * @param   {Number} x Coordinate in x space.
+ * @param   {Number} [y] Coordinate in y space.
+ * @param   {Number} [z] Coordinate in z space.
+ * @return  {Number} The noise value.
  */
 pub.noise = function(x, y, z) {
   if (noiseProfile.generator === undefined) noiseProfile.generator = new PerlinNoise(noiseProfile.seed);
@@ -906,15 +1077,31 @@ pub.noise = function(x, y, z) {
 };
 
 /**
- * @description Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overal intensity of the noise, whereas higher octaves create finer grained details in the noise sequence. By default, noise is computed over 4 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the 1st octave. This falloff amount can be changed by adding an additional function parameter. Eg. a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. Any value between 0.0 and 1.0 is valid, however note that values greater than 0.5 might result in greater than 1.0 values returned by noise().
- * <br><br>
- * By changing these parameters, the signal created by the noise() function can be adapted to fit very specific needs and characteristics.
+ * @description Adjusts the character and level of detail produced by the Perlin
+ *          noise function. Similar to harmonics in physics, noise is computed
+ *          over several octaves. Lower octaves contribute more to the output
+ *          signal and as such define the overal intensity of the noise, whereas
+ *          higher octaves create finer grained details in the noise sequence.
+ *          By default, noise is computed over 4 octaves with each octave
+ *          contributing exactly half than its predecessor, starting at 50%
+ *          strength for the 1st octave. This falloff amount can be changed by
+ *          adding an additional function parameter. Eg. a falloff factor of
+ *          `0.75` means each octave will now have 75% impact (25% less) of the
+ *          previous lower octave. Any value between `0` and `1` is valid,
+ *          however note that values greater than `0.5` might result in greater
+ *          than `1` values returned by `noise()`.
+ *          <br><br>
+ *          By changing these
+ *          parameters, the signal created by the `noise()` function can be
+ *          adapted to fit very specific needs and characteristics.
  *
- * @cat    Math
- * @subcat Random
- * @method noiseDetail
- * @param  {Number} octaves Number of octaves to be used by the noise() function.
- * @param  {Number} fallout Falloff factor for each octave.
+ * @cat     Math
+ * @subcat  Random
+ * @method  noiseDetail
+ *
+ * @param   {Number} octaves Number of octaves to be used by the noise()
+ *          function.
+ * @param   {Number} fallout Falloff factor for each octave.
  */
 pub.noiseDetail = function(octaves, fallout) {
   noiseProfile.octaves = octaves;
@@ -922,12 +1109,16 @@ pub.noiseDetail = function(octaves, fallout) {
 };
 
 /**
- * @description Sets the seed value for noise(). By default, noise() produces different results each time the program is run. Set the value parameter to a constant to return the same pseudo-random numbers each time the software is run.
+ * @description Sets the seed value for `noise()`. By default, `noise()`
+ *          produces different results each time the program is run. Set the
+ *          value parameter to a constant to return the same pseudo-random
+ *          numbers each time the software is run.
  *
- * @cat    Math
- * @subcat Random
- * @method noiseSeed
- * @param  {Number} seed Noise seed value.
+ * @cat     Math
+ * @subcat  Random
+ * @method  noiseSeed
+ *
+ * @param   {Number} seed Noise seed value.
  */
 pub.noiseSeed = function(seed) {
   noiseProfile.seed = seed;
@@ -944,14 +1135,20 @@ var precision = function(num, dec) {
 };
 
 /**
- * @description The function calculates the geometric bounds of any given page item or text. Use the `transforms()` function to modify page items.
- * In case the object is any kind of text, additional typographic information baseline and xHeight are calculated.
+ * @description The function calculates the geometric bounds of any given page
+ *          item or text. Use the `transforms()` function to modify page items.
+ *          In case the object is any kind of text, additional typographic
+ *          information `baseline` and `xHeight` are calculated.
  *
- * @cat    Document
- * @subcat Transformation
- * @method bounds
- * @param  {PageItem|Text} obj The page item or text to calculate the geometric bounds.
- * @return {Object} Geometric bounds object with these properties: width, height, left, right, top, bottom and for text: baseline, xHeight.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  bounds
+ *
+ * @param   {PageItem|Text} obj The page item or text to calculate the geometric
+ *          bounds.
+ * @return  {Object} Geometric bounds object with these properties: `width`,
+ *          `height`, `left`, `right`, `top`, `bottom` and for text: `baseline`,
+ *          `xHeight`.
  */
 pub.bounds = function (obj) {
   var x1, y1, x2, y2, w, h;

--- a/src/includes/math.js
+++ b/src/includes/math.js
@@ -944,7 +944,7 @@ var precision = function(num, dec) {
 };
 
 /**
- * @description The function calculates the geometric bounds of any given page item or text. Use the <code>transforms()</code> function to modify page items.
+ * @description The function calculates the geometric bounds of any given page item or text. Use the `transforms()` function to modify page items.
  * In case the object is any kind of text, additional typographic information baseline and xHeight are calculated.
  *
  * @cat    Document

--- a/src/includes/math.js
+++ b/src/includes/math.js
@@ -5,17 +5,17 @@
 var Vector = pub.Vector = function() {
 
   /**
-   * A class to describe a two or three dimensional vector. This datatype stores two or three variables that are commonly used as a position, velocity, and/or acceleration. Technically, position is a point and velocity and acceleration are vectors, but this is often simplified to consider all three as vectors. For example, if you consider a rectangle moving across the screen, at any given instant it has a position (the object's location, expressed as a point.), a velocity (the rate at which the object's position changes per time unit, expressed as a vector), and acceleration (the rate at which the object's velocity changes per time unit, expressed as a vector). Since vectors represent groupings of values, we cannot simply use traditional addition/multiplication/etc. Instead, we'll need to do some "vector" math, which is made easy by the methods inside the Vector class.
-   *
+   * @description A class to describe a two or three dimensional vector. This datatype stores two or three variables that are commonly used as a position, velocity, and/or acceleration. Technically, position is a point and velocity and acceleration are vectors, but this is often simplified to consider all three as vectors. For example, if you consider a rectangle moving across the screen, at any given instant it has a position (the object's location, expressed as a point.), a velocity (the rate at which the object's position changes per time unit, expressed as a vector), and acceleration (the rate at which the object's velocity changes per time unit, expressed as a vector). Since vectors represent groupings of values, we cannot simply use traditional addition/multiplication/etc. Instead, we'll need to do some "vector" math, which is made easy by the methods inside the Vector class.
+   * <br><br>
    * Constructor of Vector, can be two- or three-dimensional.
    *
-   * @constructor
-   * @cat Math
+   * @cat    Math
    * @subcat Vector
    * @method Vector
-   * @param {Number} x The first vector.
-   * @param {Number} y The second vector.
-   * @param {Number} [z] The third vector.
+   * @param  {Number} x The first vector.
+   * @param  {Number} y The second vector.
+   * @param  {Number} [z] The third vector.
+   * @constructor
    */
   function Vector(x, y, z) {
     this.x = x || 0;
@@ -23,60 +23,64 @@ var Vector = pub.Vector = function() {
     this.z = z || 0;
   }
   /**
-   * Static function. Calculates the Euclidean distance between two points (considering a point as a vector object).
+   * @description Static function. Calculates the Euclidean distance between two points (considering a point as a vector object).
    * Is meant to be called "static" i.e. Vector.dist(v1, v2);
-   * @cat Math
+   *
+   * @cat    Math
    * @subcat Vector
    * @method Vector.dist
-   * @static
-   * @param {Vector} v1 The first vector.
-   * @param {Vector} v2 The second vector.
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
    * @return {Number} The distance.
+   * @static
    */
   Vector.dist = function(v1, v2) {
     return v1.dist(v2);
   };
 
   /**
-   * Static function. Calculates the dot product of two vectors.
+   * @description Static function. Calculates the dot product of two vectors.
    * Is meant to be called "static" i.e. Vector.dot(v1, v2);
-   * @method Vector.dot
-   * @cat Math
+   *
+   * @cat    Math
    * @subcat Vector
-   * @static
-   * @param {Vector} v1 The first vector.
-   * @param {Vector} v2 The second vector.
+   * @method Vector.dot
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
    * @return {Number} The dot product.
+   * @static
    */
   Vector.dot = function(v1, v2) {
     return v1.dot(v2);
   };
 
   /**
-   * Static function. Calculates the cross product of two vectors.
+   * @description Static function. Calculates the cross product of two vectors.
    * Is meant to be called "static" i.e. Vector.cross(v1, v2);
-   * @method Vector.cross
-   * @cat Math
+   *
+   * @cat    Math
    * @subcat Vector
-   * @static
-   * @param {Vector} v1 The first vector.
-   * @param {Vector} v2 The second vector.
+   * @method Vector.cross
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
    * @return {Number} The cross product.
+   * @static
    */
   Vector.cross = function(v1, v2) {
     return v1.cross(v2);
   };
 
   /**
-   * Static function. Calculates the angle between two vectors.
+   * @description Static function. Calculates the angle between two vectors.
    * Is meant to be called "static" i.e. Vector.angleBetween(v1, v2);
-   * @method Vector.angleBetween
-   * @cat Math
+   *
+   * @cat    Math
    * @subcat Vector
-   * @static
-   * @param {Vector} v1 The first vector.
-   * @param {Vector} v2 The second vector.
+   * @method Vector.angleBetween
+   * @param  {Vector} v1 The first vector.
+   * @param  {Vector} v2 The second vector.
    * @return {Number} The angle.
+   * @static
    */
   Vector.angleBetween = function(v1, v2) {
     return Math.acos(v1.dot(v2) / (v1.mag() * v2.mag()));
@@ -85,13 +89,14 @@ var Vector = pub.Vector = function() {
   Vector.prototype = {
 
     /**
-     * Sets the x, y, and z component of the vector using three separate variables, the data from a Vector, or the values from a float array.
-     * @method Vector.set
-     * @cat Math
+     * @description Sets the x, y, and z component of the vector using three separate variables, the data from a Vector, or the values from a float array.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Number|Array|Vector} v Either a vector, array or x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.set
+     * @param  {Number|Array|Vector} v Either a vector, array or x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      */
     set: function(v, y, z) {
       if (arguments.length === 1) this.set(v.x || v[0] || 0, v.y || v[1] || 0, v.z || v[2] || 0);
@@ -102,20 +107,22 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * Gets a copy of the vector, returns a Vector object.
-     * @method Vector.get
-     * @cat Math
+     * @description Gets a copy of the vector, returns a Vector object.
+     *
+     * @cat    Math
      * @subcat Vector
+     * @method Vector.get
      * @return {Vector} A copy of the vector.
      */
     get: function() {
       return new Vector(this.x, this.y, this.z);
     },
     /**
-     * Calculates the magnitude (length) of the vector and returns the result as a float
-     * @method Vector.mag
-     * @cat Math
+     * @description Calculates the magnitude (length) of the vector and returns the result as a float
+     *
+     * @cat    Math
      * @subcat Vector
+     * @method Vector.mag
      * @return {Number} The length.
      */
     mag: function() {
@@ -125,13 +132,14 @@ var Vector = pub.Vector = function() {
       return Math.sqrt(x * x + y * y + z * z);
     },
     /**
-     * Adds x, y, and z components to a vector, adds one vector to another.
-     * @method Vector.add
-     * @cat Math
+     * @description Adds x, y, and z components to a vector, adds one vector to another.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.add
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      */
     add: function(v, y, z) {
       if (arguments.length === 1) {
@@ -145,13 +153,14 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * Substract x, y, and z components or a full vector from this vector
-     * @method Vector.sub
-     * @cat Math
+     * @description Substract x, y, and z components or a full vector from this vector
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.sub
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      */
     sub: function(v, y, z) {
       if (arguments.length === 1) {
@@ -165,13 +174,14 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * Multiplies this vector with x, y, and z components or another vector.
-     * @method Vector.mult
-     * @cat Math
+     * @description Multiplies this vector with x, y, and z components or another vector.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.mult
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      */
     mult: function(v) {
       if (typeof v === "number") {
@@ -185,13 +195,14 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * Divides this vector through x, y, and z components or another vector.
-     * @method Vector.div
-     * @cat Math
+     * @description Divides this vector through x, y, and z components or another vector.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.div
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      */
     div: function(v) {
       if (typeof v === "number") {
@@ -205,13 +216,14 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * Calculates the distance from this vector to another as x, y, and z components or full vector.
-     * @method Vector.dist
-     * @cat Math
+     * @description Calculates the distance from this vector to another as x, y, and z components or full vector.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.dist
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      * @return {Number} The distance.
      */
     dist: function(v) {
@@ -221,13 +233,14 @@ var Vector = pub.Vector = function() {
       return Math.sqrt(dx * dx + dy * dy + dz * dz);
     },
     /**
-     * Calculates the dot product from this vector to another as x, y, and z components or full vector.
-     * @method Vector.dot
-     * @cat Math
+     * @description Calculates the dot product from this vector to another as x, y, and z components or full vector.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.dot
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      * @return {Number} The dot product.
      */
     dot: function(v, y, z) {
@@ -235,13 +248,14 @@ var Vector = pub.Vector = function() {
       return this.x * v + this.y * y + this.z * z;
     },
     /**
-     * Calculates the cross product from this vector to another as x, y, and z components or full vector.
-     * @method Vector.cross
-     * @cat Math
+     * @description Calculates the cross product from this vector to another as x, y, and z components or full vector.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Vector|Number} v Either a full vector or an x component.
-     * @param {Number} [y] The y component.
-     * @param {Number} [z] The z component.
+     * @method Vector.cross
+     * @param  {Vector|Number} v Either a full vector or an x component.
+     * @param  {Number} [y] The y component.
+     * @param  {Number} [z] The z component.
      * @return {Number} The cross product.
      */
     cross: function(v) {
@@ -251,8 +265,9 @@ var Vector = pub.Vector = function() {
       return new Vector(y * v.z - v.y * z, z * v.x - v.z * x, x * v.y - v.x * y);
     },
     /**
-     * Normalizes the length of this vector to 1.
-     * @cat Math
+     * @description Normalizes the length of this vector to 1.
+     *
+     * @cat    Math
      * @subcat Vector
      * @method Vector.normalize
      */
@@ -261,11 +276,12 @@ var Vector = pub.Vector = function() {
       if (m > 0) this.div(m);
     },
     /**
-     * Normalizes the length of this vector to the given parameter.
-     * @method Vector.limit
-     * @cat Math
+     * @description Normalizes the length of this vector to the given parameter.
+     *
+     * @cat    Math
      * @subcat Vector
-     * @param {Number} high The value to scale to.
+     * @method Vector.limit
+     * @param  {Number} high The value to scale to.
      */
     limit: function(high) {
       if (this.mag() > high) {
@@ -274,30 +290,33 @@ var Vector = pub.Vector = function() {
       }
     },
     /**
-     * The 2D orientation (heading) of this vector in radian.
-     * @method Vector.heading
-     * @cat Math
+     * @description The 2D orientation (heading) of this vector in radian.
+     *
+     * @cat    Math
      * @subcat Vector
+     * @method Vector.heading
      * @return {Number} A radian angle value.
      */
     heading: function() {
       return -Math.atan2(-this.y, this.x);
     },
     /**
-     * Returns data about this vector as a string.
-     * @method Vector.toString
-     * @cat Math
+     * @description Returns data about this vector as a string.
+     *
+     * @cat    Math
      * @subcat Vector
+     * @method Vector.toString
      * @return {String} The x, y and z components as a string.
      */
     toString: function() {
       return "[" + this.x + ", " + this.y + ", " + this.z + "]";
     },
     /**
-     * Returns this vector as an array [x,y,z].
-     * @method Vector.array
-     * @cat Math
+     * @description Returns this vector as an array [x,y,z].
+     *
+     * @cat    Math
      * @subcat Vector
+     * @method Vector.array
      * @return {Array} The x, y and z components as  an Array of [x,y,z].
      */
     array: function() {
@@ -320,36 +339,36 @@ var Vector = pub.Vector = function() {
 // -- Calculation --
 
 /**
- * Calculates the absolute value (magnitude) of a number. The absolute value of a number is always positive.
+ * @description Calculates the absolute value (magnitude) of a number. The absolute value of a number is always positive.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method abs
- * @param {Number} val A number.
+ * @param  {Number} val A number.
  * @return {Number} The absolute value of that number.
  */
 pub.abs = Math.abs;
 
 /**
- * Calculates the closest int value that is greater than or equal to the value of the parameter. For example, ceil(9.03) returns the value 10.
+ * @description Calculates the closest int value that is greater than or equal to the value of the parameter. For example, ceil(9.03) returns the value 10.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method ceil
- * @param {Number} val An arbitrary number.
+ * @param  {Number} val An arbitrary number.
  * @return {Number} The next highest integer value.
  */
 pub.ceil = Math.ceil;
 
 /**
- * Constrains a value to not exceed a maximum and minimum value.
+ * @description Constrains a value to not exceed a maximum and minimum value.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method constrain
- * @param {Number} aNumber The value to constrain.
- * @param {Number} aMin Minimum limit.
- * @param {Number} aMax Maximum limit.
+ * @param  {Number} aNumber The value to constrain.
+ * @param  {Number} aMin Minimum limit.
+ * @param  {Number} aMax Maximum limit.
  * @return {Number} The constrained value.
  */
 pub.constrain = function(aNumber, aMin, aMax) {
@@ -360,15 +379,15 @@ pub.constrain = function(aNumber, aMin, aMax) {
 };
 
 /**
- * Calculates the distance between two points.
+ * @description Calculates the distance between two points.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method dist
- * @param {Number} x1 The x-coordinate of the first point.
- * @param {Number} y1 The y-coordinate of the first point.
- * @param {Number} x2 The x-coordinate of the second point.
- * @param {Number} y2 The y-coordinate of the second point.
+ * @param  {Number} x1 The x-coordinate of the first point.
+ * @param  {Number} y1 The y-coordinate of the first point.
+ * @param  {Number} x2 The x-coordinate of the second point.
+ * @param  {Number} y2 The y-coordinate of the second point.
  * @return {Number} The distance.
  */
 pub.dist = function() {
@@ -383,36 +402,36 @@ pub.dist = function() {
 };
 
 /**
- * The Math.exp() function returns ex, where x is the argument, and e is Euler's number (also known as Napier's constant), the base of the natural logarithms.
+ * @description The Math.exp() function returns ex, where x is the argument, and e is Euler's number (also known as Napier's constant), the base of the natural logarithms.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method exp
- * @param {Number} x A number.
+ * @param  {Number} x A number.
  * @return {Number} A number representing ex.
  */
 pub.exp = Math.exp;
 
 /**
- * Calculates the closest int value that is less than or equal to the value of the parameter.
+ * @description Calculates the closest int value that is less than or equal to the value of the parameter.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method floor
- * @param {Number} a A number.
+ * @param  {Number} a A number.
  * @return {Number} Integer number.
  */
 pub.floor = Math.floor;
 
 /**
- * Calculates a number between two numbers at a specific increment. The amt parameter is the amount to interpolate between the two values where 0.0 equal to the first point, 0.1 is very near the first point, 0.5 is half-way in between, etc. The lerp function is convenient for creating motion along a straight path and for drawing dotted lines.
+ * @description Calculates a number between two numbers at a specific increment. The amt parameter is the amount to interpolate between the two values where 0.0 equal to the first point, 0.1 is very near the first point, 0.5 is half-way in between, etc. The lerp function is convenient for creating motion along a straight path and for drawing dotted lines.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method lerp
- * @param {Number} value1 First value.
- * @param {Number} value2 Second value.
- * @param {Number} amt Amount between 0.0 and 1.0.
+ * @param  {Number} value1 First value.
+ * @param  {Number} value2 Second value.
+ * @param  {Number} amt Amount between 0.0 and 1.0.
  * @return {Number} The mapped value.
  */
 pub.lerp = function(value1, value2, amt) {
@@ -421,25 +440,25 @@ pub.lerp = function(value1, value2, amt) {
 };
 
 /**
- * Calculates the natural logarithm (the base-e logarithm) of a number. This function expects the values greater than 0.0.
+ * @description Calculates the natural logarithm (the base-e logarithm) of a number. This function expects the values greater than 0.0.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method log
- * @param {Number} x A number, must be greater then 0.0.
+ * @param  {Number} x A number, must be greater then 0.0.
  * @return {Number} The natural logarithm.
  */
 pub.log = Math.log;
 
 /**
- * Calculates the magnitude (or length) of a vector. A vector is a direction in space commonly used in computer graphics and linear algebra. Because it has no "start" position, the magnitude of a vector can be thought of as the distance from coordinate (0,0) to its (x,y) value. Therefore, mag() is a shortcut for writing "dist(0, 0, x, y)".
+ * @description Calculates the magnitude (or length) of a vector. A vector is a direction in space commonly used in computer graphics and linear algebra. Because it has no "start" position, the magnitude of a vector can be thought of as the distance from coordinate (0,0) to its (x,y) value. Therefore, mag() is a shortcut for writing "dist(0, 0, x, y)".
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method mag
- * @param {Number} x Coordinate.
- * @param {Number} y Coordinate.
- * @param {Number} [z] Coordinate, optional.
+ * @param  {Number} x Coordinate.
+ * @param  {Number} y Coordinate.
+ * @param  {Number} [z] Coordinate, optional.
  * @return {Number} The magnitude.
  */
 pub.mag = function(a, b, c) {
@@ -449,18 +468,17 @@ pub.mag = function(a, b, c) {
 };
 
 /**
- * Re-maps a number from one range to another.
- *
+ * @description Re-maps a number from one range to another.<br>
  * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method map
- * @param {Number} value The value to be mapped.
- * @param {Number} istart The start of the input range.
- * @param {Number} istop The end of the input range.
- * @param {Number} ostart The start of the output range.
- * @param {Number} ostop The end of the output range.
+ * @param  {Number} value The value to be mapped.
+ * @param  {Number} istart The start of the input range.
+ * @param  {Number} istop The end of the input range.
+ * @param  {Number} ostart The start of the output range.
+ * @param  {Number} ostop The end of the output range.
  * @return {Number} The mapped value.
  */
 pub.map = function(value, istart, istop, ostart, ostop) {
@@ -469,14 +487,14 @@ pub.map = function(value, istart, istop, ostart, ostop) {
 };
 
 /**
- * Determines the largest value in a sequence of numbers.
+ * @description Determines the largest value in a sequence of numbers.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method max
- * @param {Number|Array} a A value or an array of Numbers.
- * @param {Number} [b] Another value to be compared.
- * @param {Number} [c] Another value to be compared.
+ * @param  {Number|Array} a A value or an array of Numbers.
+ * @param  {Number} [b] Another value to be compared.
+ * @param  {Number} [c] Another value to be compared.
  * @return {Number} The highest value.
  */
 pub.max = function() {
@@ -490,14 +508,14 @@ pub.max = function() {
 };
 
 /**
- * Determines the smallest value in a sequence of numbers.
+ * @description Determines the smallest value in a sequence of numbers.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method min
- * @param {Number|Array} a A value or an array of Numbers.
- * @param {Number} [b] Another value to be compared.
- * @param {Number} [c] Another value to be compared.
+ * @param  {Number|Array} a A value or an array of Numbers.
+ * @param  {Number} [b] Another value to be compared.
+ * @param  {Number} [c] Another value to be compared.
  * @return {Number} The lowest value.
  */
 pub.min = function() {
@@ -511,18 +529,16 @@ pub.min = function() {
 };
 
 /**
- * Normalizes a number from another range into a value between 0 and 1.
- *
- * Identical to map(value, low, high, 0, 1);
- *
+ * @description Normalizes a number from another range into a value between 0 and 1.<br>
+ * Identical to map(value, low, high, 0, 1);<br>
  * Numbers outside the range are not clamped to 0 and 1, because out-of-range values are often intentional and useful.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method norm
- * @param {Number} aNumber The value to be normed.
- * @param {Number} low The lowest value to be expected.
- * @param {Number} high The highest value to be expected.
+ * @param  {Number} aNumber The value to be normed.
+ * @param  {Number} low The lowest value to be expected.
+ * @param  {Number} high The highest value to be expected.
  * @return {Number} The normalized value.
  */
 pub.norm = function(aNumber, low, high) {
@@ -531,35 +547,35 @@ pub.norm = function(aNumber, low, high) {
 };
 
 /**
- * Facilitates exponential expressions. The pow() function is an efficient way of multiplying numbers by themselves (or their reciprocal) in large quantities. For example, pow(3, 5) is equivalent to the expression 3*3*3*3*3 and pow(3, -5) is equivalent to 1 / 3*3*3*3*3
+ * @description Facilitates exponential expressions. The pow() function is an efficient way of multiplying numbers by themselves (or their reciprocal) in large quantities. For example, pow(3, 5) is equivalent to the expression 3*3*3*3*3 and pow(3, -5) is equivalent to 1 / 3*3*3*3*3
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method pow
- * @param {Number} num Base of the exponential expression.
- * @param {Number} exponent Power of which to raise the base.
+ * @param  {Number} num Base of the exponential expression.
+ * @param  {Number} exponent Power of which to raise the base.
  * @return {Number} the result
  */
 pub.pow = Math.pow;
 
 /**
- * Calculates the integer closest to the value parameter. For example, round(9.2) returns the value 9.
+ * @description Calculates the integer closest to the value parameter. For example, round(9.2) returns the value 9.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method round
- * @param {Number} value The value to be rounded.
+ * @param  {Number} value The value to be rounded.
  * @return {Number} The rounded value.
  */
 pub.round = Math.round;
 
 /**
- * Squares a number (multiplies a number by itself). The result is always a positive number, as multiplying two negative numbers always yields a positive result. For example, -1 * -1 = 1.
+ * @description Squares a number (multiplies a number by itself). The result is always a positive number, as multiplying two negative numbers always yields a positive result. For example, -1 * -1 = 1.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Calculation
  * @method sq
- * @param {Number} aNumber The value to be squared.
+ * @param  {Number} aNumber The value to be squared.
  * @return {Number} Squared number.
  */
 pub.sq = function(aNumber) {
@@ -570,79 +586,79 @@ pub.sq = function(aNumber) {
 // -- Trigonometry --
 
 /**
- * Calculates the square root of a number. The square root of a number is always positive, even though there may be a valid negative root. The square root s of number a is such that s*s = a. It is the opposite of squaring.
+ * @description Calculates the square root of a number. The square root of a number is always positive, even though there may be a valid negative root. The square root s of number a is such that s*s = a. It is the opposite of squaring.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method sqrt
- * @param {Number} val A value.
+ * @param  {Number} val A value.
  * @return {Number} Square root.
  */
 pub.sqrt = Math.sqrt;
 
 /**
- * The inverse of cos(), returns the arc cosine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of cos(), returns the arc cosine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method acos
- * @param {Number} value The value whose arc cosine is to be returned.
+ * @param  {Number} value The value whose arc cosine is to be returned.
  * @return {Number} The arc cosine.
  */
 pub.acos = Math.acos;
 
 /**
- * The inverse of sin(), returns the arc sine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of sin(), returns the arc sine of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method asin
- * @param {Number} value The value whose arc sine is to be returned.
+ * @param  {Number} value The value whose arc sine is to be returned.
  * @return {Number} The arc sine.
  */
 pub.asin = Math.asin;
 
 /**
- * The inverse of tan(), returns the arc tangent of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
+ * @description The inverse of tan(), returns the arc tangent of a value. This function expects the values in the range of -1 to 1 and values are returned in the range 0 to PI (3.1415927).
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method atan
- * @param {Number} value The value whose arc tangent is to be returned.
+ * @param  {Number} value The value whose arc tangent is to be returned.
  * @return {Number} The arc tangent.
  */
 pub.atan = Math.atan;
 
 /**
- * Calculates the angle (in radians) from a specified point to the coordinate origin as measured from the positive x-axis. Values are returned as a float in the range from PI to -PI. The atan2() function is most often used for orienting geometry to the position of the cursor. Note: The y-coordinate of the point is the first parameter and the x-coordinate is the second due the the structure of calculating the tangent.
+ * @description Calculates the angle (in radians) from a specified point to the coordinate origin as measured from the positive x-axis. Values are returned as a float in the range from PI to -PI. The atan2() function is most often used for orienting geometry to the position of the cursor. Note: The y-coordinate of the point is the first parameter and the x-coordinate is the second due the the structure of calculating the tangent.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method atan2
- * @param {Number} y The y coordinate.
- * @param {Number} x The x coordinate.
+ * @param  {Number} y The y coordinate.
+ * @param  {Number} x The x coordinate.
  * @return {Number} The atan2 value.
  */
 pub.atan2 = Math.atan2;
 
 /**
- * Calculates the cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range -1 to 1.
+ * @description Calculates the cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range -1 to 1.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method cos
- * @param {Number} rad A value in radians.
+ * @param  {Number} rad A value in radians.
  * @return {Number} The cosine.
  */
 pub.cos = Math.cos;
 
 /**
- * Converts a radian measurement to its corresponding value in degrees. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
+ * @description Converts a radian measurement to its corresponding value in degrees. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method degrees
- * @param {Number} aAngle An angle in radians.
+ * @param  {Number} aAngle An angle in radians.
  * @return {Number} The given angle in degree.
  */
 pub.degrees = function(aAngle) {
@@ -650,12 +666,12 @@ pub.degrees = function(aAngle) {
 };
 
 /**
- * Converts a degree measurement to its corresponding value in radians. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
+ * @description Converts a degree measurement to its corresponding value in radians. Radians and degrees are two ways of measuring the same thing. There are 360 degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 = 1.5707964. All trigonometric methods in Processing require their parameters to be specified in radians.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method radians
- * @param {Number} aAngle An angle in degree.
+ * @param  {Number} aAngle An angle in degree.
  * @return {Number} The given angle in radians.
  */
 pub.radians = function(aAngle) {
@@ -663,23 +679,23 @@ pub.radians = function(aAngle) {
 };
 
 /**
- * Calculates the sine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to 6.28). Values are returned in the range -1 to 1.
+ * @description Calculates the sine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to 6.28). Values are returned in the range -1 to 1.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method sin
- * @param {Number} rad A value in radians.
+ * @param  {Number} rad A value in radians.
  * @return {Number} The sine value.
  */
 pub.sin = Math.sin;
 
 /**
- * Calculates the ratio of the sine and cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range infinity to -infinity.
+ * @description Calculates the ratio of the sine and cosine of an angle. This function expects the values of the angle parameter to be provided in radians (values from 0 to PI*2). Values are returned in the range infinity to -infinity.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Trigonometry
  * @method tan
- * @param {Number} rad A value in radians.
+ * @param  {Number} rad A value in radians.
  * @return {Number} The tangent value.
  */
 pub.tan = Math.tan;
@@ -689,15 +705,14 @@ pub.tan = Math.tan;
 var currentRandom = Math.random;
 
 /**
- * Generates random numbers. Each time the random() function is called, it returns an unexpected value within the specified range. If one parameter is passed to the function it will return a float between zero and the value of the high parameter. The function call random(5) returns values between 0 and 5. If two parameters are passed, it will return a float with a value between the the parameters. The function call random(-5, 10.2) returns values between -5 and 10.2.
- *
+ * @description Generates random numbers. Each time the random() function is called, it returns an unexpected value within the specified range. If one parameter is passed to the function it will return a float between zero and the value of the high parameter. The function call random(5) returns values between 0 and 5. If two parameters are passed, it will return a float with a value between the the parameters. The function call random(-5, 10.2) returns values between -5 and 10.2.<br>
  * One parameter sets the range from 0 to the given parameter, while with two parameters present you set the range from val1 - val2.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Random
  * @method random
- * @param {Number} [low] The low border of the range.
- * @param {Number} [high] The high border of the range.
+ * @param  {Number} [low] The low border of the range.
+ * @param  {Number} [high] The high border of the range.
  * @return {Number} A random number.
  */
 pub.random = function() {
@@ -727,10 +742,10 @@ Marsaglia.createRandomized = function() {
   return new Marsaglia(now / 6E4 & 4294967295, now & 4294967295);
 };
 /**
- * Sets the seed value for random().
- *
+ * @description Sets the seed value for random().<br>
  * By default, random() produces different results each time the program is run. Set the seed parameter to a constant to return the same pseudo-random numbers each time the software is run.
- * @cat Math
+ *
+ * @cat    Math
  * @subcat Random
  * @method randomSeed
  * @param  {Number} seed The seed value.
@@ -739,12 +754,13 @@ pub.randomSeed = function(seed) {
   currentRandom = (new Marsaglia(seed)).nextDouble;
 };
 /**
- * Random Generator with Gaussian distribution.
- * @constructor
- * @cat Math
+ * @description Random Generator with Gaussian distribution.
+ *
+ * @cat    Math
  * @subcat Random
  * @method Random
- * @param {Number} seed The seed value.
+ * @param  {Number} seed The seed value.
+ * @constructor
  */
 pub.Random = function(seed) {
   var haveNextNextGaussian = false,
@@ -849,20 +865,20 @@ var noiseProfile = {
 };
 
 /**
- * Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural ordered, harmonic succession of numbers compared to the standard random() function. It was invented by Ken Perlin in the 1980s and been used since in graphical applications to produce procedural textures, natural motion, shapes, terrains etc.
- *
+ * @description Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural ordered, harmonic succession of numbers compared to the standard random() function. It was invented by Ken Perlin in the 1980s and been used since in graphical applications to produce procedural textures, natural motion, shapes, terrains etc.
+ * <br><br>
  * The main difference to the random() function is that Perlin noise is defined in an infinite n-dimensional space where each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. basil.js can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space. The 2nd and 3rd dimension can also be interpreted as time.
- *
+ * <br><br>
  * The actual noise is structured similar to an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, perlin noise is computed over several octaves which are added together for the final result.
- *
+ * <br><br>
  * Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space the value of the coordinates doesn't matter as such, only the distance between successive coordinates does (eg. when using noise() within a loop). As a general rule the smaller the difference between coordinates, the smoother the resulting noise sequence will be. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Random
  * @method noise
- * @param {Number} x Coordinate in x space.
- * @param {Number} [y] Coordinate in y space.
- * @param {Number} [z] Coordinate in z space.
+ * @param  {Number} x Coordinate in x space.
+ * @param  {Number} [y] Coordinate in y space.
+ * @param  {Number} [z] Coordinate in z space.
  * @return {Number} The noise value.
  */
 pub.noise = function(x, y, z) {
@@ -890,15 +906,15 @@ pub.noise = function(x, y, z) {
 };
 
 /**
- * Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overal intensity of the noise, whereas higher octaves create finer grained details in the noise sequence. By default, noise is computed over 4 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the 1st octave. This falloff amount can be changed by adding an additional function parameter. Eg. a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. Any value between 0.0 and 1.0 is valid, however note that values greater than 0.5 might result in greater than 1.0 values returned by noise().
- *
+ * @description Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overal intensity of the noise, whereas higher octaves create finer grained details in the noise sequence. By default, noise is computed over 4 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the 1st octave. This falloff amount can be changed by adding an additional function parameter. Eg. a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. Any value between 0.0 and 1.0 is valid, however note that values greater than 0.5 might result in greater than 1.0 values returned by noise().
+ * <br><br>
  * By changing these parameters, the signal created by the noise() function can be adapted to fit very specific needs and characteristics.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Random
  * @method noiseDetail
- * @param {Number} octaves Number of octaves to be used by the noise() function.
- * @param {Number} fallout Falloff factor for each octave.
+ * @param  {Number} octaves Number of octaves to be used by the noise() function.
+ * @param  {Number} fallout Falloff factor for each octave.
  */
 pub.noiseDetail = function(octaves, fallout) {
   noiseProfile.octaves = octaves;
@@ -906,12 +922,12 @@ pub.noiseDetail = function(octaves, fallout) {
 };
 
 /**
- * Sets the seed value for noise(). By default, noise() produces different results each time the program is run. Set the value parameter to a constant to return the same pseudo-random numbers each time the software is run.
+ * @description Sets the seed value for noise(). By default, noise() produces different results each time the program is run. Set the value parameter to a constant to return the same pseudo-random numbers each time the software is run.
  *
- * @cat Math
+ * @cat    Math
  * @subcat Random
  * @method noiseSeed
- * @param {Number} seed Noise seed value.
+ * @param  {Number} seed Noise seed value.
  */
 pub.noiseSeed = function(seed) {
   noiseProfile.seed = seed;
@@ -928,10 +944,10 @@ var precision = function(num, dec) {
 };
 
 /**
- * The function calculates the geometric bounds of any given page item or text. Use the <code>transforms()</code> function to modify page items.
+ * @description The function calculates the geometric bounds of any given page item or text. Use the <code>transforms()</code> function to modify page items.
  * In case the object is any kind of text, additional typographic information baseline and xHeight are calculated.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method bounds
  * @param  {PageItem|Text} obj The page item or text to calculate the geometric bounds.

--- a/src/includes/public-vars.js
+++ b/src/includes/public-vars.js
@@ -3,15 +3,17 @@
 // ----------------------------------------
 
 /**
- * System variable which stores the width of the current page.
- * @property {Number} width Width of the current page.
+ * @description System variable which stores the width of the current page.
+ *
  * @cat Environment
+ * @property {Number} width Width of the current page.
  */
 pub.width = null;
 
 /**
- * System variable which stores the height of the current page.
- * @property {Number} height Height of the current page.
+ * @description System variable which stores the height of the current page.
+ *
  * @cat Environment
+ * @property {Number} height Height of the current page.
  */
 pub.height = null;

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -3,16 +3,16 @@
 // ----------------------------------------
 
 /**
- * Draws an ellipse (oval) in the display window. An ellipse with an equal width and height is a circle.
+ * @description Draws an ellipse (oval) in the display window. An ellipse with an equal width and height is a circle.
  * The first two parameters set the location, the third sets the width, and the fourth sets the height.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method ellipse
- * @param {Number} x X-coordinate of the ellipse.
- * @param {Number} y Y-coordinate of the ellipse.
- * @param {Number} w Width of the ellipse.
- * @param {Number} h Height of the ellipse.
+ * @param  {Number} x X-coordinate of the ellipse.
+ * @param  {Number} y Y-coordinate of the ellipse.
+ * @param  {Number} w Width of the ellipse.
+ * @param  {Number} h Height of the ellipse.
  * @return {Oval} New Oval (in InDesign Scripting terms the corresponding type is Oval, not Ellipse).
  */
 pub.ellipse = function(x, y, w, h) {
@@ -66,21 +66,21 @@ pub.ellipse = function(x, y, w, h) {
 };
 
 /**
- * Draws a line (a direct path between two points) to the page.
+ * @description Draws a line (a direct path between two points) to the page.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method line
- * @param {Number} x1 X-coordinate of Point 1.
- * @param {Number} y1 Y-coordinate of Point 1.
- * @param {Number} x2 X-coordinate of Point 2.
- * @param {Number} y2 Y-coordinate of Point 2.
+ * @param  {Number} x1 X-coordinate of Point 1.
+ * @param  {Number} y1 Y-coordinate of Point 1.
+ * @param  {Number} x2 X-coordinate of Point 2.
+ * @param  {Number} y2 Y-coordinate of Point 2.
  * @return {GraphicLine} New GraphicLine.
  *
- *  @example
- *  var vec1 = new Vector( x1, y1 );
- *  var vec2 = new Vector( x2, y2 );
- *  line( vec1, vec2 );
+ * @example
+ * var vec1 = new Vector( x1, y1 );
+ * var vec2 = new Vector( x2, y2 );
+ * line( vec1, vec2 );
  */
 pub.line = function(x1, y1, x2, y2) {
   if (arguments.length !== 4) {
@@ -101,16 +101,16 @@ pub.line = function(x1, y1, x2, y2) {
 };
 
 /**
- * Using the beginShape() and endShape() functions allows to create more complex forms.
+ * @description Using the beginShape() and endShape() functions allows to create more complex forms.
  * beginShape() begins recording vertices for a shape and endShape() stops recording.
  * After calling the beginShape() function, a series of vertex() commands must follow.
  * To stop drawing the shape, call endShape(). The shapeMode parameter allows to close the shape
  * (to connect the beginning and the end).
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method beginShape
- * @param {String} shapeMode Set to CLOSE if the new Path should be auto-closed.
+ * @param  {String} shapeMode Set to CLOSE if the new Path should be auto-closed.
  */
 pub.beginShape = function(shapeMode) {
   currVertexPoints = [];
@@ -124,15 +124,15 @@ pub.beginShape = function(shapeMode) {
 };
 
 /**
- * Shapes are constructed by connecting a series of vertices. vertex() is used to
+ * @description Shapes are constructed by connecting a series of vertices. vertex() is used to
  * specify the vertex coordinates of lines and polygons. It is used exclusively between
  * the beginShape() and endShape() functions.
- *
+ * <br><br>
  * Use either vertex(x, y) for drawing straight corners or
  * vertex(x, y, xLeftHandle, yLeftHandle, xRightHandle, yRightHandle) for drawing bezier shapes.
  * You can also mix the two approaches.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method vertex
  * @param  {Number} x X-coordinate of the vertex.
@@ -160,22 +160,21 @@ pub.vertex = function() {
 };
 
 /**
- * The arc() function draws an arc. Arcs are drawn along the outer edge of an ellipse
+ * @description The arc() function draws an arc. Arcs are drawn along the outer edge of an ellipse
  * defined by the x, y, width and height parameters.
  * The origin or the arc's ellipse may be changed with the ellipseMode() function.
  * The start and stop parameters specify the angles at which to draw the arc.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method arc
- * @param {Number} cx X-coordinate of the arc's center.
- * @param {Number} cy Y-coordinate of the arc's center.
- * @param {Number} w Width of the arc's ellipse.
- * @param {Number} h Height of the arc's ellipse.
- * @param {Number} startAngle Starting angle of the arc in radians.
- * @param {Number} endAngle Ending angle of the arc in radians.
- * @param {String} [mode] Mode to define the rendering technique of the arc: OPEN (default), CHORD, or PIE.
- *
+ * @param  {Number} cx X-coordinate of the arc's center.
+ * @param  {Number} cy Y-coordinate of the arc's center.
+ * @param  {Number} w Width of the arc's ellipse.
+ * @param  {Number} h Height of the arc's ellipse.
+ * @param  {Number} startAngle Starting angle of the arc in radians.
+ * @param  {Number} endAngle Ending angle of the arc in radians.
+ * @param  {String} [mode] Mode to define the rendering technique of the arc: OPEN (default), CHORD, or PIE.
  * @return {GraphicLine|Polygon} The resulting GraphicLine or Polygon object (in InDesign Scripting terms the corresponding type is GraphicLine or Polygon, not Arc).
  *
  */
@@ -291,12 +290,12 @@ function calculateEllipticalArc(w, h, startAngle, endAngle) {
 }
 
 /**
- * addPath() is used to create multi component paths. Call addPath() to add
+ * @description addPath() is used to create multi component paths. Call addPath() to add
  * the vertices drawn so far to a single path. New vertices will then end up in a new path and
  * endShape() will return a multi path object. All component paths will account for
  * the setting (see CLOSE) given in beginShape(shapeMode).
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method addPath
  */
@@ -306,10 +305,10 @@ pub.addPath = function() {
 };
 
 /**
- * The endShape() function is the companion to beginShape() and may only be called
+ * @description The endShape() function is the companion to beginShape() and may only be called
  * after beginShape().
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method endShape
  * @return {GraphicLine|Polygon} The GraphicLine or Polygon object that was created.
@@ -360,11 +359,11 @@ function notCalledBeginShapeError () {
 }
 
 /**
- * Draws a rectangle on the page.
- * By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, however, may be changed with the rectMode() function.
+ * @description Draws a rectangle on the page.<br>
+ * By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, however, may be changed with the rectMode() function.<br>
  * The fifth, sixth, seventh and eighth parameters, if specified, determine corner radius for the top-right, top-left, lower-right and lower-left corners, respectively. If only a fifth parameter is provided, all corners will be set to this radius.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Primitives
  * @method rect
  * @param  {Number} x X-coordinate of the rectangle.
@@ -448,7 +447,7 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
 // -- Attributes --
 
 /**
- * Modifies the location from which rectangles or text frames draw. The default
+ * @description Modifies the location from which rectangles or text frames draw. The default
  * mode is rectMode(CORNER), which specifies the location to be the upper left
  * corner of the shape and uses the <code>w</code> and <code>h</code> parameters to specify the
  * width and height. The syntax rectMode(CORNERS) uses the <code>x</code> and <code>y</code>
@@ -460,10 +459,10 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
  * center point and uses the <code>w</code> and <code>h</code> parameters to specify
  * half of the shape's width and height.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Attributes
  * @method rectMode
- * @param {String} mode The rectMode to switch to: either CORNER, CORNERS, CENTER, or RADIUS.
+ * @param  {String} mode The rectMode to switch to: either CORNER, CORNERS, CENTER, or RADIUS.
  *
  */
 pub.rectMode = function (mode) {
@@ -477,7 +476,7 @@ pub.rectMode = function (mode) {
 };
 
 /**
- * The origin of new ellipses is modified by the <code>ellipseMode()</code> function.
+ * @description The origin of new ellipses is modified by the <code>ellipseMode()</code> function.
  * The default configuration is <code>ellipseMode(CENTER)</code>, which specifies the
  * location of the ellipse as the center of the shape. The RADIUS mode is
  * the same, but the <code>w</code> and <code>h</code> parameters to <code>ellipse()</code> specify the
@@ -486,10 +485,10 @@ pub.rectMode = function (mode) {
  * mode uses the four parameters to <code>ellipse()</code> to set two opposing corners
  * of the ellipse's bounding box.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Attributes
  * @method ellipseMode
- * @param {String} mode The ellipse mode to switch to: either CENTER, RADIUS, CORNER, or CORNERS.
+ * @param  {String} mode The ellipse mode to switch to: either CENTER, RADIUS, CORNER, or CORNERS.
  */
 pub.ellipseMode = function (mode) {
   if (arguments.length === 0) return currEllipseMode;
@@ -502,12 +501,12 @@ pub.ellipseMode = function (mode) {
 };
 
 /**
- * Sets the width of the stroke used for lines and the border around shapes.
+ * @description Sets the width of the stroke used for lines and the border around shapes.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Attributes
  * @method strokeWeight
- * @param {Number} weight The width of the stroke in points.
+ * @param  {Number} weight The width of the stroke in points.
  */
 pub.strokeWeight = function (weight) {
   if (typeof weight === "string" || typeof weight === "number") {
@@ -518,14 +517,14 @@ pub.strokeWeight = function (weight) {
 };
 
 /**
- * Returns the object style of a given page item or the object style with the given name. If an
+ * @description Returns the object style of a given page item or the object style with the given name. If an
  * object style of the given name does not exist, it gets created. Optionally a props object of
  * property name/value pairs can be used to set the object style's properties.
  *
- * @cat Typography
+ * @cat    Typography
  * @method objectStyle
  * @param  {PageItem|String} itemOrName A page item whose style to return or the name of the object style to return.
- * @param {Object} [props] An object of property name/value pairs to set the style's properties.
+ * @param  {Object} [props] An object of property name/value pairs to set the style's properties.
  * @return {ObjectStyle} The object style instance.
  */
 pub.objectStyle = function(itemOrName, props) {
@@ -561,13 +560,13 @@ pub.objectStyle = function(itemOrName, props) {
 };
 
 /**
- * Applies an object style to the given page item. The object style can be given as
+ * @description Applies an object style to the given page item. The object style can be given as
  * name or as an object style instance.
  *
- * @cat Typography
+ * @cat    Typography
  * @method applyObjectStyle
  * @param  {PageItem} item The page item to apply the style to.
- * @param {ObjectStyle|String} style An object style instance or the name of the object style to apply.
+ * @param  {ObjectStyle|String} style An object style instance or the name of the object style to apply.
  * @return {PageItem} The page item that the style was applied to.
  */
 
@@ -591,13 +590,13 @@ pub.applyObjectStyle = function(item, style) {
 };
 
 /**
- * Duplicates the given page after the current page or the given page item to the current page and layer. Use <code>rectMode()</code> to set center point.
+ * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use <code>rectMode()</code> to set center point.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method duplicate
- * @param {PageItem|Page} item The page item or page to duplicate.
- * @returns {Object} The new page item or page.
+ * @param  {PageItem|Page} item The page item or page to duplicate.
+ * @return {Object} The new page item or page.
  */
 pub.duplicate = function(item) {
 

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -449,14 +449,14 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
 /**
  * @description Modifies the location from which rectangles or text frames draw. The default
  * mode is rectMode(CORNER), which specifies the location to be the upper left
- * corner of the shape and uses the <code>w</code> and <code>h</code> parameters to specify the
- * width and height. The syntax rectMode(CORNERS) uses the <code>x</code> and <code>y</code>
- * parameters of <code>rect()</code> or <code>text()</code> to set the location of one corner
- * and uses the <code>w</code> and <code>h</code> parameters to set the opposite corner.
- * The syntax <code>rectMode(CENTER)</code> draws the shape from its center point and
- * uses the <code>w</code> and <code>h</code> parameters to specify the shape's
- * width and height. The syntax <code>rectMode(RADIUS)</code> draws the shape from its
- * center point and uses the <code>w</code> and <code>h</code> parameters to specify
+ * corner of the shape and uses the `w` and `h` parameters to specify the
+ * width and height. The syntax rectMode(CORNERS) uses the `x` and `y`
+ * parameters of `rect()` or `text()` to set the location of one corner
+ * and uses the `w` and `h` parameters to set the opposite corner.
+ * The syntax `rectMode(CENTER)` draws the shape from its center point and
+ * uses the `w` and `h` parameters to specify the shape's
+ * width and height. The syntax `rectMode(RADIUS)` draws the shape from its
+ * center point and uses the `w` and `h` parameters to specify
  * half of the shape's width and height.
  *
  * @cat    Document
@@ -476,13 +476,13 @@ pub.rectMode = function (mode) {
 };
 
 /**
- * @description The origin of new ellipses is modified by the <code>ellipseMode()</code> function.
- * The default configuration is <code>ellipseMode(CENTER)</code>, which specifies the
+ * @description The origin of new ellipses is modified by the `ellipseMode()` function.
+ * The default configuration is `ellipseMode(CENTER)`, which specifies the
  * location of the ellipse as the center of the shape. The RADIUS mode is
- * the same, but the <code>w</code> and <code>h</code> parameters to <code>ellipse()</code> specify the
+ * the same, but the `w` and `h` parameters to `ellipse()` specify the
  * radius of the ellipse, rather than the diameter. The CORNER mode draws
  * the shape from the upper-left corner of its bounding box. The CORNERS
- * mode uses the four parameters to <code>ellipse()</code> to set two opposing corners
+ * mode uses the four parameters to `ellipse()` to set two opposing corners
  * of the ellipse's bounding box.
  *
  * @cat    Document
@@ -590,7 +590,7 @@ pub.applyObjectStyle = function(item, style) {
 };
 
 /**
- * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use <code>rectMode()</code> to set center point.
+ * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use `rectMode()` to set center point.
  *
  * @cat    Document
  * @subcat Transformation

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -3,17 +3,21 @@
 // ----------------------------------------
 
 /**
- * @description Draws an ellipse (oval) in the display window. An ellipse with an equal width and height is a circle.
- * The first two parameters set the location, the third sets the width, and the fourth sets the height.
+ * @description Draws an ellipse (oval) in the display window. An ellipse with
+ *          an equal width and height is a circle. The first two parameters set
+ *          the location, the third sets the width, and the fourth sets the
+ *          height.
  *
- * @cat    Document
- * @subcat Primitives
- * @method ellipse
- * @param  {Number} x X-coordinate of the ellipse.
- * @param  {Number} y Y-coordinate of the ellipse.
- * @param  {Number} w Width of the ellipse.
- * @param  {Number} h Height of the ellipse.
- * @return {Oval} New Oval (in InDesign Scripting terms the corresponding type is Oval, not Ellipse).
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  ellipse
+ *
+ * @param   {Number} x X-coordinate of the ellipse.
+ * @param   {Number} y Y-coordinate of the ellipse.
+ * @param   {Number} w Width of the ellipse.
+ * @param   {Number} h Height of the ellipse.
+ * @return  {Oval} New Oval (in InDesign Scripting terms the corresponding type
+ *          is Oval, not Ellipse).
  */
 pub.ellipse = function(x, y, w, h) {
   if (arguments.length !== 4) error("ellipse(), not enough parameters to draw an ellipse! Use: x, y, w, h");
@@ -68,18 +72,19 @@ pub.ellipse = function(x, y, w, h) {
 /**
  * @description Draws a line (a direct path between two points) to the page.
  *
- * @cat    Document
- * @subcat Primitives
- * @method line
- * @param  {Number} x1 X-coordinate of Point 1.
- * @param  {Number} y1 Y-coordinate of Point 1.
- * @param  {Number} x2 X-coordinate of Point 2.
- * @param  {Number} y2 Y-coordinate of Point 2.
- * @return {GraphicLine} New GraphicLine.
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  line
+ *
+ * @param   {Number} x1 X-coordinate of Point 1.
+ * @param   {Number} y1 Y-coordinate of Point 1.
+ * @param   {Number} x2 X-coordinate of Point 2.
+ * @param   {Number} y2 Y-coordinate of Point 2.
+ * @return  {GraphicLine} New GraphicLine.
  *
  * @example
- * var vec1 = new Vector( x1, y1 );
- * var vec2 = new Vector( x2, y2 );
+ * var vec1 = new Vector(x1, y1);
+ * var vec2 = new Vector(x2, y2);
  * line( vec1, vec2 );
  */
 pub.line = function(x1, y1, x2, y2) {
@@ -101,16 +106,20 @@ pub.line = function(x1, y1, x2, y2) {
 };
 
 /**
- * @description Using the beginShape() and endShape() functions allows to create more complex forms.
- * beginShape() begins recording vertices for a shape and endShape() stops recording.
- * After calling the beginShape() function, a series of vertex() commands must follow.
- * To stop drawing the shape, call endShape(). The shapeMode parameter allows to close the shape
- * (to connect the beginning and the end).
+ * @description Using the `beginShape()` and `endShape()` functions allows to
+ *          create more complex forms. `beginShape()` begins recording vertices
+ *          for a shape and `endShape()` stops recording. After calling the
+ *          `beginShape()` function, a series of `vertex()` commands must
+ *          follow. To stop drawing the shape, call `endShape()`. The shapeMode
+ *          parameter allows to close the shape (to connect the beginning and
+ *          the end).
  *
- * @cat    Document
- * @subcat Primitives
- * @method beginShape
- * @param  {String} shapeMode Set to CLOSE if the new Path should be auto-closed.
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  beginShape
+ *
+ * @param   {String} shapeMode Set to `CLOSE` if the new path should be
+ *          auto-closed.
  */
 pub.beginShape = function(shapeMode) {
   currVertexPoints = [];
@@ -124,23 +133,24 @@ pub.beginShape = function(shapeMode) {
 };
 
 /**
- * @description Shapes are constructed by connecting a series of vertices. vertex() is used to
- * specify the vertex coordinates of lines and polygons. It is used exclusively between
- * the beginShape() and endShape() functions.
- * <br><br>
- * Use either vertex(x, y) for drawing straight corners or
- * vertex(x, y, xLeftHandle, yLeftHandle, xRightHandle, yRightHandle) for drawing bezier shapes.
- * You can also mix the two approaches.
+ * @description Shapes are constructed by connecting a series of vertices.
+ *          `vertex()` is used to specify the vertex coordinates of lines and
+ *          polygons. It is used exclusively between the `beginShape()` and
+ *          `endShape()` functions. <br><br> Use either `vertex(x, y)` for
+ *          drawing straight corners or `vertex(x, y, xLeftHandle, yLeftHandle,
+ *          xRightHandle, yRightHandle)` for drawing bezier shapes. You can also
+ *          mix the two approaches.
  *
- * @cat    Document
- * @subcat Primitives
- * @method vertex
- * @param  {Number} x X-coordinate of the vertex.
- * @param  {Number} y Y-coordinate of the vertex.
- * @param  {Number} [xLeftHandle] X-coordinate of the left-direction point.
- * @param  {Number} [yLeftHandle] Y-coordinate of the left-direction point.
- * @param  {Number} [xRightHandle] X-coordinate of the right-direction point.
- * @param  {Number} [yRightHandle] Y-coordinate of the right-direction point.
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  vertex
+ *
+ * @param   {Number} x X-coordinate of the vertex.
+ * @param   {Number} y Y-coordinate of the vertex.
+ * @param   {Number} [xLeftHandle] X-coordinate of the left-direction point.
+ * @param   {Number} [yLeftHandle] Y-coordinate of the left-direction point.
+ * @param   {Number} [xRightHandle] X-coordinate of the right-direction point.
+ * @param   {Number} [yRightHandle] Y-coordinate of the right-direction point.
  */
 pub.vertex = function() {
   if (isArray(currVertexPoints)) {
@@ -160,23 +170,27 @@ pub.vertex = function() {
 };
 
 /**
- * @description The arc() function draws an arc. Arcs are drawn along the outer edge of an ellipse
- * defined by the x, y, width and height parameters.
- * The origin or the arc's ellipse may be changed with the ellipseMode() function.
- * The start and stop parameters specify the angles at which to draw the arc.
+ * @description The `arc()` function draws an arc. Arcs are drawn along the
+ *          outer edge of an ellipse defined by the `x`, `y`, `width` and
+ *          `height` parameters. The origin or the arc's ellipse may be changed
+ *          with the `ellipseMode()` function. The start and stop parameters
+ *          specify the angles at which to draw the arc.
  *
- * @cat    Document
- * @subcat Primitives
- * @method arc
- * @param  {Number} cx X-coordinate of the arc's center.
- * @param  {Number} cy Y-coordinate of the arc's center.
- * @param  {Number} w Width of the arc's ellipse.
- * @param  {Number} h Height of the arc's ellipse.
- * @param  {Number} startAngle Starting angle of the arc in radians.
- * @param  {Number} endAngle Ending angle of the arc in radians.
- * @param  {String} [mode] Mode to define the rendering technique of the arc: OPEN (default), CHORD, or PIE.
- * @return {GraphicLine|Polygon} The resulting GraphicLine or Polygon object (in InDesign Scripting terms the corresponding type is GraphicLine or Polygon, not Arc).
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  arc
  *
+ * @param   {Number} cx X-coordinate of the arc's center.
+ * @param   {Number} cy Y-coordinate of the arc's center.
+ * @param   {Number} w Width of the arc's ellipse.
+ * @param   {Number} h Height of the arc's ellipse.
+ * @param   {Number} startAngle Starting angle of the arc in radians.
+ * @param   {Number} endAngle Ending angle of the arc in radians.
+ * @param   {String} [mode] Mode to define the rendering technique of the arc:
+ *          `OPEN` (default), `CHORD`, or `PIE`.
+ * @return  {GraphicLine|Polygon} The resulting GraphicLine or Polygon object
+ *          (in InDesign Scripting terms the corresponding type is GraphicLine
+ *          or Polygon, not Arc).
  */
 pub.arc = function(cx, cy, w, h, startAngle, endAngle, mode) {
   if (w <= 0 || endAngle < startAngle) {
@@ -249,16 +263,12 @@ pub.arc = function(cx, cy, w, h, startAngle, endAngle, mode) {
 /*
  * Cubic bezier approximation of a eliptical arc
  *
- * intial source code:
- * Golan Levin
- * golan@flong.com
+ * intial source code: Golan Levin golan@flong.com
  * http://www.flong.com/blog/2009/bezier-approximation-of-a-circular-arc-in-processing/
  *
  * The solution is taken from this PDF by Richard DeVeneza:
- * http://www.tinaja.com/glib/bezcirc2.pdf
- * linked from this excellent site by Don Lancaster:
- * http://www.tinaja.com/cubic01.asp
- *
+ * http://www.tinaja.com/glib/bezcirc2.pdf linked from this excellent site by
+ * Don Lancaster: http://www.tinaja.com/cubic01.asp
  */
 function calculateEllipticalArc(w, h, startAngle, endAngle) {
   var theta = (endAngle - startAngle);
@@ -290,14 +300,15 @@ function calculateEllipticalArc(w, h, startAngle, endAngle) {
 }
 
 /**
- * @description addPath() is used to create multi component paths. Call addPath() to add
- * the vertices drawn so far to a single path. New vertices will then end up in a new path and
- * endShape() will return a multi path object. All component paths will account for
- * the setting (see CLOSE) given in beginShape(shapeMode).
+ * @description `addPath()` is used to create multi component paths. Call
+ *          `addPath()` to add the vertices drawn so far to a single path. New
+ *          vertices will then end up in a new path and `endShape()` will return
+ *          a multi path object. All component paths will account for the
+ *          setting (see `CLOSE`) given in `beginShape(shapeMode)`.
  *
- * @cat    Document
- * @subcat Primitives
- * @method addPath
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  addPath
  */
 pub.addPath = function() {
   doAddPath();
@@ -305,13 +316,15 @@ pub.addPath = function() {
 };
 
 /**
- * @description The endShape() function is the companion to beginShape() and may only be called
- * after beginShape().
+ * @description The `endShape()` function is the companion to `beginShape()` and
+ *          may only be called after `beginShape()`.
  *
- * @cat    Document
- * @subcat Primitives
- * @method endShape
- * @return {GraphicLine|Polygon} The GraphicLine or Polygon object that was created.
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  endShape
+ *
+ * @return  {GraphicLine|Polygon} The GraphicLine or Polygon object that was
+ *          created.
  */
 pub.endShape = function() {
   doAddPath();
@@ -360,21 +373,30 @@ function notCalledBeginShapeError () {
 
 /**
  * @description Draws a rectangle on the page.<br>
- * By default, the first two parameters set the location of the upper-left corner, the third sets the width, and the fourth sets the height. The way these parameters are interpreted, however, may be changed with the rectMode() function.<br>
- * The fifth, sixth, seventh and eighth parameters, if specified, determine corner radius for the top-right, top-left, lower-right and lower-left corners, respectively. If only a fifth parameter is provided, all corners will be set to this radius.
+ *          By default, the first two
+ *          parameters set the location of the upper-left corner, the third sets
+ *          the width, and the fourth sets the height. The way these parameters
+ *          are interpreted, however, may be changed with the `rectMode()`
+ *          function.<br>
+ *          The fifth, sixth, seventh and eighth parameters, if
+ *          specified, determine corner radius for the top-right, top-left,
+ *          lower-right and lower-left corners, respectively. If only a fifth
+ *          parameter is provided, all corners will be set to this radius.
  *
- * @cat    Document
- * @subcat Primitives
- * @method rect
- * @param  {Number} x X-coordinate of the rectangle.
- * @param  {Number} y Y-coordinate of the rectangle.
- * @param  {Number} w Width of the rectangle.
- * @param  {Number} h Height of the rectangle.
- * @param  {Number} [tl] Radius of top left corner or radius of all 4 corners (optional).
- * @param  {Number} [tr] Radius of top right corner (optional).
- * @param  {Number} [br] Radius of bottom right corner (optional).
- * @param  {Number} [bl] Radius of bottom left corner (optional).
- * @return {Rectangle} The rectangle that was created.
+ * @cat     Document
+ * @subcat  Primitives
+ * @method  rect
+ *
+ * @param   {Number} x X-coordinate of the rectangle.
+ * @param   {Number} y Y-coordinate of the rectangle.
+ * @param   {Number} w Width of the rectangle.
+ * @param   {Number} h Height of the rectangle.
+ * @param   {Number} [tl] Radius of top left corner or radius of all 4 corners
+ *          (optional).
+ * @param   {Number} [tr] Radius of top right corner (optional).
+ * @param   {Number} [br] Radius of bottom right corner (optional).
+ * @param   {Number} [bl] Radius of bottom left corner (optional).
+ * @return  {Rectangle} The rectangle that was created.
  */
 pub.rect = function(x, y, w, h, tl, tr, br, bl) {
   if (w === 0 || h === 0) {
@@ -447,23 +469,25 @@ pub.rect = function(x, y, w, h, tl, tr, br, bl) {
 // -- Attributes --
 
 /**
- * @description Modifies the location from which rectangles or text frames draw. The default
- * mode is rectMode(CORNER), which specifies the location to be the upper left
- * corner of the shape and uses the `w` and `h` parameters to specify the
- * width and height. The syntax rectMode(CORNERS) uses the `x` and `y`
- * parameters of `rect()` or `text()` to set the location of one corner
- * and uses the `w` and `h` parameters to set the opposite corner.
- * The syntax `rectMode(CENTER)` draws the shape from its center point and
- * uses the `w` and `h` parameters to specify the shape's
- * width and height. The syntax `rectMode(RADIUS)` draws the shape from its
- * center point and uses the `w` and `h` parameters to specify
- * half of the shape's width and height.
+ * @description Modifies the location from which rectangles or text frames draw.
+ *          The default mode is rectMode(CORNER), which specifies the location
+ *          to be the upper left corner of the shape and uses the `w` and `h`
+ *          parameters to specify the width and height. The syntax
+ *          rectMode(CORNERS) uses the `x` and `y` parameters of `rect()` or
+ *          `text()` to set the location of one corner and uses the `w` and `h`
+ *          parameters to set the opposite corner. The syntax `rectMode(CENTER)`
+ *          draws the shape from its center point and uses the `w` and `h`
+ *          parameters to specify the shape's width and height. The syntax
+ *          `rectMode(RADIUS)` draws the shape from its center point and uses
+ *          the `w` and `h` parameters to specify half of the shape's width and
+ *          height.
  *
- * @cat    Document
- * @subcat Attributes
- * @method rectMode
- * @param  {String} mode The rectMode to switch to: either CORNER, CORNERS, CENTER, or RADIUS.
+ * @cat     Document
+ * @subcat  Attributes
+ * @method  rectMode
  *
+ * @param   {String} mode The rectMode to switch to: either CORNER, CORNERS,
+ *          CENTER, or RADIUS.
  */
 pub.rectMode = function (mode) {
   if (arguments.length === 0) return currRectMode;
@@ -476,19 +500,22 @@ pub.rectMode = function (mode) {
 };
 
 /**
- * @description The origin of new ellipses is modified by the `ellipseMode()` function.
- * The default configuration is `ellipseMode(CENTER)`, which specifies the
- * location of the ellipse as the center of the shape. The RADIUS mode is
- * the same, but the `w` and `h` parameters to `ellipse()` specify the
- * radius of the ellipse, rather than the diameter. The CORNER mode draws
- * the shape from the upper-left corner of its bounding box. The CORNERS
- * mode uses the four parameters to `ellipse()` to set two opposing corners
- * of the ellipse's bounding box.
+ * @description The origin of new ellipses is modified by the `ellipseMode()`
+ *          function. The default configuration is `ellipseMode(CENTER)`, which
+ *          specifies the location of the ellipse as the center of the shape.
+ *          The RADIUS mode is the same, but the `w` and `h` parameters to
+ *          `ellipse()` specify the radius of the ellipse, rather than the
+ *          diameter. The CORNER mode draws the shape from the upper-left corner
+ *          of its bounding box. The CORNERS mode uses the four parameters to
+ *          `ellipse()` to set two opposing corners of the ellipse's bounding
+ *          box.
  *
- * @cat    Document
- * @subcat Attributes
- * @method ellipseMode
- * @param  {String} mode The ellipse mode to switch to: either CENTER, RADIUS, CORNER, or CORNERS.
+ * @cat     Document
+ * @subcat  Attributes
+ * @method  ellipseMode
+ *
+ * @param   {String} mode The ellipse mode to switch to: either CENTER, RADIUS,
+ *          CORNER, or CORNERS.
  */
 pub.ellipseMode = function (mode) {
   if (arguments.length === 0) return currEllipseMode;
@@ -501,12 +528,14 @@ pub.ellipseMode = function (mode) {
 };
 
 /**
- * @description Sets the width of the stroke used for lines and the border around shapes.
+ * @description Sets the width of the stroke used for lines and the border
+ *          around shapes.
  *
- * @cat    Document
- * @subcat Attributes
- * @method strokeWeight
- * @param  {Number} weight The width of the stroke in points.
+ * @cat     Document
+ * @subcat  Attributes
+ * @method  strokeWeight
+ *
+ * @param   {Number} weight The width of the stroke in points.
  */
 pub.strokeWeight = function (weight) {
   if (typeof weight === "string" || typeof weight === "number") {
@@ -517,15 +546,19 @@ pub.strokeWeight = function (weight) {
 };
 
 /**
- * @description Returns the object style of a given page item or the object style with the given name. If an
- * object style of the given name does not exist, it gets created. Optionally a props object of
- * property name/value pairs can be used to set the object style's properties.
+ * @description Returns the object style of a given page item or the object
+ *          style with the given name. If an object style of the given name does
+ *          not exist, it gets created. Optionally a props object of property
+ *          name/value pairs can be used to set the object style's properties.
  *
- * @cat    Typography
- * @method objectStyle
- * @param  {PageItem|String} itemOrName A page item whose style to return or the name of the object style to return.
- * @param  {Object} [props] An object of property name/value pairs to set the style's properties.
- * @return {ObjectStyle} The object style instance.
+ * @cat     Typography
+ * @method  objectStyle
+ *
+ * @param   {PageItem|String} itemOrName A page item whose style to return or
+ *          the name of the object style to return.
+ * @param   {Object} [props] An object of property name/value pairs to set the
+ *          style's properties.
+ * @return  {ObjectStyle} The object style instance.
  */
 pub.objectStyle = function(itemOrName, props) {
   var styleErrorMsg = "objectStyle(), wrong parameters. Use: pageItem|name and props. Props is optional.";
@@ -560,14 +593,16 @@ pub.objectStyle = function(itemOrName, props) {
 };
 
 /**
- * @description Applies an object style to the given page item. The object style can be given as
- * name or as an object style instance.
+ * @description Applies an object style to the given page item. The object style
+ *          can be given as name or as an object style instance.
  *
- * @cat    Typography
- * @method applyObjectStyle
- * @param  {PageItem} item The page item to apply the style to.
- * @param  {ObjectStyle|String} style An object style instance or the name of the object style to apply.
- * @return {PageItem} The page item that the style was applied to.
+ * @cat     Typography
+ * @method  applyObjectStyle
+ *
+ * @param   {PageItem} item The page item to apply the style to.
+ * @param   {ObjectStyle|String} style An object style instance or the name of
+ *          the object style to apply.
+ * @return  {PageItem} The page item that the style was applied to.
  */
 
 pub.applyObjectStyle = function(item, style) {
@@ -590,13 +625,16 @@ pub.applyObjectStyle = function(item, style) {
 };
 
 /**
- * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use `rectMode()` to set center point.
+ * @description Duplicates the given page after the current page or the given
+ *          page item to the current page and layer. Use `rectMode()` to set
+ *          center point.
  *
- * @cat    Document
- * @subcat Transformation
- * @method duplicate
- * @param  {PageItem|Page} item The page item or page to duplicate.
- * @return {Object} The new page item or page.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  duplicate
+ *
+ * @param   {PageItem|Page} item The page item or page to duplicate.
+ * @return  {Object} The new page item or page.
  */
 pub.duplicate = function(item) {
 

--- a/src/includes/structure.js
+++ b/src/includes/structure.js
@@ -46,10 +46,10 @@ var textCollection = function(collection, legalContainers, container, cb) {
 
 };
 /**
- * @description Suspends the calling thread for a number of milliseconds.
+ * @description Suspends the calling thread for a number of milliseconds.<br>
  * During a sleep period, checks at 100 millisecond intervals to see whether the sleep should be terminated.
  *
- * @cat Environment
+ * @cat    Environment
  * @method delay
  * @param  {Number} milliseconds  The delay time in milliseconds.
  */
@@ -60,17 +60,18 @@ pub.delay = function (milliseconds) {
 /**
  * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function with each story of the given document.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method stories
  * @param  {Document} doc The document instance to iterate the stories in
  * @param  {Function} [cb] The callback function to call with each story. When this function returns false the loop stops. Passed arguments: story, loopCount.
+ * @return {Stories} A collection of Story objects.
+ *
  * @example
  * stories(doc(), function(story, loopCount){
  *   println("Number of words in each Story:");
  *   println(story.words.length);
  * });
- * @return {Stories} A collection of Story objects.
  */
 pub.stories = function(doc, cb) {
 
@@ -88,7 +89,7 @@ pub.stories = function(doc, cb) {
 /**
  * @description If no callback function is given it returns a Collection of paragraphs in the container otherwise calls the given callback function with each paragraph of the given document, page, story or textFrame.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method paragraphs
  * @param  {Document|Page|Story|TextFrame} container The document, story, page or textFrame instance to iterate the paragraphs in.
@@ -105,7 +106,7 @@ pub.paragraphs = function(container, cb) {
 /**
  * @description If no callback function is given it returns a Collection of lines in the container otherwise calls the given callback function with each line of the given document, page, story, textFrame or paragraph.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method lines
  * @param  {Document|Page|Story|TextFrame|Paragraph} container The document, page, story, textFrame or paragraph instance to iterate the lines in.
@@ -122,7 +123,7 @@ pub.lines = function(container, cb) {
 /**
  * @description If no callback function is given it returns a Collection of words in the container otherwise calls the given callback function with each word of the given document, page, story, textFrame, paragraph or line.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method words
  * @param  {Document|Page|Story|TextFrame|Paragraph|Line} container The document, page, story, textFrame, paragraph or line instance to iterate the words in.
@@ -139,7 +140,7 @@ pub.words = function(container, cb) {
 /**
  * @description If no callback function is given it returns a Collection of characters in the container otherwise calls the given callback function with each character of the given document, page, story, textFrame, paragraph, line or word.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method characters
  * @param  {Document|Page|Story|TextFrame|Paragraph|Line|Word} container The document, page, story, textFrame, paragraph, line or word instance to  iterate the characters in.
@@ -157,7 +158,7 @@ pub.characters = function(container, cb) {
 /**
  * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function for each of the PageItems in the given Document, Page, Layer or Group.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Multi-Getters
  * @method items
  * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in
@@ -185,7 +186,7 @@ pub.items = function(container, cb) {
 /**
  * @description Removes all PageItems (including locked ones) in the given Document, Page, Layer or Group. If the selected container is a Group, the Group itself will be removed as well.
  *
- * @cat Document
+ * @cat    Document
  * @method clear
  * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in.
  */
@@ -211,7 +212,7 @@ pub.clear = function(container) {
 /**
  * @description Removes the provided Page, Layer, PageItem, Swatch, etc.
  *
- * @cat Document
+ * @cat    Document
  * @method remove
  * @param  {PageItem} obj The object to be removed.
  */

--- a/src/includes/structure.js
+++ b/src/includes/structure.js
@@ -47,25 +47,31 @@ var textCollection = function(collection, legalContainers, container, cb) {
 };
 /**
  * @description Suspends the calling thread for a number of milliseconds.<br>
- * During a sleep period, checks at 100 millisecond intervals to see whether the sleep should be terminated.
+ *          During a sleep period, checks at 100 millisecond intervals to see
+ *          whether the sleep should be terminated.
  *
- * @cat    Environment
- * @method delay
- * @param  {Number} milliseconds  The delay time in milliseconds.
+ * @cat     Environment
+ * @method  delay
+ * @param   {Number} milliseconds The delay time in milliseconds.
  */
 pub.delay = function (milliseconds) {
   $.sleep(milliseconds);
 };
 
 /**
- * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function with each story of the given document.
+ * @description If no callback function is given it returns a Collection of
+ *          items otherwise calls the given callback function with each story of
+ *          the given document.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method stories
- * @param  {Document} doc The document instance to iterate the stories in
- * @param  {Function} [cb] The callback function to call with each story. When this function returns false the loop stops. Passed arguments: story, loopCount.
- * @return {Stories} A collection of Story objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  stories
+ *
+ * @param   {Document} doc The document instance to iterate the stories in
+ * @param   {Function} [cb] The callback function to call with each story. When
+ *          this function returns `false` the loop stops. Passed arguments:
+ *          `story`, `loopCount`.
+ * @return  {Stories} A collection of Story objects.
  *
  * @example
  * stories(doc(), function(story, loopCount){
@@ -87,14 +93,21 @@ pub.stories = function(doc, cb) {
 };
 
 /**
- * @description If no callback function is given it returns a Collection of paragraphs in the container otherwise calls the given callback function with each paragraph of the given document, page, story or textFrame.
+ * @description If no callback function is given it returns a Collection of
+ *          paragraphs in the container otherwise calls the given callback
+ *          function with each paragraph of the given document, page, story or
+ *          textFrame.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method paragraphs
- * @param  {Document|Page|Story|TextFrame} container The document, story, page or textFrame instance to iterate the paragraphs in.
- * @param  {Function} [cb]  Optional: The callback function to call with each paragraph. When this function returns false the loop stops. Passed arguments: para, loopCount.
- * @return {Paragraphs} A collection of Paragraph objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  paragraphs
+ *
+ * @param   {Document|Page|Story|TextFrame} container The document, story, page
+ *          or textFrame instance to iterate the paragraphs in.
+ * @param   {Function} [cb] Optional: The callback function to call with each
+ *          paragraph. When this function returns false the loop stops. Passed
+ *          arguments: `para`, `loopCount`.
+ * @return  {Paragraphs} A collection of Paragraph objects.
  */
 pub.paragraphs = function(container, cb) {
 
@@ -104,14 +117,22 @@ pub.paragraphs = function(container, cb) {
 };
 
 /**
- * @description If no callback function is given it returns a Collection of lines in the container otherwise calls the given callback function with each line of the given document, page, story, textFrame or paragraph.
+ * @description If no callback function is given it returns a Collection of
+ *          lines in the container otherwise calls the given callback function
+ *          with each line of the given document, page, story, textFrame or
+ *          paragraph.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method lines
- * @param  {Document|Page|Story|TextFrame|Paragraph} container The document, page, story, textFrame or paragraph instance to iterate the lines in.
- * @param  {Function} [cb] Optional: The callback function to call with each line. When this function returns false the loop stops. Passed arguments: line, loopCount.
- * @return {Lines} A collection of Line objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  lines
+ *
+ * @param   {Document|Page|Story|TextFrame|Paragraph} container The document,
+ *          page, story, textFrame or paragraph instance to iterate the lines
+ *          in.
+ * @param   {Function} [cb] Optional: The callback function to call with each
+ *          line. When this function returns false the loop stops. Passed
+ *          arguments: `line`, `loopCount`.
+ * @return  {Lines} A collection of Line objects.
  */
 pub.lines = function(container, cb) {
 
@@ -121,14 +142,22 @@ pub.lines = function(container, cb) {
 };
 
 /**
- * @description If no callback function is given it returns a Collection of words in the container otherwise calls the given callback function with each word of the given document, page, story, textFrame, paragraph or line.
+ * @description If no callback function is given it returns a Collection of
+ *          words in the container otherwise calls the given callback function
+ *          with each word of the given document, page, story, textFrame,
+ *          paragraph or line.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method words
- * @param  {Document|Page|Story|TextFrame|Paragraph|Line} container The document, page, story, textFrame, paragraph or line instance to iterate the words in.
- * @param  {Function} [cb] The callback function to call with each word. When this function returns false the loop stops. Passed arguments: word, loopCount.
- * @return {Words} A collection of Word objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  words
+ *
+ * @param   {Document|Page|Story|TextFrame|Paragraph|Line} container The
+ *          document, page, story, textFrame, paragraph or line instance to
+ *          iterate the words in.
+ * @param   {Function} [cb] The callback function to call with each word. When
+ *          this function returns false the loop stops. Passed arguments:
+ *          `word`, `loopCount`.
+ * @return  {Words} A collection of Word objects.
  */
 pub.words = function(container, cb) {
 
@@ -138,14 +167,22 @@ pub.words = function(container, cb) {
 };
 
 /**
- * @description If no callback function is given it returns a Collection of characters in the container otherwise calls the given callback function with each character of the given document, page, story, textFrame, paragraph, line or word.
+ * @description If no callback function is given it returns a Collection of
+ *          characters in the container otherwise calls the given callback
+ *          function with each character of the given document, page, story,
+ *          textFrame, paragraph, line or word.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method characters
- * @param  {Document|Page|Story|TextFrame|Paragraph|Line|Word} container The document, page, story, textFrame, paragraph, line or word instance to  iterate the characters in.
- * @param  {Function} [cb] Optional: The callback function to call with each character. When this function returns false the loop stops. Passed arguments: character, loopCount
- * @return {Characters} A collection of Character objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  characters
+ *
+ * @param   {Document|Page|Story|TextFrame|Paragraph|Line|Word} container The
+ *          document, page, story, textFrame, paragraph, line or word instance
+ *          to  iterate the characters in.
+ * @param   {Function} [cb] Optional: The callback function to call with each
+ *          character. When this function returns false the loop stops. Passed
+ *          arguments: `character`, `loopCount`
+ * @return  {Characters} A collection of Character objects.
  */
 pub.characters = function(container, cb) {
 
@@ -156,14 +193,20 @@ pub.characters = function(container, cb) {
 
 
 /**
- * @description If no callback function is given it returns a Collection of items otherwise calls the given callback function for each of the PageItems in the given Document, Page, Layer or Group.
+ * @description If no callback function is given it returns a Collection of
+ *          items otherwise calls the given callback function for each of the
+ *          PageItems in the given Document, Page, Layer or Group.
  *
- * @cat    Document
- * @subcat Multi-Getters
- * @method items
- * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in
- * @param  {Function|Boolean} [cb] Optional: The callback function to call for each PageItem. When this function returns false the loop stops. Passed arguments: item, loopCount.
- * @return {PageItems} A collection of PageItem objects.
+ * @cat     Document
+ * @subcat  Multi-Getters
+ * @method  items
+ *
+ * @param   {Document|Page|Layer|Group} container The container where the
+ *          PageItems sit in
+ * @param   {Function|Boolean} [cb] Optional: The callback function to call for
+ *          each PageItem. When this function returns false the loop stops.
+ *          Passed arguments: `item`, `loopCount`.
+ * @return  {PageItems} A collection of PageItem objects.
  */
 pub.items = function(container, cb) {
 
@@ -184,11 +227,15 @@ pub.items = function(container, cb) {
 
 
 /**
- * @description Removes all PageItems (including locked ones) in the given Document, Page, Layer or Group. If the selected container is a Group, the Group itself will be removed as well.
+ * @description Removes all page items (including locked ones) in the given
+ *          Document, Page, Layer or Group. If the selected container is a
+ *          group, the group itself will be removed as well.
  *
- * @cat    Document
- * @method clear
- * @param  {Document|Page|Layer|Group} container The container where the PageItems sit in.
+ * @cat     Document
+ * @method  clear
+ *
+ * @param   {Document|Page|Layer|Group} container The container where the
+ *          PageItems sit in.
  */
 pub.clear = function(container) {
 
@@ -212,9 +259,10 @@ pub.clear = function(container) {
 /**
  * @description Removes the provided Page, Layer, PageItem, Swatch, etc.
  *
- * @cat    Document
- * @method remove
- * @param  {PageItem} obj The object to be removed.
+ * @cat     Document
+ * @method  remove
+ *
+ * @param   {PageItem} obj The object to be removed.
  */
 pub.remove = function(obj) {
 

--- a/src/includes/transformation.js
+++ b/src/includes/transformation.js
@@ -4,15 +4,27 @@
 /* global precision */
 
 /**
- * @description Sets the reference point for transformations using the `transform()` function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.<br>
- * Arguments can be the basil constants `TOP_LEFT`, `TOP_CENTER`, `TOP_RIGHT`, `CENTER_LEFT`, `CENTER`, `CENTER_RIGHT`, `BOTTOM_LEFT`, `BOTTOM_CENTER` or `BOTTOM_RIGHT`. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.<br>
- * If the function is used without any arguments the currently set reference point will be returned.
+ * @description Sets the reference point for transformations using the
+ *          `transform()` function. The reference point will be used for all
+ *          following transformations, until it is changed again. By default,
+ *          the reference point is set to the top left.<br>
+ *          Arguments can be the
+ *          basil constants `TOP_LEFT`, `TOP_CENTER`, `TOP_RIGHT`,
+ *          `CENTER_LEFT`, `CENTER`, `CENTER_RIGHT`, `BOTTOM_LEFT`,
+ *          `BOTTOM_CENTER` or `BOTTOM_RIGHT`. Alternatively the digits `1`
+ *          through `9` (as they are arranged on a num pad) can be used to set
+ *          the anchor point. Lastly the function can also use an InDesign
+ *          anchor point enumerator to set the reference point.<br>
+ *          If the
+ *          function is used without any arguments the currently set reference
+ *          point will be returned.
  *
- * @cat    Document
- * @subcat Transformation
- * @method referencePoint
- * @param  {String} [referencePoint] The reference point to set.
- * @return {String} Current reference point setting.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  referencePoint
+ *
+ * @param   {String} [referencePoint] The reference point to set.
+ * @return  {String} Current reference point setting.
  */
 pub.referencePoint = function(rp) {
   if(!arguments.length) {
@@ -60,26 +72,46 @@ pub.referencePoint = function(rp) {
 };
 
 /**
- * @description Transforms a given page item. The type of transformation is determinded with the second parameter. The third parameter is the transformation value, either a number or an array of x and y values. The transformation's reference point (top left, bottom center etc.) can be set beforehand by using the `referencePoint()` function. If the third parameter is ommited, the function can be used to measure the value of the page item.
- * There are 10 different transformation types:
- *    - `"translate"`: Translates the page item by the given `[x, y]` values. Returns the coordinates of the page item's anchor point as an array.
- *    - `"rotate"`: Rotates the page item to the given degree value. Returns the page item's rotation value in degrees.
- *    - `"scale"`: Scales the page item to the given `[x, y]` scale factor values. Alternatively, a single scale factor value can be used to scale the page item uniformely. Returns the scale factor values of the page item's current scale as an array.
- *    - `"shear"`: Shears the page item to the given degree value. Returns the page item's shear value in degrees.
- *    - `"size"`: Sets the page item's size to the given `[x, y]` dimensions. Returns the size of the page item as an array.
- *    - `"width"`: Sets the page item's width to the given value. Returns the width of the page item.
- *    - `"height"`: Sets the page item's height to the given value. Returns the height of the page item.
- *    - `"position"`: Sets the position of the page item's anchor point to the given `[x, y]` coordinates. Returns the coordinates of the page item's anchor point as an array.
- *    - `"x"`: Sets the x-position of the page item's anchor point to the given value. Returns the x-coordinate of the page item's anchor point.
- *    - `"y"`: Sets the y-position of the page item's anchor point to the given value. Returns the y-coordinate of the page item's anchor point.
+ * @description Transforms a given page item. The type of transformation is
+ *          determinded with the second parameter. The third parameter is the
+ *          transformation value, either a number or an array of x and y values.
+ *          The transformation's reference point (top left, bottom center etc.)
+ *          can be set beforehand by using the `referencePoint()` function. If
+ *          the third parameter is ommited, the function can be used to measure
+ *          the value of the page item. There are 10 different transformation
+ *          types:
+ *    - `"translate"`: Translates the page item by the given `[x, y]` values.
+ *      Returns the coordinates of the page item's anchor point as an array.
+ *    - `"rotate"`: Rotates the page item to the given degree value. Returns the
+ *      page item's rotation value in degrees.
+ *    - `"scale"`: Scales the page item to the given `[x, y]` scale factor
+ *      values. Alternatively, a single scale factor value can be used to scale
+ *      the page item uniformely. Returns the scale factor values of the page
+ *      item's current scale as an array.
+ *    - `"shear"`: Shears the page item to the given degree value. Returns the
+ *      page item's shear value in degrees.
+ *    - `"size"`: Sets the page item's size to the given `[x, y]` dimensions.
+ *      Returns the size of the page item as an array.
+ *    - `"width"`: Sets the page item's width to the given value. Returns the
+ *      width of the page item.
+ *    - `"height"`: Sets the page item's height to the given value. Returns the
+ *      height of the page item.
+ *    - `"position"`: Sets the position of the page item's anchor point to the
+ *      given `[x, y]` coordinates. Returns the coordinates of the page item's
+ *      anchor point as an array.
+ *    - `"x"`: Sets the x-position of the page item's anchor point to the given
+ *      value. Returns the x-coordinate of the page item's anchor point.
+ *    - `"y"`: Sets the y-position of the page item's anchor point to the given
+ *      value. Returns the y-coordinate of the page item's anchor point.
  *
- * @cat    Document
- * @subcat Transformation
- * @method transform
- * @param  {PageItem} pItem The page item to transform.
- * @param  {String} type The type of transformation.
- * @param  {Number|Array} [value] The value(s) of the transformation.
- * @return {Number|Array} The current value(s) of the specified transformation.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  transform
+ *
+ * @param   {PageItem} pItem The page item to transform.
+ * @param   {String} type The type of transformation.
+ * @param   {Number|Array} [value] The value(s) of the transformation.
+ * @return  {Number|Array} The current value(s) of the specified transformation.
  *
  * @example <caption>Rotating a rectangle to a 25 degrees angle</caption>
  * var r = rect(20, 40, 200, 100);
@@ -90,7 +122,8 @@ pub.referencePoint = function(rp) {
  * var w = transform(r, "width");
  * println(w); // prints the rectangle's random width between 100 and 300
  *
- * @example <caption>Position a rectangle's lower right corner at a certain position</caption>
+ * @example <caption>Position a rectangle's lower right corner at a certain
+ *          position</caption>
  * var r = rect(20, 40, random(100, 300), random(50, 150));
  * referencePoint(BOTTOM_RIGHT);
  * transform(r, "position", [40, 40]);
@@ -419,23 +452,31 @@ Matrix2D.prototype = {
 };
 
 /**
- * @description Multiplies the current matrix by the one specified through the parameters.
+ * @description Multiplies the current matrix by the one specified through the
+ *          parameters.
  *
- * @cat    Document
- * @subcat Transformation
- * @method applyMatrix
- * @param  {Matrix2D} matrix The matrix to be applied.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  applyMatrix
+ *
+ * @param   {Matrix2D} matrix The matrix to be applied.
  */
 pub.applyMatrix = function (matrix) {
   currMatrix.apply(matrix);
 };
 
 /**
- * @description Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
+ * @description Pops the current transformation matrix off the matrix stack.
+ *          Understanding pushing and popping requires understanding the concept
+ *          of a matrix stack. The `pushMatrix()` function saves the current
+ *          coordinate system to the stack and `popMatrix()` restores the prior
+ *          coordinate system. `pushMatrix()` and `popMatrix()` are used in
+ *          conjuction with the other transformation methods and may be embedded
+ *          to control the scope of the transformations.
  *
- * @cat    Document
- * @subcat Transformation
- * @method popMatrix
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  popMatrix
  */
 pub.popMatrix = function () {
   if (matrixStack.length > 0) {
@@ -448,20 +489,27 @@ pub.popMatrix = function () {
 /**
  * @description Prints the current matrix to the console window.
  *
- * @cat    Document
- * @subcat Transformation
- * @method printMatrix
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  printMatrix
  */
 pub.printMatrix = function () {
   currMatrix.print();
 };
 
 /**
- * @description Pushes the current transformation matrix onto the matrix stack. Understanding `pushMatrix()` and `popMatrix()` requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
+ * @description Pushes the current transformation matrix onto the matrix stack.
+ *          Understanding `pushMatrix()` and `popMatrix()` requires
+ *          understanding the concept of a matrix stack. The `pushMatrix()`
+ *          function saves the current coordinate system to the stack and
+ *          `popMatrix()` restores the prior coordinate system. `pushMatrix()`
+ *          and `popMatrix()` are used in conjuction with the other
+ *          transformation methods and may be embedded to control the scope of
+ *          the transformations.
  *
- * @cat    Document
- * @subcat Transformation
- * @method pushMatrix
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  pushMatrix
  */
 pub.pushMatrix = function () {
   matrixStack.push(currMatrix.array());
@@ -470,9 +518,9 @@ pub.pushMatrix = function () {
 /**
  * @description Replaces the current matrix with the identity matrix.
  *
- * @cat    Document
- * @subcat Transformation
- * @method resetMatrix
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  resetMatrix
  */
 pub.resetMatrix = function () {
   matrixStack = [];
@@ -482,12 +530,26 @@ pub.resetMatrix = function () {
 };
 
 /**
- * @description Rotates an object the amount specified by the angle parameter. Angles should be specified in radians (values from 0 to `PI`*2) or converted to radians with the `radians()` function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a clockwise direction with 0 radians or degrees being up and `HALF_PI` being to the right etc. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `rotate(PI/2)` and then `rotate(PI/2)` is the same as `rotate(PI)`. If `rotate()` is called within the `draw()`, the transformation is reset when the loop begins again. Technically, `rotate()` multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
+ * @description Rotates an object the amount specified by the angle parameter.
+ *          Angles should be specified in radians (values from 0 to `PI`*2) or
+ *          converted to radians with the `radians()` function. Objects are
+ *          always rotated around their relative position to the origin and
+ *          positive numbers rotate objects in a clockwise direction with 0
+ *          radians or degrees being up and `HALF_PI` being to the right etc.
+ *          Transformations apply to everything that happens after and
+ *          subsequent calls to the function accumulates the effect. For
+ *          example, calling `rotate(PI/2)` and then `rotate(PI/2)` is the same
+ *          as `rotate(PI)`. If `rotate()` is called within the `draw()`, the
+ *          transformation is reset when the loop begins again. Technically,
+ *          `rotate()` multiplies the current transformation matrix by a
+ *          rotation matrix. This function can be further controlled by the
+ *          `pushMatrix()` and `popMatrix()`.
  *
- * @cat    Document
- * @subcat Transformation
- * @method rotate
- * @param  {Number} angle The angle specified in radians
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  rotate
+ *
+ * @param   {Number} angle The angle specified in radians
  */
 pub.rotate = function (angle) {
   if(typeof arguments[0] === "undefined") {
@@ -497,14 +559,25 @@ pub.rotate = function (angle) {
 };
 
 /**
- * @description Increasing and decreasing the size of an object by expanding and contracting vertices. Scale values are specified as decimal percentages. The function call `scale(2.0)` increases the dimension of a shape by 200%. Objects always scale from their relative origin to the coordinate system. Transformations apply to everything that happens after and subsequent calls to the function multiply the effect. For example, calling `scale(2.0)` and then `scale(1.5)` is the same as `scale(3.0)`. If `scale()` is called within `draw()`, the transformation is reset when the loop begins again. This function can be further controlled by `pushMatrix()` and `popMatrix()`.
- * If only one parameter is given, it is applied on X and Y axis.
+ * @description Increasing and decreasing the size of an object by expanding and
+ *          contracting vertices. Scale values are specified as decimal
+ *          percentages. The function call `scale(2.0)` increases the dimension
+ *          of a shape by 200%. Objects always scale from their relative origin
+ *          to the coordinate system. Transformations apply to everything that
+ *          happens after and subsequent calls to the function multiply the
+ *          effect. For example, calling `scale(2.0)` and then `scale(1.5)` is
+ *          the same as `scale(3.0)`. If `scale()` is called within `draw()`,
+ *          the transformation is reset when the loop begins again. This
+ *          function can be further controlled by `pushMatrix()` and
+ *          `popMatrix()`. If only one parameter is given, it is applied on X
+ *          and Y axis.
  *
- * @cat    Document
- * @subcat Transformation
- * @method scale
- * @param  {Number} scaleX The amount to scale the X axis.
- * @param  {Number} scaleY The amount to scale the Y axis.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  scale
+ *
+ * @param   {Number} scaleX The amount to scale the X axis.
+ * @param   {Number} scaleY The amount to scale the Y axis.
  */
 pub.scale = function (scaleX, scaleY) {
   if(typeof arguments[0] != "number" || (arguments.length === 2 && typeof arguments[1] != "number")) {
@@ -514,13 +587,20 @@ pub.scale = function (scaleX, scaleY) {
 };
 
 /**
- * @description Specifies an amount to displace objects within the page. The x parameter specifies left/right translation, the y parameter specifies up/down translation. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `translate(50, 0)` and then `translate(20, 0)` is the same as `translate(70, 0)`. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
+ * @description Specifies an amount to displace objects within the page. The `x`
+ *          parameter specifies left/right translation, the `y` parameter
+ *          specifies up/down translation. Transformations apply to everything
+ *          that happens after and subsequent calls to the function accumulates
+ *          the effect. For example, calling `translate(50, 0)` and then
+ *          `translate(20, 0)` is the same as `translate(70, 0)`. This function
+ *          can be further controlled by the `pushMatrix()` and `popMatrix()`.
  *
- * @cat    Document
- * @subcat Transformation
- * @method translate
- * @param  {Number} tx The amount of offset on the X axis.
- * @param  {Number} ty The amount of offset on the Y axis.
+ * @cat     Document
+ * @subcat  Transformation
+ * @method  translate
+ *
+ * @param   {Number} tx The amount of offset on the X axis.
+ * @param   {Number} ty The amount of offset on the Y axis.
  */
 pub.translate = function (tx, ty) {
   if(typeof arguments[0] === "undefined" || typeof arguments[1] === "undefined") {

--- a/src/includes/transformation.js
+++ b/src/includes/transformation.js
@@ -4,15 +4,15 @@
 /* global precision */
 
 /**
- * @description Sets the reference point for transformations using the <code>transform()</code> function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.
- * Arguments can be the basil constants <code>TOP_LEFT</code>, <code>TOP_CENTER</code>, <code>TOP_RIGHT</code>, <code>CENTER_LEFT</code>, <code>CENTER</code>, <code>CENTER_RIGHT</code>, <code>BOTTOM_LEFT</code>, <code>BOTTOM_CENTER</code> or <code>BOTTOM_RIGHT</code>. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.
+ * @description Sets the reference point for transformations using the <code>transform()</code> function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.<br>
+ * Arguments can be the basil constants <code>TOP_LEFT</code>, <code>TOP_CENTER</code>, <code>TOP_RIGHT</code>, <code>CENTER_LEFT</code>, <code>CENTER</code>, <code>CENTER_RIGHT</code>, <code>BOTTOM_LEFT</code>, <code>BOTTOM_CENTER</code> or <code>BOTTOM_RIGHT</code>. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.<br>
  * If the function is used without any arguments the currently set reference point will be returned.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method referencePoint
- * @param {String} [referencePoint] The reference point to set.
- * @returns {String} Current reference point setting.
+ * @param  {String} [referencePoint] The reference point to set.
+ * @return {String} Current reference point setting.
  */
 pub.referencePoint = function(rp) {
   if(!arguments.length) {
@@ -75,13 +75,13 @@ pub.referencePoint = function(rp) {
  * <li> <code>"y"</code>: Sets the y-position of the page item's anchor point to the given value. Returns the y-coordinate of the page item's anchor point.</li>
  * </ul>
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method transform
- * @param {PageItem} pItem The page item to transform.
- * @param {String} type The type of transformation.
- * @param {Number|Array} [value] The value(s) of the transformation.
- * @returns {Number|Array} The current value(s) of the specified transformation.
+ * @param  {PageItem} pItem The page item to transform.
+ * @param  {String} type The type of transformation.
+ * @param  {Number|Array} [value] The value(s) of the transformation.
+ * @return {Number|Array} The current value(s) of the specified transformation.
  *
  * @example <caption>Rotating a rectangle to a 25 degrees angle</caption>
  * var r = rect(20, 40, 200, 100);
@@ -97,7 +97,6 @@ pub.referencePoint = function(rp) {
  * referencePoint(BOTTOM_RIGHT);
  * transform(r, "position", [40, 40]);
  */
-
 pub.transform = function(pItem, type, value) {
 
   if(!pItem || !pItem.hasOwnProperty("geometricBounds")) {
@@ -422,12 +421,12 @@ Matrix2D.prototype = {
 };
 
 /**
- *@description Multiplies the current matrix by the one specified through the parameters.
+ * @description Multiplies the current matrix by the one specified through the parameters.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method applyMatrix
- * @param {Matrix2D} matrix The matrix to be applied.
+ * @param  {Matrix2D} matrix The matrix to be applied.
  */
 pub.applyMatrix = function (matrix) {
   currMatrix.apply(matrix);
@@ -436,7 +435,7 @@ pub.applyMatrix = function (matrix) {
 /**
  * @description Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires understanding the concept of a matrix stack. The <code>pushMatrix()</code> function saves the current coordinate system to the stack and <code>popMatrix()</code> restores the prior coordinate system. <code>pushMatrix()</code> and <code>popMatrix()</code> are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method popMatrix
  */
@@ -449,9 +448,9 @@ pub.popMatrix = function () {
 };
 
 /**
- * Prints the current matrix to the console window.
+ * @description Prints the current matrix to the console window.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method printMatrix
  */
@@ -462,7 +461,7 @@ pub.printMatrix = function () {
 /**
  * @description Pushes the current transformation matrix onto the matrix stack. Understanding <code>pushMatrix()</code> and <code>popMatrix()</code> requires understanding the concept of a matrix stack. The <code>pushMatrix()</code> function saves the current coordinate system to the stack and <code>popMatrix()</code> restores the prior coordinate system. <code>pushMatrix()</code> and <code>popMatrix()</code> are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method pushMatrix
  */
@@ -471,9 +470,9 @@ pub.pushMatrix = function () {
 };
 
 /**
- * Replaces the current matrix with the identity matrix.
+ * @description Replaces the current matrix with the identity matrix.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method resetMatrix
  */
@@ -487,10 +486,10 @@ pub.resetMatrix = function () {
 /**
  * @description Rotates an object the amount specified by the angle parameter. Angles should be specified in radians (values from 0 to <code>PI</code>*2) or converted to radians with the <code>radians()</code> function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a clockwise direction with 0 radians or degrees being up and <code>HALF_PI</code> being to the right etc. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <code>rotate(PI/2)</code> and then <code>rotate(PI/2)</code> is the same as <code>rotate(PI)</code>. If <code>rotate()</code> is called within the <code>draw()</code>, the transformation is reset when the loop begins again. Technically, <code>rotate()</code> multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by the <code>pushMatrix()</code> and <code>popMatrix()</code>.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method rotate
- * @param {Number} angle The angle specified in radians
+ * @param  {Number} angle The angle specified in radians
  */
 pub.rotate = function (angle) {
   if(typeof arguments[0] === "undefined") {
@@ -503,11 +502,11 @@ pub.rotate = function (angle) {
  * @description Increasing and decreasing the size of an object by expanding and contracting vertices. Scale values are specified as decimal percentages. The function call <code>scale(2.0)</code> increases the dimension of a shape by 200%. Objects always scale from their relative origin to the coordinate system. Transformations apply to everything that happens after and subsequent calls to the function multiply the effect. For example, calling <code>scale(2.0)</code> and then <code>scale(1.5)</code> is the same as <code>scale(3.0)</code>. If <code>scale()</code> is called within <code>draw()</code>, the transformation is reset when the loop begins again. This function can be further controlled by <code>pushMatrix()</code> and <code>popMatrix()</code>.
  * If only one parameter is given, it is applied on X and Y axis.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method scale
- * @param {Number} scaleX The amount to scale the X axis.
- * @param {Number} scaleY The amount to scale the Y axis.
+ * @param  {Number} scaleX The amount to scale the X axis.
+ * @param  {Number} scaleY The amount to scale the Y axis.
  */
 pub.scale = function (scaleX, scaleY) {
   if(typeof arguments[0] != "number" || (arguments.length === 2 && typeof arguments[1] != "number")) {
@@ -519,11 +518,11 @@ pub.scale = function (scaleX, scaleY) {
 /**
  * @description Specifies an amount to displace objects within the page. The x parameter specifies left/right translation, the y parameter specifies up/down translation. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <code>translate(50, 0)</code> and then <code>translate(20, 0)</code> is the same as <code>translate(70, 0)</code>. This function can be further controlled by the <code>pushMatrix()</code> and <code>popMatrix()</code>.
  *
- * @cat Document
+ * @cat    Document
  * @subcat Transformation
  * @method translate
- * @param {Number} tx The amount of offset on the X axis.
- * @param {Number} ty The amount of offset on the Y axis.
+ * @param  {Number} tx The amount of offset on the X axis.
+ * @param  {Number} ty The amount of offset on the Y axis.
  */
 pub.translate = function (tx, ty) {
   if(typeof arguments[0] === "undefined" || typeof arguments[1] === "undefined") {

--- a/src/includes/transformation.js
+++ b/src/includes/transformation.js
@@ -4,8 +4,8 @@
 /* global precision */
 
 /**
- * @description Sets the reference point for transformations using the <code>transform()</code> function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.<br>
- * Arguments can be the basil constants <code>TOP_LEFT</code>, <code>TOP_CENTER</code>, <code>TOP_RIGHT</code>, <code>CENTER_LEFT</code>, <code>CENTER</code>, <code>CENTER_RIGHT</code>, <code>BOTTOM_LEFT</code>, <code>BOTTOM_CENTER</code> or <code>BOTTOM_RIGHT</code>. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.<br>
+ * @description Sets the reference point for transformations using the `transform()` function. The reference point will be used for all following transformations, until it is changed again. By default, the reference point is set to the top left.<br>
+ * Arguments can be the basil constants `TOP_LEFT`, `TOP_CENTER`, `TOP_RIGHT`, `CENTER_LEFT`, `CENTER`, `CENTER_RIGHT`, `BOTTOM_LEFT`, `BOTTOM_CENTER` or `BOTTOM_RIGHT`. Alternatively the digits 1 through 9 (as they are arranged on a num pad) can be used to set the anchor point. Lastly the function can also use an InDesign anchor point enumerator to set the reference point.<br>
  * If the function is used without any arguments the currently set reference point will be returned.
  *
  * @cat    Document
@@ -60,20 +60,18 @@ pub.referencePoint = function(rp) {
 };
 
 /**
- * @description Transforms a given page item. The type of transformation is determinded with the second parameter. The third parameter is the transformation value, either a number or an array of x and y values. The transformation's reference point (top left, bottom center etc.) can be set beforehand by using the <code>referencePoint()</code> function. If the third parameter is ommited, the function can be used to measure the value of the page item.
+ * @description Transforms a given page item. The type of transformation is determinded with the second parameter. The third parameter is the transformation value, either a number or an array of x and y values. The transformation's reference point (top left, bottom center etc.) can be set beforehand by using the `referencePoint()` function. If the third parameter is ommited, the function can be used to measure the value of the page item.
  * There are 10 different transformation types:
- * <ul>
- * <li> <code>"translate"</code>: Translates the page item by the given <code>[x, y]</code> values. Returns the coordinates of the page item's anchor point as an array.</li>
- * <li> <code>"rotate"</code>: Rotates the page item to the given degree value. Returns the page item's rotation value in degrees.</li>
- * <li> <code>"scale"</code>: Scales the page item to the given <code>[x, y]</code> scale factor values. Alternatively, a single scale factor value can be used to scale the page item uniformely. Returns the scale factor values of the page item's current scale as an array.</li>
- * <li> <code>"shear"</code>: Shears the page item to the given degree value. Returns the page item's shear value in degrees.</li>
- * <li> <code>"size"</code>: Sets the page item's size to the given <code>[x, y]</code> dimensions. Returns the size of the page item as an array.</li>
- * <li> <code>"width"</code>: Sets the page item's width to the given value. Returns the width of the page item.</li>
- * <li> <code>"height"</code>: Sets the page item's height to the given value. Returns the height of the page item.</li>
- * <li> <code>"position"</code>: Sets the position of the page item's anchor point to the given <code>[x, y]</code> coordinates. Returns the coordinates of the page item's anchor point as an array.</li>
- * <li> <code>"x"</code>: Sets the x-position of the page item's anchor point to the given value. Returns the x-coordinate of the page item's anchor point.</li>
- * <li> <code>"y"</code>: Sets the y-position of the page item's anchor point to the given value. Returns the y-coordinate of the page item's anchor point.</li>
- * </ul>
+ *    - `"translate"`: Translates the page item by the given `[x, y]` values. Returns the coordinates of the page item's anchor point as an array.
+ *    - `"rotate"`: Rotates the page item to the given degree value. Returns the page item's rotation value in degrees.
+ *    - `"scale"`: Scales the page item to the given `[x, y]` scale factor values. Alternatively, a single scale factor value can be used to scale the page item uniformely. Returns the scale factor values of the page item's current scale as an array.
+ *    - `"shear"`: Shears the page item to the given degree value. Returns the page item's shear value in degrees.
+ *    - `"size"`: Sets the page item's size to the given `[x, y]` dimensions. Returns the size of the page item as an array.
+ *    - `"width"`: Sets the page item's width to the given value. Returns the width of the page item.
+ *    - `"height"`: Sets the page item's height to the given value. Returns the height of the page item.
+ *    - `"position"`: Sets the position of the page item's anchor point to the given `[x, y]` coordinates. Returns the coordinates of the page item's anchor point as an array.
+ *    - `"x"`: Sets the x-position of the page item's anchor point to the given value. Returns the x-coordinate of the page item's anchor point.
+ *    - `"y"`: Sets the y-position of the page item's anchor point to the given value. Returns the y-coordinate of the page item's anchor point.
  *
  * @cat    Document
  * @subcat Transformation
@@ -433,7 +431,7 @@ pub.applyMatrix = function (matrix) {
 };
 
 /**
- * @description Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires understanding the concept of a matrix stack. The <code>pushMatrix()</code> function saves the current coordinate system to the stack and <code>popMatrix()</code> restores the prior coordinate system. <code>pushMatrix()</code> and <code>popMatrix()</code> are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
+ * @description Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
  *
  * @cat    Document
  * @subcat Transformation
@@ -459,7 +457,7 @@ pub.printMatrix = function () {
 };
 
 /**
- * @description Pushes the current transformation matrix onto the matrix stack. Understanding <code>pushMatrix()</code> and <code>popMatrix()</code> requires understanding the concept of a matrix stack. The <code>pushMatrix()</code> function saves the current coordinate system to the stack and <code>popMatrix()</code> restores the prior coordinate system. <code>pushMatrix()</code> and <code>popMatrix()</code> are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
+ * @description Pushes the current transformation matrix onto the matrix stack. Understanding `pushMatrix()` and `popMatrix()` requires understanding the concept of a matrix stack. The `pushMatrix()` function saves the current coordinate system to the stack and `popMatrix()` restores the prior coordinate system. `pushMatrix()` and `popMatrix()` are used in conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
  *
  * @cat    Document
  * @subcat Transformation
@@ -484,7 +482,7 @@ pub.resetMatrix = function () {
 };
 
 /**
- * @description Rotates an object the amount specified by the angle parameter. Angles should be specified in radians (values from 0 to <code>PI</code>*2) or converted to radians with the <code>radians()</code> function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a clockwise direction with 0 radians or degrees being up and <code>HALF_PI</code> being to the right etc. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <code>rotate(PI/2)</code> and then <code>rotate(PI/2)</code> is the same as <code>rotate(PI)</code>. If <code>rotate()</code> is called within the <code>draw()</code>, the transformation is reset when the loop begins again. Technically, <code>rotate()</code> multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by the <code>pushMatrix()</code> and <code>popMatrix()</code>.
+ * @description Rotates an object the amount specified by the angle parameter. Angles should be specified in radians (values from 0 to `PI`*2) or converted to radians with the `radians()` function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a clockwise direction with 0 radians or degrees being up and `HALF_PI` being to the right etc. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `rotate(PI/2)` and then `rotate(PI/2)` is the same as `rotate(PI)`. If `rotate()` is called within the `draw()`, the transformation is reset when the loop begins again. Technically, `rotate()` multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
  *
  * @cat    Document
  * @subcat Transformation
@@ -499,7 +497,7 @@ pub.rotate = function (angle) {
 };
 
 /**
- * @description Increasing and decreasing the size of an object by expanding and contracting vertices. Scale values are specified as decimal percentages. The function call <code>scale(2.0)</code> increases the dimension of a shape by 200%. Objects always scale from their relative origin to the coordinate system. Transformations apply to everything that happens after and subsequent calls to the function multiply the effect. For example, calling <code>scale(2.0)</code> and then <code>scale(1.5)</code> is the same as <code>scale(3.0)</code>. If <code>scale()</code> is called within <code>draw()</code>, the transformation is reset when the loop begins again. This function can be further controlled by <code>pushMatrix()</code> and <code>popMatrix()</code>.
+ * @description Increasing and decreasing the size of an object by expanding and contracting vertices. Scale values are specified as decimal percentages. The function call `scale(2.0)` increases the dimension of a shape by 200%. Objects always scale from their relative origin to the coordinate system. Transformations apply to everything that happens after and subsequent calls to the function multiply the effect. For example, calling `scale(2.0)` and then `scale(1.5)` is the same as `scale(3.0)`. If `scale()` is called within `draw()`, the transformation is reset when the loop begins again. This function can be further controlled by `pushMatrix()` and `popMatrix()`.
  * If only one parameter is given, it is applied on X and Y axis.
  *
  * @cat    Document
@@ -516,7 +514,7 @@ pub.scale = function (scaleX, scaleY) {
 };
 
 /**
- * @description Specifies an amount to displace objects within the page. The x parameter specifies left/right translation, the y parameter specifies up/down translation. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <code>translate(50, 0)</code> and then <code>translate(20, 0)</code> is the same as <code>translate(70, 0)</code>. This function can be further controlled by the <code>pushMatrix()</code> and <code>popMatrix()</code>.
+ * @description Specifies an amount to displace objects within the page. The x parameter specifies left/right translation, the y parameter specifies up/down translation. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling `translate(50, 0)` and then `translate(20, 0)` is the same as `translate(70, 0)`. This function can be further controlled by the `pushMatrix()` and `popMatrix()`.
  *
  * @cat    Document
  * @subcat Transformation

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -3,22 +3,25 @@
 // ----------------------------------------
 
 /**
- * @description Creates a text frame on the current layer on the current page in the current document.
- * The text frame gets created in the position specified by the x and y parameters.
- * The default document font will be used unless a font is set with the textFont() function.
- * The default document font size will be used unless a font size is set with the textSize() function.
- * Change the color of the text with the fill() function.
- * The text displays in relation to the textAlign() and textYAlign() functions.
- * The width and height parameters define a rectangular area.
+ * @description Creates a text frame on the current layer on the current page in
+ *          the current document. The text frame gets created in the position
+ *          specified by the `x` and `y` parameters. The default document font
+ *          will be used unless a font is set with the `textFont()` function.
+ *          The default document font size will be used unless a font size is
+ *          set with the `textSize()` function. Change the color of the text
+ *          with the `fill()` function. The text displays in relation to the
+ *          `textAlign()` and `textYAlign()` functions. The `width` and `height`
+ *          parameters define a rectangular area.
  *
- * @cat    Typography
- * @method text
- * @param  {String} txt The text content to set in the text frame.
- * @param  {Number} x   x-coordinate of text frame
- * @param  {Number} y   y-coordinate of text frame
- * @param  {Number} w   width of text frame
- * @param  {Number} h   height of text frame
- * @return {TextFrame}  The created text frame instance
+ * @cat     Typography
+ * @method  text
+ *
+ * @param   {String} txt The text content to set in the text frame.
+ * @param   {Number} x x-coordinate of text frame
+ * @param   {Number} y y-coordinate of text frame
+ * @param   {Number} w width of text frame
+ * @param   {Number} h height of text frame
+ * @return  {TextFrame} The created text frame instance
  */
 pub.text = function(txt, x, y, w, h) {
   if (arguments.length !== 5) {
@@ -81,21 +84,29 @@ pub.text = function(txt, x, y, w, h) {
 };
 
 /**
- * @description Sets text properties to the given item. If the item is not an instance the text property can be set to,
- * the property gets set to the direct descendants of the given item, e.g. all stories of a given document.
- * <br><br>
- * If no value is given and the given property is a string, the function acts as a getter and returns the
- * corresponding value(s) in an array. This can either be an array containing the value of the concrete item
- * (e.g. character) the values of the item's descendants (e.g. paragraphs of given text frame).
+ * @description Sets text properties to the given item. If the item is not an
+ *          instance the text property can be set to, the property gets set to
+ *          the direct descendants of the given item, e.g. all stories of a
+ *          given document.
+ *          <br><br>
+ *          If no value is given and the given property
+ *          is a string, the function acts as a getter and returns the
+ *          corresponding value(s) in an array. This can either be an array
+ *          containing the value of the concrete item (e.g. character) the
+ *          values of the item's descendants (e.g. paragraphs of given text
+ *          frame).
  *
- * @cat    Typography
- * @method typo
- * @param  {Document|Spread|Page|Layer|Story|TextFrame|Text} item  The object to apply the property to.
- * @param  {String|Object} property  The text property name or an object of key/value property/value pairs.
- *                                   If property is a string and no value is given, the function acts as getter.
- * @param  {String|Number|Object} [value]  The value to apply to the property.
- * @return {String[]|Number[]|Object[]}  The property value(s) if the function acts as getter or the items the property
- *                                       was assigned to.
+ * @cat     Typography
+ * @method  typo
+ *
+ * @param   {Document|Spread|Page|Layer|Story|TextFrame|Text} item The object to
+ *          apply the property to.
+ * @param   {String|Object} property The text property name or an object of
+ *          key/value property/value pairs. If property is a string and no value
+ *          is given, the function acts as getter.
+ * @param   {String|Number|Object} [value] The value to apply to the property.
+ * @return  {String[]|Number[]|Object[]} The property value(s) if the function
+ *          acts as getter or the items the property was assigned to.
  */
 pub.typo = function(item, property, value) {
   var result = [],
@@ -168,13 +179,15 @@ var isValid = function (item) {
 };
 
 /**
- * @description Returns the current font and sets it if argument fontName is given.
+ * @description Returns the current font and sets it if argument `fontName` is
+ *          given.
  *
- * @cat    Typography
- * @method textFont
- * @param  {String} [fontName] The name of the font to set e.g. Helvetica
- * @param  {String} [fontStyle] The font style e.g. Bold
- * @return {Font} The current font object
+ * @cat     Typography
+ * @method  textFont
+ *
+ * @param   {String} [fontName] The name of the font to set e.g. Helvetica
+ * @param   {String} [fontStyle] The font style e.g. Bold
+ * @return  {Font} The current font object
  */
 pub.textFont = function(fontName, fontStyle) {
 
@@ -199,12 +212,14 @@ pub.textFont = function(fontName, fontStyle) {
 };
 
 /**
- * @description Returns the current font size in points and sets it if argument pointSize is given.
+ * @description Returns the current font size in points and sets it if argument
+ *          `pointSize` is given.
  *
- * @cat    Typography
- * @method textSize
- * @param  {Number} [pointSize] The size in points to set.
- * @return {Number}             The current point size.
+ * @cat     Typography
+ * @method  textSize
+ *
+ * @param   {Number} [pointSize] The size in points to set.
+ * @return  {Number} The current point size.
  */
 pub.textSize = function(pointSize) {
   if (arguments.length === 1) {
@@ -216,22 +231,25 @@ pub.textSize = function(pointSize) {
 /**
  * @description Sets the current horizontal and vertical text alignment.
  *
- * @cat    Typography
- * @method textAlign
- * @param  {String} align    The horizontal text alignment to set. Must be one of the InDesign Justification enum values:
- *                           Justification.AWAY_FROM_BINDING_SIDE<br>
- *                           Justification.CENTER_ALIGN<br>
- *                           Justification.CENTER_JUSTIFIED<br>
- *                           Justification.FULLY_JUSTIFIED<br>
- *                           Justification.LEFT_ALIGN<br>
- *                           Justification.RIGHT_ALIGN<br>
- *                           Justification.RIGHT_JUSTIFIED<br>
- *                           Justification.TO_BINDING_SIDE<br>
- * @param  {String} [yAlign] The vertical text alignment to set. Must be one of the InDesign VerticalJustification enum values:
- *                           VerticalJustification.BOTTOM_ALIGN<br>
- *                           VerticalJustification.CENTER_ALIGN<br>
- *                           VerticalJustification.JUSTIFY_ALIGN<br>
- *                           VerticalJustification.TOP_ALIGN<br>
+ * @cat     Typography
+ * @method  textAlign
+ *
+ * @param   {String} align The horizontal text alignment to set. Must be one of
+ *          the InDesign Justification enum values:
+ *      - `Justification.AWAY_FROM_BINDING_SIDE`
+ *      - `Justification.CENTER_ALIGN`
+ *      - `Justification.CENTER_JUSTIFIED`
+ *      - `Justification.FULLY_JUSTIFIED`
+ *      - `Justification.LEFT_ALIGN`
+ *      - `Justification.RIGHT_ALIGN`
+ *      - `Justification.RIGHT_JUSTIFIED`
+ *      - `Justification.TO_BINDING_SIDE`
+ * @param   {String} [yAlign] The vertical text alignment to set. Must be one of
+ *          the InDesign VerticalJustification enum values:
+ *      - `VerticalJustification.BOTTOM_ALIGN`
+ *      - `VerticalJustification.CENTER_ALIGN`
+ *      - `VerticalJustification.JUSTIFY_ALIGN`
+ *      - `VerticalJustification.TOP_ALIGN`
  */
 pub.textAlign = function(align, yAlign) {
   currAlign = align;
@@ -239,13 +257,15 @@ pub.textAlign = function(align, yAlign) {
 };
 
 /**
- * @description Returns the spacing between lines of text in units of points and sets it if argument leading is given.
+ * @description Returns the spacing between lines of text in units of points and
+ *          sets it if argument `leading` is given.
  *
- * @cat    Typography
- * @method textLeading
- * @param  {Number|String} [leading] The spacing between lines of text in units of points or the default InDesign enum
- *                                   value Leading.AUTO.
- * @return {Number|String}           The current leading.
+ * @cat     Typography
+ * @method  textLeading
+ *
+ * @param   {Number|String} [leading] The spacing between lines of text in units
+ *          of points or the default InDesign enum value `Leading.AUTO`.
+ * @return  {Number|String} The current leading.
  */
 pub.textLeading = function(leading) {
   if (arguments.length === 1) {
@@ -255,12 +275,14 @@ pub.textLeading = function(leading) {
 };
 
 /**
- * @description Returns the current kerning and sets it if argument kerning is given.
+ * @description Returns the current kerning and sets it if argument `kerning` is
+ *          given.
  *
- * @cat    Typography
- * @method textKerning
- * @param  {Number} [kerning] The value to set.
- * @return {Number}           The current kerning.
+ * @cat     Typography
+ * @method  textKerning
+ *
+ * @param   {Number} [kerning] The value to set.
+ * @return  {Number} The current kerning.
  */
 pub.textKerning = function(kerning) {
   if (arguments.length === 1) {
@@ -270,12 +292,14 @@ pub.textKerning = function(kerning) {
 };
 
 /**
- * @description Returns the current tracking and sets it if argument tracking is given.
+ * @description Returns the current tracking and sets it if argument `tracking`
+ *          is given.
  *
- * @cat    Typography
- * @method textTracking
- * @param  {Number} [tracking] The value to set.
- * @return {Number}            The current tracking.
+ * @cat     Typography
+ * @method  textTracking
+ *
+ * @param   {Number} [tracking] The value to set.
+ * @return  {Number} The current tracking.
  */
 pub.textTracking = function(tracking) {
   if (arguments.length === 1) {
@@ -285,15 +309,20 @@ pub.textTracking = function(tracking) {
 };
 
 /**
- * @description Returns the character style of a given text object or the character style with the given name. If a
- * character style of the given name does not exist, it gets created. Optionally a props object of
- * property name/value pairs can be used to set the character style's properties.
+ * @description Returns the character style of a given text object or the
+ *          character style with the given name. If a character style of the
+ *          given name does not exist, it gets created. Optionally a props
+ *          object of property name/value pairs can be used to set the character
+ *          style's properties.
  *
- * @cat    Typography
- * @method characterStyle
- * @param  {Text|String} textOrName  A text object whose style to return or the name of the character style to return.
- * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
- * @return {CharacterStyle}  The character style instance.
+ * @cat     Typography
+ * @method  characterStyle
+ *
+ * @param   {Text|String} textOrName A text object whose style to return or the
+ *          name of the character style to return.
+ * @param   {Object} [props] Optional: An object of property name/value pairs to
+ *          set the style's properties.
+ * @return  {CharacterStyle} The character style instance.
  */
 pub.characterStyle = function(textOrName, props) {
   var styleErrorMsg = "characterStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
@@ -328,14 +357,18 @@ pub.characterStyle = function(textOrName, props) {
 };
 
 /**
- * @description Applies a character style to the given text object, text frame or story. The character style
- * can be given as name or as character style instance.
+ * @description Applies a character style to the given text object, text frame
+ *          or story. The character style can be given as name or as character
+ *          style instance.
  *
- * @cat    Typography
- * @method applyCharacterStyle
- * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
- * @param  {CharacterStyle|String} style  A character style instance or the name of the character style to apply.
- * @return {Text}  The text that the style was applied to.
+ * @cat     Typography
+ * @method  applyCharacterStyle
+ *
+ * @param   {TextFrame|TextObject|Story} text The text frame, text object or
+ *          story to apply the style to.
+ * @param   {CharacterStyle|String} style A character style instance or the name
+ *          of the character style to apply.
+ * @return  {Text} The text that the style was applied to.
  */
 
 pub.applyCharacterStyle = function(text, style) {
@@ -362,15 +395,20 @@ pub.applyCharacterStyle = function(text, style) {
 };
 
 /**
- * @description Returns the paragraph style of a given text object or the paragraph style with the given name. If a
- * paragraph style of the given name does not exist, it gets created. Optionally a props object of
- * property name/value pairs can be used to set the paragraph style's properties.
+ * @description Returns the paragraph style of a given text object or the
+ *          paragraph style with the given name. If a paragraph style of the
+ *          given name does not exist, it gets created. Optionally a props
+ *          object of property name/value pairs can be used to set the paragraph
+ *          style's properties.
  *
- * @cat    Typography
- * @method paragraphStyle
- * @param  {Text|String} textOrName  A text object whose style to return or the name of the paragraph style to return.
- * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
- * @return {ParagraphStyle}  The paragraph style instance.
+ * @cat     Typography
+ * @method  paragraphStyle
+ *
+ * @param   {Text|String} textOrName A text object whose style to return or the
+ *          name of the paragraph style to return.
+ * @param   {Object} [props] Optional: An object of property name/value pairs to
+ *          set the style's properties.
+ * @return  {ParagraphStyle} The paragraph style instance.
  */
 pub.paragraphStyle = function(textOrName, props) {
   var styleErrorMsg = "paragraphStyle(), wrong parameters. Use: textObject|name and props. Props is optional.";
@@ -405,14 +443,18 @@ pub.paragraphStyle = function(textOrName, props) {
 };
 
 /**
- * @description Applies a paragraph style to the given text object, text frame or story. The paragraph style
- * can be given as name or as paragraph style instance.
+ * @description Applies a paragraph style to the given text object, text frame
+ *          or story. The paragraph style can be given as name or as paragraph
+ *          style instance.
  *
- * @cat    Typography
- * @method applyParagraphStyle
- * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
- * @param  {ParagraphStyle|String} style  A paragraph style instance or the name of the paragraph style to apply.
- * @return {Text}  The text that the style was applied to.
+ * @cat     Typography
+ * @method  applyParagraphStyle
+ *
+ * @param   {TextFrame|TextObject|Story} text The text frame, text object or
+ *          story to apply the style to.
+ * @param   {ParagraphStyle|String} style A paragraph style instance or the name
+ *          of the paragraph style to apply.
+ * @return  {Text} The text that the style was applied to.
  */
 
 pub.applyParagraphStyle = function(text, style) {
@@ -439,12 +481,14 @@ pub.applyParagraphStyle = function(text, style) {
 };
 
 /**
- * @description Links the stories of two textframes to one story. Text of first textframe overflows to second one.
+ * @description Links the stories of two textframes to one story. Text of first
+ *          textframe overflows to second one.
  *
- * @cat    Story
- * @method linkTextFrames
- * @param  {TextFrame} textFrameA
- * @param  {TextFrame} textFrameB
+ * @cat     Story
+ * @method  linkTextFrames
+ *
+ * @param   {TextFrame} textFrameA
+ * @param   {TextFrame} textFrameB
  */
 pub.linkTextFrames = function (textFrameA, textFrameB) {
   if (textFrameA instanceof TextFrame && textFrameB instanceof TextFrame) {
@@ -455,12 +499,15 @@ pub.linkTextFrames = function (textFrameA, textFrameB) {
 };
 
 /**
- * @description Fills the given textFrame and all linked textFrame with random placeholder text. The placeholder text will be added at the end of any already existing text in the text frame.
+ * @description Fills the given text frame and all linked text frames with
+ *          random placeholder text. The placeholder text will be added at the
+ *          end of any already existing text in the text frame.
  *
- * @cat    Story
- * @method placeholder
- * @param  {TextFrame} textFrame
- * @return {Text} The inserted placeholder text.
+ * @cat     Story
+ * @method  placeholder
+ *
+ * @param   {TextFrame} textFrame The text frame to fill.
+ * @return  {Text} The inserted placeholder text.
  */
 pub.placeholder = function (textFrame) {
   if (textFrame instanceof TextFrame) {

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -3,7 +3,7 @@
 // ----------------------------------------
 
 /**
- * Creates a text frame on the current layer on the current page in the current document.
+ * @description Creates a text frame on the current layer on the current page in the current document.
  * The text frame gets created in the position specified by the x and y parameters.
  * The default document font will be used unless a font is set with the textFont() function.
  * The default document font size will be used unless a font size is set with the textSize() function.
@@ -11,7 +11,7 @@
  * The text displays in relation to the textAlign() and textYAlign() functions.
  * The width and height parameters define a rectangular area.
  *
- * @cat Typography
+ * @cat    Typography
  * @method text
  * @param  {String} txt The text content to set in the text frame.
  * @param  {Number} x   x-coordinate of text frame
@@ -81,14 +81,14 @@ pub.text = function(txt, x, y, w, h) {
 };
 
 /**
- * Sets text properties to the given item. If the item is not an instance the text property can be set to,
+ * @description Sets text properties to the given item. If the item is not an instance the text property can be set to,
  * the property gets set to the direct descendants of the given item, e.g. all stories of a given document.
- *
+ * <br><br>
  * If no value is given and the given property is a string, the function acts as a getter and returns the
  * corresponding value(s) in an array. This can either be an array containing the value of the concrete item
  * (e.g. character) the values of the item's descendants (e.g. paragraphs of given text frame).
  *
- * @cat Typography
+ * @cat    Typography
  * @method typo
  * @param  {Document|Spread|Page|Layer|Story|TextFrame|Text} item  The object to apply the property to.
  * @param  {String|Object} property  The text property name or an object of key/value property/value pairs.
@@ -168,9 +168,9 @@ var isValid = function (item) {
 };
 
 /**
- * Returns the current font and sets it if argument fontName is given.
+ * @description Returns the current font and sets it if argument fontName is given.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textFont
  * @param  {String} [fontName] The name of the font to set e.g. Helvetica
  * @param  {String} [fontStyle] The font style e.g. Bold
@@ -199,9 +199,9 @@ pub.textFont = function(fontName, fontStyle) {
 };
 
 /**
- * Returns the current font size in points and sets it if argument pointSize is given.
+ * @description Returns the current font size in points and sets it if argument pointSize is given.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textSize
  * @param  {Number} [pointSize] The size in points to set.
  * @return {Number}             The current point size.
@@ -214,24 +214,24 @@ pub.textSize = function(pointSize) {
 };
 
 /**
- * Sets the current horizontal and vertical text alignment.
+ * @description Sets the current horizontal and vertical text alignment.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textAlign
  * @param  {String} align    The horizontal text alignment to set. Must be one of the InDesign Justification enum values:
- *                           Justification.AWAY_FROM_BINDING_SIDE <br />
- *                           Justification.CENTER_ALIGN <br />
- *                           Justification.CENTER_JUSTIFIED <br />
- *                           Justification.FULLY_JUSTIFIED <br />
- *                           Justification.LEFT_ALIGN <br />
- *                           Justification.RIGHT_ALIGN <br />
- *                           Justification.RIGHT_JUSTIFIED <br />
- *                           Justification.TO_BINDING_SIDE <br />
+ *                           Justification.AWAY_FROM_BINDING_SIDE<br>
+ *                           Justification.CENTER_ALIGN<br>
+ *                           Justification.CENTER_JUSTIFIED<br>
+ *                           Justification.FULLY_JUSTIFIED<br>
+ *                           Justification.LEFT_ALIGN<br>
+ *                           Justification.RIGHT_ALIGN<br>
+ *                           Justification.RIGHT_JUSTIFIED<br>
+ *                           Justification.TO_BINDING_SIDE<br>
  * @param  {String} [yAlign] The vertical text alignment to set. Must be one of the InDesign VerticalJustification enum values:
- *                           VerticalJustification.BOTTOM_ALIGN <br />
- *                           VerticalJustification.CENTER_ALIGN <br />
- *                           VerticalJustification.JUSTIFY_ALIGN <br />
- *                           VerticalJustification.TOP_ALIGN <br />
+ *                           VerticalJustification.BOTTOM_ALIGN<br>
+ *                           VerticalJustification.CENTER_ALIGN<br>
+ *                           VerticalJustification.JUSTIFY_ALIGN<br>
+ *                           VerticalJustification.TOP_ALIGN<br>
  */
 pub.textAlign = function(align, yAlign) {
   currAlign = align;
@@ -239,9 +239,9 @@ pub.textAlign = function(align, yAlign) {
 };
 
 /**
- * Returns the spacing between lines of text in units of points and sets it if argument leading is given.
+ * @description Returns the spacing between lines of text in units of points and sets it if argument leading is given.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textLeading
  * @param  {Number|String} [leading] The spacing between lines of text in units of points or the default InDesign enum
  *                                   value Leading.AUTO.
@@ -255,9 +255,9 @@ pub.textLeading = function(leading) {
 };
 
 /**
- * Returns the current kerning and sets it if argument kerning is given.
+ * @description Returns the current kerning and sets it if argument kerning is given.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textKerning
  * @param  {Number} [kerning] The value to set.
  * @return {Number}           The current kerning.
@@ -270,9 +270,9 @@ pub.textKerning = function(kerning) {
 };
 
 /**
- * Returns the current tracking and sets it if argument tracking is given.
+ * @description Returns the current tracking and sets it if argument tracking is given.
  *
- * @cat Typography
+ * @cat    Typography
  * @method textTracking
  * @param  {Number} [tracking] The value to set.
  * @return {Number}            The current tracking.
@@ -285,14 +285,14 @@ pub.textTracking = function(tracking) {
 };
 
 /**
- * Returns the character style of a given text object or the character style with the given name. If a
+ * @description Returns the character style of a given text object or the character style with the given name. If a
  * character style of the given name does not exist, it gets created. Optionally a props object of
  * property name/value pairs can be used to set the character style's properties.
  *
- * @cat Typography
+ * @cat    Typography
  * @method characterStyle
  * @param  {Text|String} textOrName  A text object whose style to return or the name of the character style to return.
- * @param {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
+ * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
  * @return {CharacterStyle}  The character style instance.
  */
 pub.characterStyle = function(textOrName, props) {
@@ -328,13 +328,13 @@ pub.characterStyle = function(textOrName, props) {
 };
 
 /**
- * Applies a character style to the given text object, text frame or story. The character style
+ * @description Applies a character style to the given text object, text frame or story. The character style
  * can be given as name or as character style instance.
  *
- * @cat Typography
+ * @cat    Typography
  * @method applyCharacterStyle
  * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
- * @param {CharacterStyle|String} style  A character style instance or the name of the character style to apply.
+ * @param  {CharacterStyle|String} style  A character style instance or the name of the character style to apply.
  * @return {Text}  The text that the style was applied to.
  */
 
@@ -362,14 +362,14 @@ pub.applyCharacterStyle = function(text, style) {
 };
 
 /**
- * Returns the paragraph style of a given text object or the paragraph style with the given name. If a
+ * @description Returns the paragraph style of a given text object or the paragraph style with the given name. If a
  * paragraph style of the given name does not exist, it gets created. Optionally a props object of
  * property name/value pairs can be used to set the paragraph style's properties.
  *
- * @cat Typography
+ * @cat    Typography
  * @method paragraphStyle
  * @param  {Text|String} textOrName  A text object whose style to return or the name of the paragraph style to return.
- * @param {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
+ * @param  {Object} [props]  Optional: An object of property name/value pairs to set the style's properties.
  * @return {ParagraphStyle}  The paragraph style instance.
  */
 pub.paragraphStyle = function(textOrName, props) {
@@ -405,13 +405,13 @@ pub.paragraphStyle = function(textOrName, props) {
 };
 
 /**
- * Applies a paragraph style to the given text object, text frame or story. The paragraph style
+ * @description Applies a paragraph style to the given text object, text frame or story. The paragraph style
  * can be given as name or as paragraph style instance.
  *
- * @cat Typography
+ * @cat    Typography
  * @method applyParagraphStyle
  * @param  {TextFrame|TextObject|Story} text  The text frame, text object or story to apply the style to.
- * @param {ParagraphStyle|String} style  A paragraph style instance or the name of the paragraph style to apply.
+ * @param  {ParagraphStyle|String} style  A paragraph style instance or the name of the paragraph style to apply.
  * @return {Text}  The text that the style was applied to.
  */
 
@@ -439,9 +439,9 @@ pub.applyParagraphStyle = function(text, style) {
 };
 
 /**
- * Links the stories of two textframes to one story. Text of first textframe overflows to second one.
+ * @description Links the stories of two textframes to one story. Text of first textframe overflows to second one.
  *
- * @cat Story
+ * @cat    Story
  * @method linkTextFrames
  * @param  {TextFrame} textFrameA
  * @param  {TextFrame} textFrameB
@@ -455,9 +455,9 @@ pub.linkTextFrames = function (textFrameA, textFrameB) {
 };
 
 /**
- * Fills the given textFrame and all linked textFrame with random placeholder text. The placeholder text will be added at the end of any already existing text in the text frame.
+ * @description Fills the given textFrame and all linked textFrame with random placeholder text. The placeholder text will be added at the end of any already existing text in the text frame.
  *
- * @cat Story
+ * @cat    Story
  * @method placeholder
  * @param  {TextFrame} textFrame
  * @return {Text} The inserted placeholder text.


### PR DESCRIPTION
This makes the formatting of all jsdocs inline documentation consistent and therefore cleans it up considerably. After quite a bit of research and testing around, I came up with a formatting style that looks clean, is maintainable and works with the doc generation (once we have the markdown rendering in place).

Here is a before/after of the `margins()` function

Before
```js
/**
 * Sets the margins of a given page. If 1 value is given, all 4 sides are set equally. If 4 values are given, the current page will be adjusted. Adding a 5th value will set the margin of a given page. Calling the function without any values, will return the margins for the current page.
 *
 * @cat Document
 * @subcat Page
 * @method margins
 * @param {Number} [top] Top margin or all if only one.
 * @param {Number} [right] Right margin.
 * @param {Number} [bottom] Bottom margin.
 * @param {Number} [left] Left margin.
 * @param {Number} [pageNumber] Sets margins to selected page, currentPage() if left blank.
 * @return {Object} Current page margins with the properties: top, right, bottom, left.
 */
```

After
```js
/**
 * @description Sets the margins of a given page. If 1 value is given, all 4
 *          sides are set equally. If 4 values are given, the current page will
 *          be adjusted. Adding a 5th value will set the margin of a given page.
 *          Calling the function without any values, will return the margins for
 *          the current page.
 *
 * @cat     Document
 * @subcat  Page
 * @method  margins
 *
 * @param   {Number} [top] Top margin or all if only one.
 * @param   {Number} [right] Right margin.
 * @param   {Number} [bottom] Bottom margin.
 * @param   {Number} [left] Left margin.
 * @param   {Number} [pageNumber] Sets margins to selected page, currentPage()
 *          if left blank.
 * @return  {Object} Current page margins with the properties: `top`, `right`,
 *          `bottom`, `left`.
 */
```

As you can see, this now also strictly stays within the 80-characters line limit to be better readable in most editors.

The syntax looks like this now:
```js
/**
 * @description The description of the method. If the description is longer, it
 *          wraps around to an indentation value that aligns with other
 *          information below.
 *
 * @cat     Category
 * @subcat  Sub-Category
 * @method  methodName
 *
 * @param   {Type} name A parameter.
 * @param   {Type} name A parameter with a description that is long enough that
 *          it wraps into the next line.
 * @param   {Type} [name] An optional parameter.
 * @return  {Type} Description of the return value. This also wraps into the
 *          next line if the description is long enough.
 *          
 * @example <caption>How to use this function</caption>
 * var foo = methodName(); // code lines must not use indentation
 */
```

All methods have been changed to adhere to this new syntax. Markdown was added for inline code snippets and for lists.