### PR TITLE
Print correct 2.0 pre-release version when running scripts

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -4958,7 +4958,7 @@ pub.SCRIPTNAME = scriptName;
  * @subcat   Constants
  * @property VERSION {String}
  */
-pub.VERSION = "1.1.0";
+pub.VERSION = "2.0.0-PRE";
 
 // ----------------------------------------
 // src/includes/image.js

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -452,4 +452,4 @@ pub.SCRIPTNAME = scriptName;
  * @subcat   Constants
  * @property VERSION {String}
  */
-pub.VERSION = "1.1.0";
+pub.VERSION = "2.0.0-PRE";

--- a/src/includes/environment.js
+++ b/src/includes/environment.js
@@ -452,4 +452,4 @@ pub.SCRIPTNAME = scriptName;
  * @subcat   Constants
  * @property VERSION {String}
  */
-pub.VERSION = "2.0.0-PRE";
+pub.VERSION = "2.0.0-beta";


### PR DESCRIPTION
Long overdue update to basil.js version that gets printed when running scripts (could be confusing when using this version versus another). package.json can be updated later once really ready.