### PR TITLE
Fix for guides functions

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -3137,7 +3137,7 @@ pub.guideY = function (y) {
   }
   var guides = currentPage().guides;
   var guide = guides.add(currentLayer());
-  guide.fitToPage = true;
+  guide.fitToPage = (currCanvasMode === PAGE || currCanvasMode === MARGIN || currCanvasMode === BLEED);
   guide.orientation = HorizontalOrVertical.HORIZONTAL;
   guide.location = y + currOriginY;
   return guide;

--- a/basil.js
+++ b/basil.js
@@ -3109,12 +3109,14 @@ pub.canvasMode = function (m) {
  * @return  {Guide} New guide line.
  */
 pub.guideX = function (x) {
-  checkNull(x);
+  if(!isNumber(x)) {
+    error("guideX(), invalid argument! Use number.");
+  }
   var guides = currentPage().guides;
   var guide = guides.add(currentLayer());
   guide.fitToPage = true;
   guide.orientation = HorizontalOrVertical.VERTICAL;
-  guide.location = x;
+  guide.location = x + currOriginX;
   return guide;
 };
 
@@ -3130,12 +3132,14 @@ pub.guideX = function (x) {
  * @return  {Guide} New guide line.
  */
 pub.guideY = function (y) {
-  checkNull(y);
+  if(!isNumber(y)) {
+    error("guideY(), invalid argument! Use number.");
+  }
   var guides = currentPage().guides;
   var guide = guides.add(currentLayer());
   guide.fitToPage = true;
   guide.orientation = HorizontalOrVertical.HORIZONTAL;
-  guide.location = y;
+  guide.location = y + currOriginY;
   return guide;
 };
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -90,6 +90,8 @@ basil.js x.x.x DAY MONTH YEAR
 * selection() can now be used to set the selection
 * label() can now be used to assign a label to a page item
 * endsWith() and startsWith() now also work for arrays
+* guideX() and guideY() now correctly place guides in facing canvas modes
+* guideY() now places a guide spanning the entire spread when in facing canvas modes
 * Updated categories and sub-categories of many functions to better align to Processing/p5.js categories
   or – in case of non-Processing functions – to better reflect the InDesign categories they belong to
 * Changed all include/includepath/targetengine statements from # to //@

--- a/src/includes/document.js
+++ b/src/includes/document.js
@@ -355,12 +355,14 @@ pub.canvasMode = function (m) {
  * @return  {Guide} New guide line.
  */
 pub.guideX = function (x) {
-  checkNull(x);
+  if(!isNumber(x)) {
+    error("guideX(), invalid argument! Use number.");
+  }
   var guides = currentPage().guides;
   var guide = guides.add(currentLayer());
   guide.fitToPage = true;
   guide.orientation = HorizontalOrVertical.VERTICAL;
-  guide.location = x;
+  guide.location = x + currOriginX;
   return guide;
 };
 
@@ -376,12 +378,14 @@ pub.guideX = function (x) {
  * @return  {Guide} New guide line.
  */
 pub.guideY = function (y) {
-  checkNull(y);
+  if(!isNumber(y)) {
+    error("guideY(), invalid argument! Use number.");
+  }
   var guides = currentPage().guides;
   var guide = guides.add(currentLayer());
   guide.fitToPage = true;
   guide.orientation = HorizontalOrVertical.HORIZONTAL;
-  guide.location = y;
+  guide.location = y + currOriginY;
   return guide;
 };
 

--- a/src/includes/document.js
+++ b/src/includes/document.js
@@ -383,7 +383,7 @@ pub.guideY = function (y) {
   }
   var guides = currentPage().guides;
   var guide = guides.add(currentLayer());
-  guide.fitToPage = true;
+  guide.fitToPage = (currCanvasMode === PAGE || currCanvasMode === MARGIN || currCanvasMode === BLEED);
   guide.orientation = HorizontalOrVertical.HORIZONTAL;
   guide.location = y + currOriginY;
   return guide;


### PR DESCRIPTION
This fixes `guideX()` and `guideY()` to place guides correctly when using any canvas modes other than `PAGE`. Additionally, this sets the guideY's `fitToPage` property to `false` when in any of the facing canvas modes, so the guide will cross the entire spread (as is to expected in these modes).

Will merge right away.