### PR TITLE
typo() for path text

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -7991,7 +7991,7 @@ pub.textTracking = function(tracking) {
  * @subcat  Attributes
  * @method  typo
  *
- * @param   {Document|Spread|Page|Layer|Story|TextFrame|Text} item The object to apply the property to.
+ * @param   {Document|Spread|Page|Layer|Story|TextFrame|TextPath|Text} item The object to apply the property to.
  * @param   {String|Object} property The text property name or an object of key/value property/value pairs. If property is a string and no value is given, the function acts as getter.
  * @param   {String|Number|Object} [value] The value to apply to the property.
  * @return  {String[]|Number[]|Object[]} The property value(s) if the function acts as getter or the items the property was assigned to.
@@ -8036,8 +8036,9 @@ pub.typo = function(item, property, value) {
       pub.typo(textFrame, property, value);
     });
   } else if (item instanceof Story ||
-             item instanceof TextFrame) {
-    var paras = item.paragraphs;
+             item instanceof TextFrame ||
+             item instanceof TextPath) {
+    var paras = item instanceof TextPath ? item.texts[0].paragraphs :item.paragraphs;
     // loop backwards to prevent invalid object reference error when
     // start of para is overflown in "invisible" textFrame area after
     // applying prop to previous para(s)

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -243,7 +243,7 @@ pub.textTracking = function(tracking) {
  * @subcat  Attributes
  * @method  typo
  *
- * @param   {Document|Spread|Page|Layer|Story|TextFrame|Text} item The object to apply the property to.
+ * @param   {Document|Spread|Page|Layer|Story|TextFrame|TextPath|Text} item The object to apply the property to.
  * @param   {String|Object} property The text property name or an object of key/value property/value pairs. If property is a string and no value is given, the function acts as getter.
  * @param   {String|Number|Object} [value] The value to apply to the property.
  * @return  {String[]|Number[]|Object[]} The property value(s) if the function acts as getter or the items the property was assigned to.
@@ -288,8 +288,9 @@ pub.typo = function(item, property, value) {
       pub.typo(textFrame, property, value);
     });
   } else if (item instanceof Story ||
-             item instanceof TextFrame) {
-    var paras = item.paragraphs;
+             item instanceof TextFrame ||
+             item instanceof TextPath) {
+    var paras = item instanceof TextPath ? item.texts[0].paragraphs :item.paragraphs;
     // loop backwards to prevent invalid object reference error when
     // start of para is overflown in "invisible" textFrame area after
     // applying prop to previous para(s)


### PR DESCRIPTION
This allows to use `typo()` for text on path as well. Fixes #309, will merge right away.