### PR TITLE
selection() works again with no arguments

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -3652,7 +3652,7 @@ pub.objectStyle = function(itemOrName, props) {
  * @return  {Object} The first selected object.
  */
 pub.selection = function(item) {
-  if(item.hasOwnProperty("select")) {
+  if(item && item.hasOwnProperty("select")) {
     item.select();
     return item;
   }

--- a/src/includes/document.js
+++ b/src/includes/document.js
@@ -1196,7 +1196,7 @@ pub.objectStyle = function(itemOrName, props) {
  * @return  {Object} The first selected object.
  */
 pub.selection = function(item) {
-  if(item.hasOwnProperty("select")) {
+  if(item && item.hasOwnProperty("select")) {
     item.select();
     return item;
   }


### PR DESCRIPTION
Quick fix for `selection()` to work again with no arguments. Will merge right away.