### PR TITLE
Fixing isArray() and functions that depended on it

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -2337,6 +2337,9 @@ pub.trimWord = function(s) {
  * @return  {Boolean} returns true if this is the case
  */
 var isArray = pub.isArray = function(obj) {
+  if(obj === undefined || obj === null) {
+    return false;
+  }
   return obj.constructor.name === "Array";
 };
 

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -827,6 +827,9 @@ pub.trimWord = function(s) {
  * @return  {Boolean} returns true if this is the case
  */
 var isArray = pub.isArray = function(obj) {
+  if(obj === undefined || obj === null) {
+    return false;
+  }
   return obj.constructor.name === "Array";
 };
 

--- a/test/all-tests.jsx
+++ b/test/all-tests.jsx
@@ -9,4 +9,3 @@
 // @include "string-tests.jsx";
 // @include "transform-tests.jsx";
 // @include "typography-tests.jsx";
-// @include "vertex-tests.jsx";


### PR DESCRIPTION
This fixes a bug that I introduced recently to `isArray()` that made it not work for `undefined` and `null` values anymore. Subsequently the `transform()` function was broken for some transforms. This is all fixed now. Will merge right away.