### PR TITLE
Dev fixbounds

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -3390,8 +3390,8 @@ pub.bounds = function (obj) {
       y1 = bounds[0] - currOriginY;
       x2 = bounds[3] - currOriginX;
       y2 = bounds[2] - currOriginY;
-      w = x2 - x1;
-      h = y2 - y1;
+      w = x2 - x1 - currOriginX;
+      h = y2 - y1 - currOriginX;
       return {"width": w, "height": h, "left": x1, "right": x2, "top": y1, "bottom": y2};
     }
     // no idea what that might be, give up

--- a/basil.js
+++ b/basil.js
@@ -3365,20 +3365,20 @@ pub.bounds = function (obj) {
 
     return {"width": w,
             "height": h,
-            "left": x1 + currOriginX,
-            "right": x2 + currOriginX,
-            "top": y1 + currOriginY,
-            "bottom": y2 + currOriginY,
-            "baseline": baseline + currOriginY,
-            "xHeight": xHeight + currOriginY};
+            "left": x1 - currOriginX,
+            "right": x2 - currOriginX,
+            "top": y1 - currOriginY,
+            "bottom": y2 - currOriginY,
+            "baseline": baseline - currOriginY,
+            "xHeight": xHeight - currOriginY};
   } else {
     // is it a pageItem?
     if (obj.hasOwnProperty("geometricBounds")) {
       var geometricBounds = obj.geometricBounds; // [y1, x1, y2, x2]
-      x1 = geometricBounds[1] + currOriginX;
-      y1 = geometricBounds[0] + currOriginY;
-      x2 = geometricBounds[3] + currOriginX;
-      y2 = geometricBounds[2] + currOriginY;
+      x1 = geometricBounds[1] - currOriginX;
+      y1 = geometricBounds[0] - currOriginY;
+      x2 = geometricBounds[3] - currOriginX;
+      y2 = geometricBounds[2] - currOriginY;
       w = x2 - x1;
       h = y2 - y1;
       return {"width": w, "height": h, "left": x1, "right": x2, "top": y1, "bottom": y2};
@@ -3386,10 +3386,10 @@ pub.bounds = function (obj) {
     // everything else e.g. page, spread
     else if (obj.hasOwnProperty("bounds")) {
       var bounds = obj.bounds; // [y1, x1, y2, x2]
-      x1 = bounds[1] + currOriginX;
-      y1 = bounds[0] + currOriginY;
-      x2 = bounds[3] + currOriginX;
-      y2 = bounds[2] + currOriginY;
+      x1 = bounds[1] - currOriginX;
+      y1 = bounds[0] - currOriginY;
+      x2 = bounds[3] - currOriginX;
+      y2 = bounds[2] - currOriginY;
       w = x2 - x1;
       h = y2 - y1;
       return {"width": w, "height": h, "left": x1, "right": x2, "top": y1, "bottom": y2};

--- a/src/includes/document.js
+++ b/src/includes/document.js
@@ -886,8 +886,8 @@ pub.bounds = function (obj) {
       y1 = bounds[0] - currOriginY;
       x2 = bounds[3] - currOriginX;
       y2 = bounds[2] - currOriginY;
-      w = x2 - x1;
-      h = y2 - y1;
+      w = x2 - x1 - currOriginX;
+      h = y2 - y1 - currOriginX;
       return {"width": w, "height": h, "left": x1, "right": x2, "top": y1, "bottom": y2};
     }
     // no idea what that might be, give up

--- a/src/includes/document.js
+++ b/src/includes/document.js
@@ -861,20 +861,20 @@ pub.bounds = function (obj) {
 
     return {"width": w,
             "height": h,
-            "left": x1 + currOriginX,
-            "right": x2 + currOriginX,
-            "top": y1 + currOriginY,
-            "bottom": y2 + currOriginY,
-            "baseline": baseline + currOriginY,
-            "xHeight": xHeight + currOriginY};
+            "left": x1 - currOriginX,
+            "right": x2 - currOriginX,
+            "top": y1 - currOriginY,
+            "bottom": y2 - currOriginY,
+            "baseline": baseline - currOriginY,
+            "xHeight": xHeight - currOriginY};
   } else {
     // is it a pageItem?
     if (obj.hasOwnProperty("geometricBounds")) {
       var geometricBounds = obj.geometricBounds; // [y1, x1, y2, x2]
-      x1 = geometricBounds[1] + currOriginX;
-      y1 = geometricBounds[0] + currOriginY;
-      x2 = geometricBounds[3] + currOriginX;
-      y2 = geometricBounds[2] + currOriginY;
+      x1 = geometricBounds[1] - currOriginX;
+      y1 = geometricBounds[0] - currOriginY;
+      x2 = geometricBounds[3] - currOriginX;
+      y2 = geometricBounds[2] - currOriginY;
       w = x2 - x1;
       h = y2 - y1;
       return {"width": w, "height": h, "left": x1, "right": x2, "top": y1, "bottom": y2};
@@ -882,10 +882,10 @@ pub.bounds = function (obj) {
     // everything else e.g. page, spread
     else if (obj.hasOwnProperty("bounds")) {
       var bounds = obj.bounds; // [y1, x1, y2, x2]
-      x1 = bounds[1] + currOriginX;
-      y1 = bounds[0] + currOriginY;
-      x2 = bounds[3] + currOriginX;
-      y2 = bounds[2] + currOriginY;
+      x1 = bounds[1] - currOriginX;
+      y1 = bounds[0] - currOriginY;
+      x2 = bounds[3] - currOriginX;
+      y2 = bounds[2] - currOriginY;
       w = x2 - x1;
       h = y2 - y1;
       return {"width": w, "height": h, "left": x1, "right": x2, "top": y1, "bottom": y2};


### PR DESCRIPTION
Fixed a few issues in `bounds()` when using `canvasMode(MARGIN)` or `canvasMode(FACING_MARGINS)`. `BLEED`, `FACING_BLEEDS`, `PAGE`, `FACING_PAGES` are all working fine too.

Only thing that still remains, is when getting the `bounds(pages())` in one of the `FACING_` modes, which was already an issue and can be solved later.

Here's a test script using `bounds()` of a few items:

```
// @includepath ~/Documents/;%USERPROFILE%Documents; 
// @include basiljs/basil.js; 
 
function draw() { 
  var output = layer("output");
  clear(output);
  
  canvasMode(MARGIN);
  //canvasMode(FACING_MARGINS);

  // first rect
  var r = rect(0, 0, width, height);
  var bnds = bounds(r);
  
  // 2nd rect overlay
  fill(255, 0, 0);
  var r2 = rect(bnds.left, bnds.top, bnds.width, bnds.height);
 
  // text, with bounds of letter
  fill(0, 255, 0);
  var tf = text("hello", 0, 0, width, height);
  typo(tf, "pointSize", 150);
  characters(tf, function(obj){
    if(obj.contents.toLowerCase() == 'h'){
      var bnds = bounds(obj);
      rectMode(CORNERS);
      fill(0, 0, 255);
      var r= rect(bnds.left, bnds.xHeight, bnds.right, bnds.baseline);
      referencePoint(CENTER);
      transform(r, "rotation", 45);
    }
  });

  // issue with bounds(page()) remains in FACING mode
  var bnd = bounds(page());
  fill(gradient(color(50), color(200)));
  var bg = rect(bnd.left, bnd.top, bnd.width, bnd.height);
  arrange(bg, BACK);
} 
```