### PR TITLE
Fixing page functions to return page objects and to jump to new page

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -2956,7 +2956,7 @@ pub.addPage = function(location) {
     location = pub.AT_END;
   }
 
-  return currentDoc().pages.add(location, pub.page());
+  return getAndUpdatePage(currentDoc().pages.add(location, pub.page()), "addPage");
 };
 
 /**
@@ -3952,7 +3952,7 @@ var getAndUpdatePage = function(page, parentFunctionName) {
       // focus GUI on new page, if not in HIDDEN mode
       app.activeWindow.activePage = currPage;
     }
-
+    return currPage;
 }
 
 var getMasterSpread = function(master, parentFunctionName) {

--- a/src/includes/document.js
+++ b/src/includes/document.js
@@ -457,7 +457,7 @@ pub.addPage = function(location) {
     location = pub.AT_END;
   }
 
-  return currentDoc().pages.add(location, pub.page());
+  return getAndUpdatePage(currentDoc().pages.add(location, pub.page()), "addPage");
 };
 
 /**
@@ -1453,7 +1453,7 @@ var getAndUpdatePage = function(page, parentFunctionName) {
       // focus GUI on new page, if not in HIDDEN mode
       app.activeWindow.activePage = currPage;
     }
-
+    return currPage;
 }
 
 var getMasterSpread = function(master, parentFunctionName) {


### PR DESCRIPTION
There was an error introduced by my recent page and master page additions/fixes:
`addPage()` did not jump to the newly added page anymore. This fixes it and also fixes return values for `nextPage()` and `previousPage()`.

Will merge right away.