### PR TITLE
vertex path: move CLOSE argument from beginShape() to endShape()

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -6867,35 +6867,35 @@ pub.addPath = function() {
 };
 
 /**
- * @description Using the `beginShape()` and `endShape()` functions allows to create more complex forms. `beginShape()` begins recording vertices for a shape and `endShape()` stops recording. After calling the `beginShape()` function, a series of `vertex()` commands must follow. To stop drawing the shape, call `endShape()`. The shapeMode parameter allows to close the shape (to connect the beginning and the end).
+ * @description Using the `beginShape()` and `endShape()` functions allows to create more complex forms. `beginShape()` begins recording vertices for a shape and `endShape()` stops recording. After calling the `beginShape()` function, a series of `vertex()` commands must follow. To stop drawing the shape, call `endShape()`.
  *
  * @cat     Shape
  * @subcat  Vertex
  * @method  beginShape
  *
- * @param   {String} shapeMode Set to `CLOSE` if the new path should be auto-closed.
  */
-pub.beginShape = function(shapeMode) {
+pub.beginShape = function() {
   currVertexPoints = [];
   currPathPointer = 0;
   currPolygon = null;
-  if(typeof shapeMode != null) {
-    currShapeMode = shapeMode;
-  } else {
-    currShapeMode = null;
-  }
 };
 
 /**
- * @description The `endShape()` function is the companion to `beginShape()` and may only be called after `beginShape()`.
+ * @description The `endShape()` function is the companion to `beginShape()` and may only be called after `beginShape()`. It creates and returns a path of the previously called `vertex()` points. The `shapeMode` parameter allows to close the shape (to connect the beginning and the end).
  *
  * @cat     Shape
  * @subcat  Vertex
  * @method  endShape
  *
+ * @param   {String} shapeMode Set to `CLOSE` if the new path should be auto-closed.
  * @return  {GraphicLine|Polygon} The GraphicLine or Polygon object that was created.
  */
-pub.endShape = function() {
+pub.endShape = function(shapeMode) {
+  if(shapeMode === pub.CLOSE) {
+    currShapeMode = shapeMode;
+  } else {
+    currShapeMode = null;
+  }
   doAddPath();
   currPolygon.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
                    AnchorPoint.TOP_LEFT_ANCHOR,

--- a/changelog.txt
+++ b/changelog.txt
@@ -66,6 +66,8 @@ basil.js x.x.x DAY MONTH YEAR
 * page(), pageNumber() and removePage() now also accept page name strings as parameters
 * pageCount() can now also be used to set the doc's page count
 * previousPage() and nextPage() now work as expected
+* when drawing closed vertex paths, endShape() instead of beginShape() now takes the
+  CLOSE constant as argument
 * println() and print() can now print multiple parameters to console
 * trimWord() now correctly trims all punctuation from word borders
 * text() now respects the currently set rectangle mode

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -351,35 +351,35 @@ pub.addPath = function() {
 };
 
 /**
- * @description Using the `beginShape()` and `endShape()` functions allows to create more complex forms. `beginShape()` begins recording vertices for a shape and `endShape()` stops recording. After calling the `beginShape()` function, a series of `vertex()` commands must follow. To stop drawing the shape, call `endShape()`. The shapeMode parameter allows to close the shape (to connect the beginning and the end).
+ * @description Using the `beginShape()` and `endShape()` functions allows to create more complex forms. `beginShape()` begins recording vertices for a shape and `endShape()` stops recording. After calling the `beginShape()` function, a series of `vertex()` commands must follow. To stop drawing the shape, call `endShape()`.
  *
  * @cat     Shape
  * @subcat  Vertex
  * @method  beginShape
  *
- * @param   {String} shapeMode Set to `CLOSE` if the new path should be auto-closed.
  */
-pub.beginShape = function(shapeMode) {
+pub.beginShape = function() {
   currVertexPoints = [];
   currPathPointer = 0;
   currPolygon = null;
-  if(typeof shapeMode != null) {
-    currShapeMode = shapeMode;
-  } else {
-    currShapeMode = null;
-  }
 };
 
 /**
- * @description The `endShape()` function is the companion to `beginShape()` and may only be called after `beginShape()`.
+ * @description The `endShape()` function is the companion to `beginShape()` and may only be called after `beginShape()`. It creates and returns a path of the previously called `vertex()` points. The `shapeMode` parameter allows to close the shape (to connect the beginning and the end).
  *
  * @cat     Shape
  * @subcat  Vertex
  * @method  endShape
  *
+ * @param   {String} shapeMode Set to `CLOSE` if the new path should be auto-closed.
  * @return  {GraphicLine|Polygon} The GraphicLine or Polygon object that was created.
  */
-pub.endShape = function() {
+pub.endShape = function(shapeMode) {
+  if(shapeMode === pub.CLOSE) {
+    currShapeMode = shapeMode;
+  } else {
+    currShapeMode = null;
+  }
   doAddPath();
   currPolygon.transform(CoordinateSpaces.PASTEBOARD_COORDINATES,
                    AnchorPoint.TOP_LEFT_ANCHOR,

--- a/test/shape-tests.jsx
+++ b/test/shape-tests.jsx
@@ -25,26 +25,21 @@ basilTest("VertexTests", {
   testVertex: function() {
 
     beginShape();
-
-    vertex(0, 0);
-    vertex(-10, 0);
-    vertex(-10, 10);
-
+      vertex(0, 0);
+      vertex(-10, 0);
+      vertex(-10, 10);
     var shape = endShape();
+
     assert(shape instanceof GraphicLine);
     assert(shape.paths.item(0).entirePath.length === 3);
 
     beginShape();
-
-    vertex(0, 0);
-    vertex(-10, 0);
-    vertex(-10, 10);
-
+      vertex(0, 0);
+      vertex(-10, 0);
+      vertex(-10, 10);
     addPath();
-
-    vertex(0, 0);
-    vertex(-10, 0);
-
+      vertex(0, 0);
+      vertex(-10, 0);
     shape = endShape();
 
     assert(shape instanceof GraphicLine);
@@ -53,14 +48,12 @@ basilTest("VertexTests", {
 
 
     beginShape();
-
-    vertex(0, 0);
-    vertex(-10, 0);
-    vertex(-10, 10);
-
+      vertex(0, 0);
+      vertex(-10, 0);
+      vertex(-10, 10);
     shape = endShape(CLOSE);
-    assert(shape instanceof GraphicLine);
 
+    assert(shape instanceof Polygon);
     assert(shape.paths.length === 1);
     assert(shape.paths.item(0).entirePath.length === 3);
 


### PR DESCRIPTION
As described in #291 .
Cleaned up the test file a bit as well, and renamed it to be aligned better with our file names.<

Will merge right away.