### PR TITLE
Initial removal of global variables without loop condition

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -47,7 +47,7 @@
 
 // clearing global space if it is still populated from previous run of a loop script
 // to ensure basil methods work properly
-if($.engineName === "loop" && $.global.basilGlobal) {
+if($.global.basilGlobal) {
   for (var i = basilGlobal.length - 1; i >= 0; i--) {
     if($.global.hasOwnProperty(basilGlobal[i])) {
       try{

--- a/src/main.js
+++ b/src/main.js
@@ -46,7 +46,7 @@
 
 // clearing global space if it is still populated from previous run of a loop script
 // to ensure basil methods work properly
-if($.engineName === "loop" && $.global.basilGlobal) {
+if($.global.basilGlobal) {
   for (var i = basilGlobal.length - 1; i >= 0; i--) {
     if($.global.hasOwnProperty(basilGlobal[i])) {
       try{


### PR DESCRIPTION
Removed the loop condition from this initial removal of global variables as it was disallowing chaining of basil scripts from other scripts.

This should not cause any issues I think, however, if you *do* encounter some issues with this, let me know, then I'll have to reverse it or think of something else.