### PR TITLE
getURL updates - params + Windows support

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -5351,14 +5351,15 @@ pub.folder = function(folderPath) {
  * @method  loadJSON
  *
  * @param   {String|File} file The JSON file name in the document's data directory, an absolute path to a JSON file, a File instance or an URL.
+ * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
  * @return  {Object} The resulting data object.
  */
-pub.loadJSON = function(file) {
+pub.loadJSON = function(file, curlOptions) {
 
   var jsonString;
 
   if (isURL(file)) {
-    jsonString = getURL(file);
+    jsonString = getURL(file, curlOptions);
   } else {
     var inputFile = initDataFile(file),
       data = null;
@@ -5379,11 +5380,12 @@ pub.loadJSON = function(file) {
  * @method  loadString
  *
  * @param   {String|File} file The text file name in the document's data directory or a File instance or an URL
+ * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
  * @return  {String} String file or URL content.
  */
-pub.loadString = function(file) {
+pub.loadString = function(file, curlOptions) {
   if (isURL(file)) {
-    return getURL(file);
+    return getURL(file, curlOptions);
   } else {
     var inputFile = initDataFile(file),
       data = null;
@@ -5403,11 +5405,12 @@ pub.loadString = function(file) {
  * @method  loadStrings
  *
  * @param   {String|File} file The text file name in the document's data directory or a file instance or an URL
+ * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
  * @return  {Array} Array of the individual lines in the given file or URL
  */
-pub.loadStrings = function(file) {
+pub.loadStrings = function(file, curlOptions) {
   if (isURL(file)) {
-    var result = getURL(file);
+    var result = getURL(file, curlOptions);
     return result.match(/[^\r\n]+/g);
   } else {
     var inputFile = initDataFile(file),
@@ -5659,12 +5662,42 @@ pub.year = function() {
 // Input Private
 // ----------------------------------------
 
-var getURL = function(url) {
+var getURL = function(url, curlOptions) {
   if (isURL(url)) {
     if (Folder.fs === "Macintosh") {
-      return pub.shellExecute("curl -m 15 -L '" + url + "'");
+      curlUserOptions = '';
+      if(curlOptions != undefined){
+        curlUserOptions = curlOptions;
+      }
+      return pub.shellExecute("curl -m 15 -L '" + url + "' " + curlUserOptions);
     } else {
-      error(getParentFunctionName(1) + "(), loading of strings via an URL is a Mac only feature at the moment. Sorry!");
+      // Windows
+      var vbs = 'Dim str\r';
+      vbs += 'URL = "' + url + '"\r';
+      vbs += 'Set WshShell = CreateObject("WScript.Shell")\r';
+      vbs += 'Set http = CreateObject("Microsoft.XmlHttp")\r';
+      vbs += 'On Error Resume Next\r';
+      vbs += 'http.open "GET", URL, False\r';
+      vbs += 'http.send ""\r';
+      vbs += 'if err.Number = 0 Then\r';
+      vbs += 'str = http.responseText\r';
+      vbs += 'Else\r';
+      vbs += 'MsgBox("error " & Err.Number & ": " & Err.Description)\r';
+      vbs += 'End If\r';
+      vbs += 'set WshShell = Nothing\r';
+      vbs += 'Set http = Nothing\r';
+      vbs += 'Set objInDesign = CreateObject("InDesign.Application")\r';
+      vbs += 'objInDesign.ScriptArgs.SetValue "WshShellResponse", str';
+
+      try {
+        app.doScript(vbs, ScriptLanguage.VISUAL_BASIC, undefined, UndoModes.FAST_ENTIRE_SCRIPT);
+      } catch(err) {
+        error(err.message + ", line: " + err.line);
+      }
+
+      var str = app.scriptArgs.getValue("WshShellResponse");
+      app.scriptArgs.clear();
+      return str;
     }
   } else {
     error(getParentFunctionName(1) + "(), the url " + url + " is invalid. Please double check!");

--- a/basil.js
+++ b/basil.js
@@ -5351,15 +5351,15 @@ pub.folder = function(folderPath) {
  * @method  loadJSON
  *
  * @param   {String|File} file The JSON file name in the document's data directory, an absolute path to a JSON file, a File instance or an URL.
- * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
+ * @param   {String} [userAgent] Optional parameter when URL is used, to specify a user-agent making request.
  * @return  {Object} The resulting data object.
  */
-pub.loadJSON = function(file, curlOptions) {
+pub.loadJSON = function(file, userAgent) {
 
   var jsonString;
 
   if (isURL(file)) {
-    jsonString = getURL(file, curlOptions);
+    jsonString = getURL(file, userAgent);
   } else {
     var inputFile = initDataFile(file),
       data = null;
@@ -5380,12 +5380,12 @@ pub.loadJSON = function(file, curlOptions) {
  * @method  loadString
  *
  * @param   {String|File} file The text file name in the document's data directory or a File instance or an URL
- * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
+ * @param   {String} [userAgent] Optional parameter when URL is used, to specify a user-agent making request.
  * @return  {String} String file or URL content.
  */
-pub.loadString = function(file, curlOptions) {
+pub.loadString = function(file, userAgent) {
   if (isURL(file)) {
-    return getURL(file, curlOptions);
+    return getURL(file, userAgent);
   } else {
     var inputFile = initDataFile(file),
       data = null;
@@ -5405,12 +5405,12 @@ pub.loadString = function(file, curlOptions) {
  * @method  loadStrings
  *
  * @param   {String|File} file The text file name in the document's data directory or a file instance or an URL
- * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
+ * @param   {String} [userAgent] Optional parameter when URL is used, to specify a user-agent making request.
  * @return  {Array} Array of the individual lines in the given file or URL
  */
-pub.loadStrings = function(file, curlOptions) {
+pub.loadStrings = function(file, userAgent) {
   if (isURL(file)) {
-    var result = getURL(file, curlOptions);
+    var result = getURL(file, userAgent);
     return result.match(/[^\r\n]+/g);
   } else {
     var inputFile = initDataFile(file),
@@ -5662,20 +5662,24 @@ pub.year = function() {
 // Input Private
 // ----------------------------------------
 
-var getURL = function(url, curlOptions) {
+var getURL = function(url, userAgent) {
   if (isURL(url)) {
     if (Folder.fs === "Macintosh") {
-      curlUserOptions = '';
-      if(curlOptions != undefined){
-        curlUserOptions = curlOptions;
+      curlAgent = '';
+      if(userAgent != undefined){
+        curlAgent = "--user-agent '"+userAgent+"'";
       }
-      return pub.shellExecute("curl -m 15 -L '" + url + "' " + curlUserOptions);
+      return pub.shellExecute("curl -m 15 -L '" + url + "' " + curlAgent);
     } else {
-      // Windows
+      // Windows support - Based on GetDataFromWshShell()
+      // https://community.adobe.com/t5/indesign/execute-a-vbscript-inside-a-javascript/m-p/9406203?page=1#M69766
       var vbs = 'Dim str\r';
       vbs += 'URL = "' + url + '"\r';
       vbs += 'Set WshShell = CreateObject("WScript.Shell")\r';
       vbs += 'Set http = CreateObject("Microsoft.XmlHttp")\r';
+      if(userAgent != undefined){
+        vbs += 'http.setRequestHeader "User-Agent", "'+userAgent+'"\r';
+      }
       vbs += 'On Error Resume Next\r';
       vbs += 'http.open "GET", URL, False\r';
       vbs += 'http.send ""\r';

--- a/changelog.txt
+++ b/changelog.txt
@@ -103,6 +103,7 @@ basil.js x.x.x DAY MONTH YEAR
 * Changed the location of the basil.js library from `~/Documents/basiljs/bundle/basil.js` to `~/Documents/basiljs/basil.js` in all the example files.
 The user is allowed to have his files wherever he wants.
 * bounds() now correctly measures bounds in different canvas modes(MARGIN/BLEED etc.)
+* loadJSON(), loadString(), loadStrings() when passed a URL, can receive custom user-agent as 2nd parameter
 
 - b.go() and b.loop() are removed (use function draw() or function loop() instead)
 - b.itemX(), b.itemY(), b.itemWidth(), b.itemHeight(), b.itemPosition() and b.itemSize() are removed

--- a/src/includes/input.js
+++ b/src/includes/input.js
@@ -313,14 +313,15 @@ pub.folder = function(folderPath) {
  * @method  loadJSON
  *
  * @param   {String|File} file The JSON file name in the document's data directory, an absolute path to a JSON file, a File instance or an URL.
+ * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
  * @return  {Object} The resulting data object.
  */
-pub.loadJSON = function(file) {
+pub.loadJSON = function(file, curlOptions) {
 
   var jsonString;
 
   if (isURL(file)) {
-    jsonString = getURL(file);
+    jsonString = getURL(file, curlOptions);
   } else {
     var inputFile = initDataFile(file),
       data = null;
@@ -341,11 +342,12 @@ pub.loadJSON = function(file) {
  * @method  loadString
  *
  * @param   {String|File} file The text file name in the document's data directory or a File instance or an URL
+ * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
  * @return  {String} String file or URL content.
  */
-pub.loadString = function(file) {
+pub.loadString = function(file, curlOptions) {
   if (isURL(file)) {
-    return getURL(file);
+    return getURL(file, curlOptions);
   } else {
     var inputFile = initDataFile(file),
       data = null;
@@ -365,11 +367,12 @@ pub.loadString = function(file) {
  * @method  loadStrings
  *
  * @param   {String|File} file The text file name in the document's data directory or a file instance or an URL
+ * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
  * @return  {Array} Array of the individual lines in the given file or URL
  */
-pub.loadStrings = function(file) {
+pub.loadStrings = function(file, curlOptions) {
   if (isURL(file)) {
-    var result = getURL(file);
+    var result = getURL(file, curlOptions);
     return result.match(/[^\r\n]+/g);
   } else {
     var inputFile = initDataFile(file),
@@ -621,12 +624,43 @@ pub.year = function() {
 // Input Private
 // ----------------------------------------
 
-var getURL = function(url) {
+var getURL = function(url, curlOptions) {
   if (isURL(url)) {
     if (Folder.fs === "Macintosh") {
-      return pub.shellExecute("curl -m 15 -L '" + url + "'");
+      curlUserOptions = '';
+      if(curlOptions != undefined){
+        curlUserOptions = curlOptions;
+      }
+      return pub.shellExecute("curl -m 15 -L '" + url + "' " + curlUserOptions);
     } else {
-      error(getParentFunctionName(1) + "(), loading of strings via an URL is a Mac only feature at the moment. Sorry!");
+      // Windows support - Based on GetDataFromWshShell()
+      // https://community.adobe.com/t5/indesign/execute-a-vbscript-inside-a-javascript/m-p/9406203?page=1#M69766
+      var vbs = 'Dim str\r';
+      vbs += 'URL = "' + url + '"\r';
+      vbs += 'Set WshShell = CreateObject("WScript.Shell")\r';
+      vbs += 'Set http = CreateObject("Microsoft.XmlHttp")\r';
+      vbs += 'On Error Resume Next\r';
+      vbs += 'http.open "GET", URL, False\r';
+      vbs += 'http.send ""\r';
+      vbs += 'if err.Number = 0 Then\r';
+      vbs += 'str = http.responseText\r';
+      vbs += 'Else\r';
+      vbs += 'MsgBox("error " & Err.Number & ": " & Err.Description)\r';
+      vbs += 'End If\r';
+      vbs += 'set WshShell = Nothing\r';
+      vbs += 'Set http = Nothing\r';
+      vbs += 'Set objInDesign = CreateObject("InDesign.Application")\r';
+      vbs += 'objInDesign.ScriptArgs.SetValue "WshShellResponse", str';
+
+      try {
+        app.doScript(vbs, ScriptLanguage.VISUAL_BASIC, undefined, UndoModes.FAST_ENTIRE_SCRIPT);
+      } catch(err) {
+        error(err.message + ", line: " + err.line);
+      }
+
+      var str = app.scriptArgs.getValue("WshShellResponse");
+      app.scriptArgs.clear();
+      return str;
     }
   } else {
     error(getParentFunctionName(1) + "(), the url " + url + " is invalid. Please double check!");

--- a/src/includes/input.js
+++ b/src/includes/input.js
@@ -313,15 +313,15 @@ pub.folder = function(folderPath) {
  * @method  loadJSON
  *
  * @param   {String|File} file The JSON file name in the document's data directory, an absolute path to a JSON file, a File instance or an URL.
- * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
+ * @param   {String} [userAgent] Optional parameter when URL is used, to specify a user-agent making request.
  * @return  {Object} The resulting data object.
  */
-pub.loadJSON = function(file, curlOptions) {
+pub.loadJSON = function(file, userAgent) {
 
   var jsonString;
 
   if (isURL(file)) {
-    jsonString = getURL(file, curlOptions);
+    jsonString = getURL(file, userAgent);
   } else {
     var inputFile = initDataFile(file),
       data = null;
@@ -342,12 +342,12 @@ pub.loadJSON = function(file, curlOptions) {
  * @method  loadString
  *
  * @param   {String|File} file The text file name in the document's data directory or a File instance or an URL
- * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
+ * @param   {String} [userAgent] Optional parameter when URL is used, to specify a user-agent making request.
  * @return  {String} String file or URL content.
  */
-pub.loadString = function(file, curlOptions) {
+pub.loadString = function(file, userAgent) {
   if (isURL(file)) {
-    return getURL(file, curlOptions);
+    return getURL(file, userAgent);
   } else {
     var inputFile = initDataFile(file),
       data = null;
@@ -367,12 +367,12 @@ pub.loadString = function(file, curlOptions) {
  * @method  loadStrings
  *
  * @param   {String|File} file The text file name in the document's data directory or a file instance or an URL
- * @param   {String} [curlOptions] Optional Mac-only parameters when URL is used, ie. `"--user-agent 'browser agent'"`
+ * @param   {String} [userAgent] Optional parameter when URL is used, to specify a user-agent making request.
  * @return  {Array} Array of the individual lines in the given file or URL
  */
-pub.loadStrings = function(file, curlOptions) {
+pub.loadStrings = function(file, userAgent) {
   if (isURL(file)) {
-    var result = getURL(file, curlOptions);
+    var result = getURL(file, userAgent);
     return result.match(/[^\r\n]+/g);
   } else {
     var inputFile = initDataFile(file),
@@ -624,14 +624,14 @@ pub.year = function() {
 // Input Private
 // ----------------------------------------
 
-var getURL = function(url, curlOptions) {
+var getURL = function(url, userAgent) {
   if (isURL(url)) {
     if (Folder.fs === "Macintosh") {
-      curlUserOptions = '';
-      if(curlOptions != undefined){
-        curlUserOptions = curlOptions;
+      curlAgent = '';
+      if(userAgent != undefined){
+        curlAgent = "--user-agent '"+userAgent+"'";
       }
-      return pub.shellExecute("curl -m 15 -L '" + url + "' " + curlUserOptions);
+      return pub.shellExecute("curl -m 15 -L '" + url + "' " + curlAgent);
     } else {
       // Windows support - Based on GetDataFromWshShell()
       // https://community.adobe.com/t5/indesign/execute-a-vbscript-inside-a-javascript/m-p/9406203?page=1#M69766
@@ -639,6 +639,9 @@ var getURL = function(url, curlOptions) {
       vbs += 'URL = "' + url + '"\r';
       vbs += 'Set WshShell = CreateObject("WScript.Shell")\r';
       vbs += 'Set http = CreateObject("Microsoft.XmlHttp")\r';
+      if(userAgent != undefined){
+        vbs += 'http.setRequestHeader "User-Agent", "'+userAgent+'"\r';
+      }
       vbs += 'On Error Resume Next\r';
       vbs += 'http.open "GET", URL, False\r';
       vbs += 'http.send ""\r';


### PR DESCRIPTION
- added support for CURL optional params (mac only) when using `loadString()` / `loadStrings()` / `loadJSON()`, since some API's (reddit) require sending a `--user-agent` to make a unique request.
- added support for Windows to also load URLs in the above functions! This had been a sore point for PC users in classes/workshops – but tested this script a few times and seems to work fine.