### PR TITLE
Csv functions

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1566,21 +1566,21 @@ function CSV() {
   }
 
   /**
-   * @summary Decodes a CSV string to an array.
+   * @summary Parses (decodes) a CSV string to an array.
    * @description Function parses a string as CSV-object Array.
    *
    * @cat     Data
    * @subcat  CSV
-   * @method  CSV.decode
+   * @method  CSV.parse
    *
    * @param   {String} String to be parsed as CSV-object.
    * @return  {Array} Returns CSV-object Array
    *
    * @example
-   * var arr = CSV.decode(str);
-   * var str = CSV.encode(arr);
+   * var arr = CSV.parse(str);
+   * var str = CSV.stringify(arr);
    */
-  this.decode = function(text) {
+  this.parse = function(text) {
     var header;
     return parseRows(text, function(row, i) {
       if (i) {
@@ -1595,8 +1595,8 @@ function CSV() {
   };
 
   /**
-   * @summary Sets the delimiter of the CSV decode and encode function.
-   * @description Sets the delimiter of the CSV decode and encode function.
+   * @summary Sets the delimiter of the CSV parse and stringify function.
+   * @description Sets the delimiter of the CSV parse and stringify function.
    *
    * @cat     Data
    * @subcat  CSV
@@ -1615,21 +1615,21 @@ function CSV() {
   };
 
   /**
-   * @summary Encodes an array to a CSV string.
+   * @summary Stringifies (encodes) an array to a CSV string.
    * @description Function convert an javascript array of objects to a CSV-string.
    *
    * @cat     Data
    * @subcat  CSV
-   * @method  CSV.encode
+   * @method  CSV.stringify
    *
    * @param   {Array} Array to be converted to a CSV-string
    * @return  {String} Returns CSV-string
    *
    * @example
-   * var str = CSV.encode(arr);
-   * var arr = CSV.decode(str);
+   * var str = CSV.stringify(arr);
+   * var arr = CSV.parse(str);
    */
-  this.encode = function(rows) {
+  this.stringify = function(rows) {
     var csvStrings = [];
     var header = [];
     var firstRow = rows[0]; // all rows have to have the same properties keys

--- a/basil.js
+++ b/basil.js
@@ -1557,30 +1557,32 @@ function CSV() {
     delimiterStr = null,
     delimiterCode = null;
 
-  initDelimiter(",");
   function initDelimiter(delimiter) {
-    reParse = new RegExp("\r\n|[" + delimiter + "\r\n]", "g"), // field separator regex
-    reFormat = new RegExp("[\"" + delimiter + "\n]"),
-    delimiterCode = delimiter.charCodeAt(0);
-    delimiterStr = delimiter;
+    var newDelimiter = delimiter || ",";
+    reParse = new RegExp("\r\n|[" + newDelimiter + "\r\n]", "g"), // field separator regex
+    reFormat = new RegExp("[\"" + newDelimiter + "\n]"),
+    delimiterCode = newDelimiter.charCodeAt(0);
+    delimiterStr = newDelimiter;
   }
 
   /**
    * @summary Parses (decodes) a CSV string to an array.
-   * @description Function parses a string as CSV-object Array.
+   * @description Function parses a string as CSV-object Array, with optional custom delimiter.
    *
    * @cat     Data
    * @subcat  CSV
    * @method  CSV.parse
    *
    * @param   {String} String to be parsed as CSV-object.
+   * @param   {String} [delimiter] optional character[s] used to separate data.
    * @return  {Array} Returns CSV-object Array
    *
    * @example
    * var arr = CSV.parse(str);
    * var str = CSV.stringify(arr);
    */
-  this.parse = function(text) {
+  this.parse = function(text, delimiter) {
+    initDelimiter(delimiter);
     var header;
     return parseRows(text, function(row, i) {
       if (i) {
@@ -1595,41 +1597,23 @@ function CSV() {
   };
 
   /**
-   * @summary Sets the delimiter of the CSV parse and stringify function.
-   * @description Sets the delimiter of the CSV parse and stringify function.
-   *
-   * @cat     Data
-   * @subcat  CSV
-   * @method  CSV.delimiter
-   *
-   * @param   {String} [delimiter] Optional Sets the delimiter for CSV parsing
-   * @return  {String} Returns the current delimiter if called without argument
-   */
-  this.delimiter = function(delimiter) {
-    if (arguments.length === 0) return delimiterStr;
-    if (typeof delimiter === "string") {
-      initDelimiter(delimiter);
-    } else {
-      error("CSV.delimiter, separator has to be a character or string");
-    }
-  };
-
-  /**
    * @summary Stringifies (encodes) an array to a CSV string.
-   * @description Function convert an javascript array of objects to a CSV-string.
+   * @description Function convert an javascript array of objects to a CSV-string, with optional custom delimiter.
    *
    * @cat     Data
    * @subcat  CSV
    * @method  CSV.stringify
    *
    * @param   {Array} Array to be converted to a CSV-string
+   * @param   {String} [delimiter] optional character[s] used to separate data.
    * @return  {String} Returns CSV-string
    *
    * @example
    * var str = CSV.stringify(arr);
    * var arr = CSV.parse(str);
    */
-  this.stringify = function(rows) {
+  this.stringify = function(rows, delimiter) {
+    initDelimiter(delimiter);
     var csvStrings = [];
     var header = [];
     var firstRow = rows[0]; // all rows have to have the same properties keys
@@ -5343,6 +5327,35 @@ pub.folder = function(folderPath) {
 };
 
 /**
+ * @summary Gets and parses the contents of a CSV file.
+ * @description Reads the contents of a CSV file and returns a CSV-object array with the data. If the file is specified by name as string, the path can point either directly at a file in the document's data directory or be specified as an absolute path.
+ *
+ * @cat     Input
+ * @subcat  Files
+ * @method  loadCSV
+ *
+ * @param   {String|File} file The CSV file name in the document's data directory, an absolute path to a CSV file, a File instance or an URL.
+ * @param   {String} [delimiter] optional character[s] used to separate data.
+ * @return  {Object} The resulting data object.
+ */
+pub.loadCSV = function(file, delimiter) {
+
+  var csvString;
+
+  if (isURL(file)) {
+    csvString = getURL(file);
+  } else {
+    var inputFile = initDataFile(file),
+      data = null;
+    inputFile.open("r");
+    csvString = inputFile.read();
+    inputFile.close();
+  }
+
+  return pub.CSV.parse(csvString, delimiter);
+};
+
+/**
  * @summary Gets and parses the contents of a JSON file.
  * @description Reads the contents of a JSON file and returns an object with the data. If the file is specified by name as string, the path can point either directly at a file in the document's data directory or be specified as an absolute path.
  *
@@ -6885,6 +6898,30 @@ var println = pub.println = function() {
 // ----------------------------------------
 // Output/Files
 // ----------------------------------------
+
+/**
+ * @summary  Encodes a CSV-object array to multi-line strings and saves it to a CSV file.
+ * @description Encodes a CSV-object array to multi-line strings and saves it to a CSV file. If the given file exists it gets overridden.
+ *
+ * @cat     Output
+ * @subcat  Files
+ * @method  saveCSV
+ *
+ * @param   {String|File} file The file name or a File instance.
+ * @param   {Object} data The object to encode and save in the file.
+ * @param   {String} [delimiter] optional character[s] used to separate data.
+ * @return  {File} The CSV file the data was written to.
+ */
+pub.saveCSV = function(file, data, delimiter) {
+  var csvString = pub.CSV.stringify(data, delimiter);
+  var outputFile = initExportFile(file);
+  outputFile.open("w");
+  outputFile.lineFeed = Folder.fs === "Macintosh" ? "Unix" : "Windows";
+  outputFile.encoding = "UTF-8";
+  outputFile.write(csvString);
+  outputFile.close();
+  return outputFile;
+};
 
 /**
  * @summary  Encodes an object to a JSON string and saves it to a JSON file.

--- a/changelog.txt
+++ b/changelog.txt
@@ -52,6 +52,10 @@ basil.js x.x.x DAY MONTH YEAR
   checks if a given variable is an integer
 + basil scripts don't try to start ExtendScript Toolkit in the background anymore
 + Added week() to return week number of the year
++ Added loadCSV() to load an parse CSV files one step
++ Added saveCSV() to stringify data and save it as CSV file in one step
++ Added CSV.parse() and CSV.stringify() to replace CSV.decode() and CSV.encode()
+  parse and stringify accept optional 2nd parameter for custom delimiter.
 
 * translate(), rotate() and scale() now behave like they do in Processing and change the current matrix
 * basil scripts will by default use the user's default units or the current units of the document,
@@ -116,6 +120,9 @@ The user is allowed to have his files wherever he wants.
 - b.storyCount() is removed (use stories(doc()).length instead)
 - Array.map() and Array.filter() are removed
 - b.Random.nextGaussian() is removed
+- CSV.decode() and CSV.encode() are removed and replaced by CSV.parse()
+  and CSV.stringfy()
+- CSV.delimiter() is removed and integrated as optional parameter of CSV.parse() and CSV.stringify()
 
 Special thanks to Hartmut Bohnacker for making the transform functions work in Processing style!
 

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -154,21 +154,21 @@ function CSV() {
   }
 
   /**
-   * @summary Decodes a CSV string to an array.
+   * @summary Parses (decodes) a CSV string to an array.
    * @description Function parses a string as CSV-object Array.
    *
    * @cat     Data
    * @subcat  CSV
-   * @method  CSV.decode
+   * @method  CSV.parse
    *
    * @param   {String} String to be parsed as CSV-object.
    * @return  {Array} Returns CSV-object Array
    *
    * @example
-   * var arr = CSV.decode(str);
-   * var str = CSV.encode(arr);
+   * var arr = CSV.parse(str);
+   * var str = CSV.stringify(arr);
    */
-  this.decode = function(text) {
+  this.parse = function(text) {
     var header;
     return parseRows(text, function(row, i) {
       if (i) {
@@ -183,8 +183,8 @@ function CSV() {
   };
 
   /**
-   * @summary Sets the delimiter of the CSV decode and encode function.
-   * @description Sets the delimiter of the CSV decode and encode function.
+   * @summary Sets the delimiter of the CSV parse and stringify function.
+   * @description Sets the delimiter of the CSV parse and stringify function.
    *
    * @cat     Data
    * @subcat  CSV
@@ -203,21 +203,21 @@ function CSV() {
   };
 
   /**
-   * @summary Encodes an array to a CSV string.
+   * @summary Stringifies (encodes) an array to a CSV string.
    * @description Function convert an javascript array of objects to a CSV-string.
    *
    * @cat     Data
    * @subcat  CSV
-   * @method  CSV.encode
+   * @method  CSV.stringify
    *
    * @param   {Array} Array to be converted to a CSV-string
    * @return  {String} Returns CSV-string
    *
    * @example
-   * var str = CSV.encode(arr);
-   * var arr = CSV.decode(str);
+   * var str = CSV.stringify(arr);
+   * var arr = CSV.parse(str);
    */
-  this.encode = function(rows) {
+  this.stringify = function(rows) {
     var csvStrings = [];
     var header = [];
     var firstRow = rows[0]; // all rows have to have the same properties keys

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -145,30 +145,32 @@ function CSV() {
     delimiterStr = null,
     delimiterCode = null;
 
-  initDelimiter(",");
   function initDelimiter(delimiter) {
-    reParse = new RegExp("\r\n|[" + delimiter + "\r\n]", "g"), // field separator regex
-    reFormat = new RegExp("[\"" + delimiter + "\n]"),
-    delimiterCode = delimiter.charCodeAt(0);
-    delimiterStr = delimiter;
+    var newDelimiter = delimiter || ",";
+    reParse = new RegExp("\r\n|[" + newDelimiter + "\r\n]", "g"), // field separator regex
+    reFormat = new RegExp("[\"" + newDelimiter + "\n]"),
+    delimiterCode = newDelimiter.charCodeAt(0);
+    delimiterStr = newDelimiter;
   }
 
   /**
    * @summary Parses (decodes) a CSV string to an array.
-   * @description Function parses a string as CSV-object Array.
+   * @description Function parses a string as CSV-object Array, with optional custom delimiter.
    *
    * @cat     Data
    * @subcat  CSV
    * @method  CSV.parse
    *
    * @param   {String} String to be parsed as CSV-object.
+   * @param   {String} [delimiter] optional character[s] used to separate data.
    * @return  {Array} Returns CSV-object Array
    *
    * @example
    * var arr = CSV.parse(str);
    * var str = CSV.stringify(arr);
    */
-  this.parse = function(text) {
+  this.parse = function(text, delimiter) {
+    initDelimiter(delimiter);
     var header;
     return parseRows(text, function(row, i) {
       if (i) {
@@ -183,41 +185,23 @@ function CSV() {
   };
 
   /**
-   * @summary Sets the delimiter of the CSV parse and stringify function.
-   * @description Sets the delimiter of the CSV parse and stringify function.
-   *
-   * @cat     Data
-   * @subcat  CSV
-   * @method  CSV.delimiter
-   *
-   * @param   {String} [delimiter] Optional Sets the delimiter for CSV parsing
-   * @return  {String} Returns the current delimiter if called without argument
-   */
-  this.delimiter = function(delimiter) {
-    if (arguments.length === 0) return delimiterStr;
-    if (typeof delimiter === "string") {
-      initDelimiter(delimiter);
-    } else {
-      error("CSV.delimiter, separator has to be a character or string");
-    }
-  };
-
-  /**
    * @summary Stringifies (encodes) an array to a CSV string.
-   * @description Function convert an javascript array of objects to a CSV-string.
+   * @description Function convert an javascript array of objects to a CSV-string, with optional custom delimiter.
    *
    * @cat     Data
    * @subcat  CSV
    * @method  CSV.stringify
    *
    * @param   {Array} Array to be converted to a CSV-string
+   * @param   {String} [delimiter] optional character[s] used to separate data.
    * @return  {String} Returns CSV-string
    *
    * @example
    * var str = CSV.stringify(arr);
    * var arr = CSV.parse(str);
    */
-  this.stringify = function(rows) {
+  this.stringify = function(rows, delimiter) {
+    initDelimiter(delimiter);
     var csvStrings = [];
     var header = [];
     var firstRow = rows[0]; // all rows have to have the same properties keys

--- a/src/includes/input.js
+++ b/src/includes/input.js
@@ -305,6 +305,35 @@ pub.folder = function(folderPath) {
 };
 
 /**
+ * @summary Gets and parses the contents of a CSV file.
+ * @description Reads the contents of a CSV file and returns a CSV-object array with the data. If the file is specified by name as string, the path can point either directly at a file in the document's data directory or be specified as an absolute path.
+ *
+ * @cat     Input
+ * @subcat  Files
+ * @method  loadCSV
+ *
+ * @param   {String|File} file The CSV file name in the document's data directory, an absolute path to a CSV file, a File instance or an URL.
+ * @param   {String} [delimiter] optional character[s] used to separate data.
+ * @return  {Object} The resulting data object.
+ */
+pub.loadCSV = function(file, delimiter) {
+
+  var csvString;
+
+  if (isURL(file)) {
+    csvString = getURL(file);
+  } else {
+    var inputFile = initDataFile(file),
+      data = null;
+    inputFile.open("r");
+    csvString = inputFile.read();
+    inputFile.close();
+  }
+
+  return pub.CSV.parse(csvString, delimiter);
+};
+
+/**
  * @summary Gets and parses the contents of a JSON file.
  * @description Reads the contents of a JSON file and returns an object with the data. If the file is specified by name as string, the path can point either directly at a file in the document's data directory or be specified as an absolute path.
  *

--- a/src/includes/output.js
+++ b/src/includes/output.js
@@ -45,6 +45,30 @@ var println = pub.println = function() {
 // ----------------------------------------
 
 /**
+ * @summary  Encodes a CSV-object array to multi-line strings and saves it to a CSV file.
+ * @description Encodes a CSV-object array to multi-line strings and saves it to a CSV file. If the given file exists it gets overridden.
+ *
+ * @cat     Output
+ * @subcat  Files
+ * @method  saveCSV
+ *
+ * @param   {String|File} file The file name or a File instance.
+ * @param   {Object} data The object to encode and save in the file.
+ * @param   {String} [delimiter] optional character[s] used to separate data.
+ * @return  {File} The CSV file the data was written to.
+ */
+pub.saveCSV = function(file, data, delimiter) {
+  var csvString = pub.CSV.stringify(data, delimiter);
+  var outputFile = initExportFile(file);
+  outputFile.open("w");
+  outputFile.lineFeed = Folder.fs === "Macintosh" ? "Unix" : "Windows";
+  outputFile.encoding = "UTF-8";
+  outputFile.write(csvString);
+  outputFile.close();
+  return outputFile;
+};
+
+/**
  * @summary  Encodes an object to a JSON string and saves it to a JSON file.
  * @description Encodes an object to a JSON string and saves it to a JSON file. If the given file exists it gets overridden.
  *

--- a/test/data-tests.jsx
+++ b/test/data-tests.jsx
@@ -136,6 +136,19 @@ basilTest("DataTests", {
   },
 
 // ----------------------------------------
+// Data/CSV
+// ----------------------------------------
+
+  testCSV: function(){
+    var myDoc = doc();
+    var rawData = 'name**age**color\nbob**14**red\nbev**46**orange\nfred**8**black\nsally**20**blue';
+    var data = CSV.parse(rawData, '**');
+    assert(data.length === 4);
+    assert(data[0].name === 'bob');
+    assert(typeof CSV.stringify(data) === 'string');
+  },
+
+// ----------------------------------------
 // Data/JSON
 // ----------------------------------------
 


### PR DESCRIPTION
- replace `CSV.encode()`/`CSV.decode()` w/ `stringify`/`parse`
- added `saveCSV()` and `loadCSV()`
- removed `CSV.delimiter()` and embedded into above functions
- added test for CSV `parse` and `stringify`
- updated changelog