### PR TITLE
Fixed isArray() to also handle allPageItems, allGraphics etc.

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -2326,7 +2326,7 @@ pub.trimWord = function(s) {
  * @return  {Boolean} returns true if this is the case
  */
 var isArray = pub.isArray = function(obj) {
-  return Object.prototype.toString.call(obj) === "[object Array]";
+  return obj.constructor.name === "Array";
 };
 
 /**

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -827,7 +827,7 @@ pub.trimWord = function(s) {
  * @return  {Boolean} returns true if this is the case
  */
 var isArray = pub.isArray = function(obj) {
-  return Object.prototype.toString.call(obj) === "[object Array]";
+  return obj.constructor.name === "Array";
 };
 
 /**

--- a/test/data-tests.jsx
+++ b/test/data-tests.jsx
@@ -64,7 +64,7 @@ basilTest("DataTests", {
 
   },
 
-  testHashList2: function (b) {
+  testHashList2: function () {
 
     var hash = new HashList(); // start over
 
@@ -115,7 +115,31 @@ basilTest("DataTests", {
 
   },
 
-  testIsText: function(b) {
+  testIsArray: function() {
+    var myDoc = doc();
+
+    var arr1 = [];
+    assert(isArray(arr1));
+
+    var arr2 = [1, 2, 3];
+    assert(isArray(arr2));
+
+    var arr3 = new Array;
+    assert(isArray(arr3));
+
+    assert(isArray(doc().allPageItems), "empty allPageItems array");
+
+    var txt = text(LOREM, 0, 0, 20, 20);
+
+    assert(isArray(doc().allPageItems), "non-empty allPageItems array");
+
+    assert(isArray(txt.geometricBounds));
+
+    assert(!isArray(txt.words), "collection is not an array");
+
+  },
+
+  testIsText: function() {
     var myDoc = doc();
 
     var tf = text(LOREM, 0, 0, 200, 200);

--- a/test/document-tests.jsx
+++ b/test/document-tests.jsx
@@ -33,14 +33,14 @@ basilTest("DocumentTests", {
 
     var g = graphics(doc());
 
-    assert(g.constructor.name === "Array");
+    assert(isArray(g));
     assert(g[0] instanceof Image);
 
     var gCounter = 0;
     var gcb1 = graphics(doc(), function(graphic, i) {
       gCounter++;
     })
-    assert(gcb1.constructor.name === "Array");
+    assert(isArray(gcb1));
     assert(gCounter === g.length);
     assert(gCounter === gcb1.length);
 
@@ -49,7 +49,7 @@ basilTest("DocumentTests", {
         return false;
       }
     })
-    assert(gcb2.constructor.name === "Array");
+    assert(isArray(gcb2));
     assert(gcb2[0] instanceof Image);
     assert(gcb2.length < gcb1.length);
   },


### PR DESCRIPTION
Fixed the `isArray()` issue described in #290. Added tests for `isArray()`. Will merge right away.