### PR TITLE
Fixing pageCount

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -3150,8 +3150,12 @@ pub.page = function(page) {
  */
 pub.pageCount = function(pageCount) {
   if(arguments.length) {
+    var pageCountPrevious = currentDoc().pages.count();
     if(pub.isInteger(pageCount) && pageCount > 0 && pageCount < 10000) {
       currentDoc().documentPreferences.pagesPerDocument = pageCount;
+      if(pageCount < pageCountPrevious) {
+        pub.page(currentDoc().pages.count());
+      }
     } else {
       error("pageCount(), wrong arguments! Use an integer between 1 and 9999 to set page count.");
     }

--- a/src/includes/document.js
+++ b/src/includes/document.js
@@ -632,8 +632,12 @@ pub.page = function(page) {
  */
 pub.pageCount = function(pageCount) {
   if(arguments.length) {
+    var pageCountPrevious = currentDoc().pages.count();
     if(pub.isInteger(pageCount) && pageCount > 0 && pageCount < 10000) {
       currentDoc().documentPreferences.pagesPerDocument = pageCount;
+      if(pageCount < pageCountPrevious) {
+        pub.page(currentDoc().pages.count());
+      }
     } else {
       error("pageCount(), wrong arguments! Use an integer between 1 and 9999 to set page count.");
     }


### PR DESCRIPTION
Caused error if changing `pageCount()` to anything less than current document had. Useful for undo'ing a script that regularly uses `addPage()`. Now will auto switch to last available page to avoid crash.