### PR TITLE
createOutlines() + pathToPoints()

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -9052,7 +9052,7 @@ pub.createOutlines = function(item, cb) {
         changedFill = true;
       }
     }
-    inspect(item)
+
     outlines = item.createOutlines();
 
   // check if textPath

--- a/basil.js
+++ b/basil.js
@@ -7734,41 +7734,60 @@ pub.vertex = function() {
 
 /**
  * @summary Get points and bezier coordinates from path(s).
- * @description Returns an object containing an array of all points, an array of all beziers (points + their anchor points) and an array of all paths of a given path item in InDesign. Together with `createOutlines()` this can be used on text items. Accepts both single paths or a collection/group of paths.
+ * @description Returns an object containing an array of all points, an array of all beziers (points + their anchor points) and an array of all paths (containing its array of points + beziers) of a given pageItem in InDesign. Together with `createOutlines()` this can be used on text items. Accepts both single paths or a collection/group of paths.
  * When using this on a multi path object (e.g. text with separate paths), the `paths` property can be used to loop over every path separately, whereas the properties `points` and `beziers` contain arrays for all paths combined.
  * An optional second parameter allows to add and return additional points between existing points, which is helpful for subdividing existing paths.
  *
  * @cat    Shape
  * @method pathToPoints
  * @param  {Object} obj       The pageItem(s) to process point/bezier coordinates of.
- * @param  {Number} [addPts]  Optional amount of additional interpolated points.
+ * @param  {Number} [addPoints]  Optional amount of additional interpolated points.
  * @return {Object}           Returns object with the following arrays `points`, `beziers`, `paths`
  *
  * @example <caption>Points</caption>
  * var pts = pathToPoints(obj);
  * println(pts.points.length); // # of points
- * point(pts.points[0].x, pts.points[0].y); // first point
+ *
+ * for (var i = 0; i < pts.points.length; i++) {
+ *   var pt = pts.points[i];
+ *   point(pt.x, pt.y);
+ * }
  *
  * @example <caption>Points w/ Interpolation</caption>
  * var pts = pathToPoints(obj, 5); // adds 5 points between points
  * println(pts.points.length); # of points
  *
+ * for (var i = 0; i < pts.points.length; i++) {
+ *   var pt = pts.points[i];
+ *   point(pt.x, pt.y);
+ * }
+ *
  * @example <caption>Beziers</caption>
  * var pts = pathToPoints(obj);
  * println(pts.beziers.length); # of beziers
- * // vertex(pts.beziers[0].anchor.x, pts.beziers[0].anchor.y, pts.beziers[0].left.x, pts.beziers[0].left.y, pts.beziers[0].right.x, pts.beziers[0].right.y);
+ *
+ * beginShape();
+ * for (var i = 0; i < pts.beziers.length; i++) {
+ *   var bz = pts.beziers[i];
+ *   vertex(bz.anchor.x, bz.anchor.y, bz.left.x, bz.left.y, bz.right.x, bz.right.y);
+ * }
+ * endShape(CLOSE);
  *
  * @example <caption>Isolated Paths of Points</caption>
  * var pts = pathToPoints(obj);
+ *
  * for (var i=0; i < pts.paths.length; i++) {
  *   var path = pts.paths[i];
  *   println(path.points.length); # of points
- *   point(path.points[0].x, path.points[0].y); // first point
- * }
  *
+ *   for (var i = 0; i < path.points.length; i++) {
+ *     var pt = path.points[i];
+ *     point(pt.x, pt.y);
+ *   }
+ * }
  */
 
-pub.pathToPoints = function(obj, addPts) {
+pub.pathToPoints = function(obj, addPoints) {
   var pz = {paths:[], points:[], beziers:[]},
   pzGroup = false,
   grabPoints = function(formElm) {
@@ -7788,14 +7807,14 @@ pub.pathToPoints = function(obj, addPts) {
         pzBeziers.push(pzBezier)
 
         // optionally interpolated points
-        if (addPts === undefined) {
+        if (addPoints === undefined) {
           var pzPoint = {x:pt.anchor[0], y:pt.anchor[1]};
           pz.points.push(pzPoint)
           pzPoints.push(pzPoint);
         } else {
           var nextSel = (i + 1) % paths.pathPoints.length;
           var nextPt = paths.pathPoints[nextSel];
-          var amt = 1.0 / (addPts + 1);
+          var amt = 1.0 / (addPoints + 1);
 
           if (formElm.paths[0].pathType === PathType.OPEN_PATH && i === paths.pathPoints.length-1) {
             amt = 1; // don't interpolate end to start on open paths
@@ -9013,21 +9032,22 @@ pub.paragraphStyle = function(textOrName, props) {
 
 /**
  * @summary Convert text items to outlines.
- * @description Returns a polygon or array of polygons (if text is multi-line, multi-boxed, or a textPath) and optionally processes them with a callback function.
+ * @description Returns an array of polygons after outlining text and optionally processes them with a callback function.
  * Use together with `pathToPoints()` for getting point and bezier coordinates from outlines.
  *
  * @cat Typography
  * @method createOutlines
- * @param  {Story|TextFrame||Paragraph||Line||Word||Character||GraphicLine||Polygon||Oval||Rectangle} item Text or textpath to be outlined.
- * @param  {Function} [cb] Optional: The callback function to call with each polygon. Passed arguments: `obj`, `loopCounter`
+ *
+ * @param  {TextFrame|TextPath} item Text or TextPath to be outlined.
+ * @param  {Function} [cb] Optional: Callback function to use with each polygon. Passed arguments: `obj`, `loopCounter`
  * @return {Array of Polygons} Returns an array of polygons.
  *
- * @example <caption>createOutlines</caption>
+ * @example
  * textSize(150);
  * var myText = text("Hello", 0, 0, width, height);
  * var outlines = createOutlines(myText);
  *
- * @example <caption>createOutlines with Callback</caption>
+ * @example <caption>w/ Callback</caption>
  * textSize(150);
  * var myText = text("Hello \nWorld", 0, 0, width, height);
  * var outlines = createOutlines(myText, function(obj){

--- a/basil.js
+++ b/basil.js
@@ -819,7 +819,7 @@ var getParentFunctionName = function(level) {
 }
 
 var checkNull = function (obj) {
-  if(obj === null || typeof obj === undefined) error("Received null object.");
+  if(obj === null || typeof obj === undefined) error("Received null " + obj);
 };
 
 var isEnum = function(base, value) {
@@ -7729,6 +7729,159 @@ pub.vertex = function() {
 };
 
 // ----------------------------------------
+// Shape/Path to Points
+// ----------------------------------------
+
+/**
+ * @summary Get points and bezier coordinates from path(s).
+ * @description Returns an object containing array of points, beziers, and both separated by paths. Intended for use with `createOutlines()` of text, but works with most pageItem paths. Accepts both single paths or a collection/group of paths. Both points and beziers will have connected lines (one big array), use paths followed by points or beziers for isolated shapes.
+ *
+ * @cat    Shape
+ * @method pathToPoints
+ * @param  {Object} obj       The pageItem(s) to process point/bezier coordinates of
+ * @param  {Number} [addPts]  Optional amount of additional interpolated points. Ignore if using beziers.
+ * @return {Object}           Returns object with following values: .points[], .beziers[], .paths[].points[], .paths[].beziers[]
+ *
+ * @example <caption>Points</caption>
+ * noFill();
+ * var myEllipse = ellipse(width / 2, height / 2, width / 2, width / 2);
+ * var pts = pathToPoints(myEllipse);
+ * var ptsExtended = pathToPoints(myEllipse, 5); // add 5 points between points
+ *
+ * noStroke();
+ * fill(0, 0, 255);
+ *
+ * // draw normal points
+ * for (var i=0; i < pts.points.length; i++) {
+ *   var pt = pts.points[i];
+ *   ellipse(pt.x, pt.y, 10, 10);
+ * }
+ *
+ * noFill();
+ * stroke(255, 0, 0);
+ * // draw extended points
+ * for (var i=0; i < ptsExtended.points.length; i++) {
+ *   var pt = ptsExtended.points[i];
+ *   ellipse(pt.x, pt.y, 10, 10);
+ * }
+ *
+ * @example <caption>Beziers from text using createOutlines()</caption>
+ * textSize(400);
+ * var myText = text("H", width/4, height/4, 500, 500);
+ * var outlines = createOutlines(myText);
+ * var pts = pathToPoints(outlines);
+ * property(outlines, "fillColor", "None");
+ *
+ * noFill();
+ * stroke(0, 255, 0);
+ *
+ * // draw bezier
+ * beginShape();
+ * for (var i=0; i < pts.beziers.length; i++) {
+ *   var pt = pts.beziers[i]; // point w/ .anchor .left .right
+ *   vertex(pt.anchor.x, pt.anchor.y, pt.left.x, pt.left.y, pt.right.x, pt.right.y);
+ * }
+ * endShape(CLOSE);
+ *
+ * // debug bezier
+ * for (var i=0; i < pts.beziers.length; i++) {
+ *   var pt = pts.beziers[i]; // point
+ *   var anchor = pt.anchor; // anchor
+ *   var left = pt.left; // left handle
+ *   var right = pt.right; // right handle
+ *   noStroke();
+ *   fill(0);
+ *   ellipse(anchor.x, anchor.y, 5, 5);
+ *   ellipse(left.x, left.y, 5, 5);
+ *   ellipse(right.x, right.y, 5, 5);
+ *   stroke(0, 255, 0);
+ *   line(anchor.x, anchor.y, left.x, left.y);
+ *   line(anchor.x, anchor.y, right.x, right.y);
+ * }
+ *
+ * @example <caption>Isolated Paths of Beziers from text using createOutlines()</caption>
+ * textSize(200);
+ * var myText = text("hello", width/4, height/4, 500, 500);
+ * var outlines = createOutlines(myText);
+ * var pts = pathToPoints(outlines);
+ * property(outlines, "fillColor", "None");
+ *
+ * noFill();
+ * stroke(0, 255, 0);
+ *
+ * // just beziers
+ * for (var p=0; p < pts.paths.length; p++) {
+ *   var path = pts.paths[p]; // each path isolated
+ *   beginShape();
+ *   for (var i=0; i<path.beziers.length; i++) {
+ *     var tp = path.beziers[i];
+ *     vertex(tp.anchor.x, tp.anchor.y, tp.left.x, tp.left.y, tp.right.x, tp.right.y);
+ *   }
+ *   endShape(CLOSE);
+ * }
+ *
+ */
+
+pub.pathToPoints = function(obj, addPts) {
+  var pz = {paths:[], points:[], beziers:[]},
+  pzGroup = false,
+  grabPoints = function(formElm) {
+    for (var j=0; j < formElm.paths.length; j++) {
+      var paths = formElm.paths[j];
+      var pzPaths = [];
+      var pzPoints = [];
+      var pzBeziers = [];
+      for (var i=0; i < paths.pathPoints.length; i++) {
+        var pt = paths.pathPoints[i];
+        var pzBezier = {
+          anchor:{x:pt.anchor[0], y:pt.anchor[1]},
+          left:{x:pt.leftDirection[0], y:pt.leftDirection[1]},
+          right:{x:pt.rightDirection[0], y:pt.rightDirection[1]}
+        };
+        pz.beziers.push(pzBezier)
+        pzBeziers.push(pzBezier)
+
+        // optionally interpolated points
+        if (addPts === undefined) {
+          var pzPoint = {x:pt.anchor[0], y:pt.anchor[1]};
+          pz.points.push(pzPoint)
+          pzPoints.push(pzPoint);
+        } else {
+          var nextPt = paths.pathPoints[(i + 1) % paths.pathPoints.length];
+          var amt = 1.0 / (addPts + 1);
+          for (var t = 0; t < 1; t += amt) {
+            var ptStep = interpolateBezier(pt, nextPt, t);
+            var pzPointStep = {x:ptStep.x, y:ptStep.y};
+            pz.points.push(pzPointStep)
+            pzPoints.push(pzPointStep);
+          }
+        }
+      }
+
+      var pzPath = {points:pzPoints, beziers:pzBeziers};
+      pz.paths.push(pzPath);
+    }
+  }
+
+  // catch grouped items
+  if (obj instanceof Group) {
+    obj = obj.pageItems;
+    pzGroup = true;
+  }
+
+  // process type as multi-line/character or single
+  if (obj instanceof Array || pzGroup) {
+    for (var k=0; k < obj.length; k++) {
+      grabPoints(obj[k]);
+    }
+  } else {
+    grabPoints(obj);
+  }
+
+  return pz;
+}
+
+// ----------------------------------------
 // Shape Private
 // ----------------------------------------
 
@@ -7815,6 +7968,28 @@ function doAddPath() {
   } else {
     notCalledBeginShapeError();
   }
+}
+
+/*
+ * https://stackoverflow.com/questions/4089443/find-the-tangent-of-a-point-on-a-cubic-bezier-curve
+ * https://webglfundamentals.org/webgl/lessons/webgl-3d-geometry-lathe.html
+ */
+function interpolateBezier(startPoint, endPoint, t) {
+  var newCoord = [];
+  for (var i = 0; i < 2; i++) {
+    var p1 = startPoint.anchor[i];
+    var p2 = startPoint.rightDirection[i];
+    var p3 = endPoint.leftDirection[i];
+    var p4 = endPoint.anchor[i];
+
+    var C1 = (p4 - (3.0 * p3) + (3.0 * p2) - p1);
+    var C2 = ((3.0 * p3) - (6.0 * p2) + (3.0 * p1));
+    var C3 = ((3.0 * p2) - (3.0 * p1));
+    var C4 = (p1);
+
+    newCoord[i] = (C1 * t * t * t + C2 * t * t + C3 * t + C4);
+  }
+  return {x:newCoord[0], y:newCoord[1]};
 }
 
 function notCalledBeginShapeError () {
@@ -8619,7 +8794,11 @@ pub.textLeading = function(leading) {
  */
 pub.textSize = function(pointSize) {
   if (arguments.length === 1) {
-    currFontSize = pointSize;
+    if(pointSize > 0) {
+      currFontSize = pointSize;
+    }else{
+      error("textSize() must be greater than 0.");
+    }
   }
   return currFontSize;
 };
@@ -8875,6 +9054,116 @@ pub.paragraphStyle = function(textOrName, props) {
 
   return style;
 };
+
+// ----------------------------------------
+// Typography/Outlines
+// ----------------------------------------
+
+/**
+ * @summary Convert text items to outlines.
+ * @description Returns a polygon or array of polygons (if text is multi-line, multi-boxed, or a textPath) and optionally processes them with a callback function. Intended for use with `pathToPoints()` for getting point and bezier coordinates from outlines. Warning, InDesign requires that text have a fill color in order to createOutlines.
+ *
+ * @cat Typography
+ * @method createOutlines
+ * @param  {Story|TextFrame||Paragraph||Line||Word||Character||GraphicLine||Polygon||Oval||Rectangle} item Text or textpath to be outlined.
+ * @param  {Function} [cb] Optional: The callback function to call with each polygon. Passed arguments: `obj`, `loopCounter`
+ * @return {Polygon | Array of Polygons} Returns a single or array of polygons depending on text converted.
+ *
+ * @example <caption>Points</caption>
+ * textSize(150);
+ * var myText = text("Hello", width/4, height/4, 500, 800);
+ * var outlines = createOutlines(myText); // create outlines
+ * var pts = pathToPoints(outlines); // get points
+ * // inspect(pts); // view structure
+ * for (var i=0; i < pts.points.length; i++) {
+ *   var pt = pts.points[i]; // each point
+ *   ellipse(pt.x, pt.y, 5, 5);
+ * }
+ * property(outlines, "fillColor", "None");
+ *
+ * @example <caption>Points Extended</caption>
+ * textSize(150);
+ * var myText = text("Hello", width/4, height/4, 500, 800);
+ * var outlines = createOutlines(myText); // create outlines
+ * var pts = pathToPoints(outlines, 4); // get points, add 4 between each point
+ * for (var i=0; i < pts.points.length; i++) {
+ *   var pt = pts.points[i]; // each point
+ *   var s = map(i, 0, pts.points.length, .1, 5);
+ *   ellipse(pt.x, pt.y, s, s);
+ * }
+ * property(outlines, "fillColor", "None");
+ *
+ * @example <caption>Path isolated Beziers</caption>
+ * textSize(150);
+ * var myText = text("Hello", width/4, height/4, 500, 800);
+ * var outlines = createOutlines(myText); // create outlines
+ * var pts = pathToPoints(outlines); // get points + beziers + paths
+ * property(outlines, "fillColor", "None");
+ *
+ * noFill();
+ * stroke(0);
+ *
+ * // process paths -> beziers
+ * for (var p=0; p < pts.paths.length; p++) {
+ *   var path = pts.paths[p]; // each path isolated
+ *   beginShape();
+ *   for (var i=0; i < path.beziers.length; i++) {
+ *     var tp = path.beziers[i];
+ *     var offset = sin(i * 5) * 15; // shift points
+ *     vertex(tp.anchor.x + offset, tp.anchor.y, tp.left.x, tp.left.y, tp.right.x, tp.right.y);
+ *   }
+ *   endShape(CLOSE);
+ * }
+ *
+ */
+
+
+pub.createOutlines = function(item, cb) {
+  var outlines;
+
+  // check textFrames, textPaths, or neither
+  if (item.hasOwnProperty('createOutlines')) {
+    outlines = item.createOutlines();
+  } else if ( item instanceof GraphicLine ||
+              item instanceof Oval ||
+              item instanceof Rectangle ||
+              item instanceof Polygon) {
+    if (item.textPaths.length > 0) {
+      outlines = item.textPaths[0].texts[0].createOutlines();
+    }
+  } else {
+    error("Be sure to use:\n Story | TextFrame | Paragraph | Line | Word | Character | TextPath")
+    return false;
+  }
+
+  // process outlines
+  if (outlines.length != undefined && outlines.length === 1) {
+    // multi-line text from group array
+    if (outlines[0] instanceof Group) {
+      outlines = ungroup(outlines[0]);
+      if (cb instanceof Function) {
+        return forEach(outlines, cb);
+      } else {
+        return outlines;
+      }
+    }
+
+    // single polygon
+    if (cb instanceof Function) {
+      cb(outlines[0]);
+    } else {
+      return outlines[0];
+    }
+  } else {
+
+    // collection of polygons
+    if (cb instanceof Function) {
+      return forEach(outlines, cb);
+    } else {
+      return outlines;
+    }
+  }
+}
 
 // ----------------------------------------
 // Typography/Constants

--- a/basil.js
+++ b/basil.js
@@ -7755,7 +7755,7 @@ pub.vertex = function() {
  *
  * @example <caption>Points w/ Interpolation</caption>
  * var pts = pathToPoints(obj, 5); // adds 5 points between points
- * println(pts.points.length); # of points
+ * println(pts.points.length); // # of points
  *
  * for (var i = 0; i < pts.points.length; i++) {
  *   var pt = pts.points[i];
@@ -7764,7 +7764,7 @@ pub.vertex = function() {
  *
  * @example <caption>Beziers</caption>
  * var pts = pathToPoints(obj);
- * println(pts.beziers.length); # of beziers
+ * println(pts.beziers.length); // # of beziers
  *
  * beginShape();
  * for (var i = 0; i < pts.beziers.length; i++) {
@@ -7774,16 +7774,17 @@ pub.vertex = function() {
  * endShape(CLOSE);
  *
  * @example <caption>Isolated Paths of Points</caption>
- * var pts = pathToPoints(obj);
+ * var pts = pathToPoints(outlines, 3); // add 3 for more detail
  *
- * for (var i=0; i < pts.paths.length; i++) {
- *   var path = pts.paths[i];
- *   println(path.points.length); # of points
+ * for (var j=0; j < pts.paths.length; j++) {
+ *   var path = pts.paths[j];
  *
+ *   beginShape();
  *   for (var i = 0; i < path.points.length; i++) {
  *     var pt = path.points[i];
- *     point(pt.x, pt.y);
+ *     vertex(pt.x + random(5), pt.y);
  *   }
+ *   endShape(CLOSE);
  * }
  */
 

--- a/basil.js
+++ b/basil.js
@@ -819,7 +819,7 @@ var getParentFunctionName = function(level) {
 }
 
 var checkNull = function (obj) {
-  if(obj === null || typeof obj === undefined) error("Received null " + obj);
+  if(obj === null || typeof obj === undefined) error("Received null object.");
 };
 
 var isEnum = function(base, value) {
@@ -7734,13 +7734,15 @@ pub.vertex = function() {
 
 /**
  * @summary Get points and bezier coordinates from path(s).
- * @description Returns an object containing array of points, beziers, and both separated by paths. Intended for use with `createOutlines()` of text, but works with most pageItem paths. Accepts both single paths or a collection/group of paths. Both points and beziers will have connected lines (one big array), use paths followed by points or beziers for isolated shapes.
+ * @description Returns an object containing an array of all points, an array of all beziers (points + their anchor points) and an array of all paths of a given path item in InDesign. Together with `createOutlines()` this can be used on text items to retrieve points, beziers and paths of text items. Accepts both single paths or a collection/group of paths.
+ * When using this on a multi path object (e.g. text with separate paths), the `paths` property can be used to loop over every path separately, whereas the properties `points` and `beziers` contain arrays for all paths combined.
+ * An optional second parameter allows to add and return additional points between existing points, which is helpful for subdividing existing paths.
  *
  * @cat    Shape
  * @method pathToPoints
- * @param  {Object} obj       The pageItem(s) to process point/bezier coordinates of
- * @param  {Number} [addPts]  Optional amount of additional interpolated points. Ignore if using beziers.
- * @return {Object}           Returns object with following values: .points[], .beziers[], .paths[].points[], .paths[].beziers[]
+ * @param  {Object} obj       The pageItem(s) to process point/bezier coordinates of.
+ * @param  {Number} [addPts]  Optional amount of additional interpolated points.
+ * @return {Object}           Returns object with the following arrays `points`, `beziers`, `paths`
  *
  * @example <caption>Points</caption>
  * noFill();
@@ -7847,7 +7849,8 @@ pub.pathToPoints = function(obj, addPts) {
           pz.points.push(pzPoint)
           pzPoints.push(pzPoint);
         } else {
-          var nextPt = paths.pathPoints[(i + 1) % paths.pathPoints.length];
+          var nextSel = (i + 1) % paths.pathPoints.length;
+          var nextPt = paths.pathPoints[nextSel];
           var amt = 1.0 / (addPts + 1);
           for (var t = 0; t < 1; t += amt) {
             var ptStep = interpolateBezier(pt, nextPt, t);

--- a/changelog.txt
+++ b/changelog.txt
@@ -54,6 +54,8 @@ basil.js x.x.x DAY MONTH YEAR
   checks if a given variable is an integer
 + basil scripts don't try to start ExtendScript Toolkit in the background anymore
 + Added week() to return week number of the year
++ Added createOutlines() to convert text + textPaths to outlines paths
++ Added pathToPoints() to get points, beziers, and both isolated by paths, from pageItems
 
 * translate(), rotate() and scale() now behave like they do in Processing and change the current matrix
 * basil scripts will by default use the user's default units or the current units of the document,

--- a/changelog.txt
+++ b/changelog.txt
@@ -111,8 +111,6 @@ The user is allowed to have his files wherever he wants.
 * bounds() now correctly measures bounds in different canvas modes(MARGIN/BLEED etc.)
 * loadJSON(), loadString(), loadStrings() when passed a URL, can receive custom user-agent as 2nd parameter
 * weekday() now returns number day of the week (0 - 6)
-* textSize() now returns helpful error if given size 0 or below
-
 
 - b.go() and b.loop() are removed (use function draw() or function loop() instead)
 - b.itemX(), b.itemY(), b.itemWidth(), b.itemHeight(), b.itemPosition() and b.itemSize() are removed

--- a/changelog.txt
+++ b/changelog.txt
@@ -111,6 +111,7 @@ The user is allowed to have his files wherever he wants.
 * bounds() now correctly measures bounds in different canvas modes(MARGIN/BLEED etc.)
 * loadJSON(), loadString(), loadStrings() when passed a URL, can receive custom user-agent as 2nd parameter
 * weekday() now returns number day of the week (0 - 6)
+* textSize() now returns helpful error if given size 0 or below
 
 
 - b.go() and b.loop() are removed (use function draw() or function loop() instead)

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -548,7 +548,7 @@ var getParentFunctionName = function(level) {
 }
 
 var checkNull = function (obj) {
-  if(obj === null || typeof obj === undefined) error("Received null " + obj);
+  if(obj === null || typeof obj === undefined) error("Received null object.");
 };
 
 var isEnum = function(base, value) {

--- a/src/includes/core.js
+++ b/src/includes/core.js
@@ -548,7 +548,7 @@ var getParentFunctionName = function(level) {
 }
 
 var checkNull = function (obj) {
-  if(obj === null || typeof obj === undefined) error("Received null object.");
+  if(obj === null || typeof obj === undefined) error("Received null " + obj);
 };
 
 var isEnum = function(base, value) {

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -553,41 +553,60 @@ pub.vertex = function() {
 
 /**
  * @summary Get points and bezier coordinates from path(s).
- * @description Returns an object containing an array of all points, an array of all beziers (points + their anchor points) and an array of all paths of a given path item in InDesign. Together with `createOutlines()` this can be used on text items. Accepts both single paths or a collection/group of paths.
+ * @description Returns an object containing an array of all points, an array of all beziers (points + their anchor points) and an array of all paths (containing its array of points + beziers) of a given pageItem in InDesign. Together with `createOutlines()` this can be used on text items. Accepts both single paths or a collection/group of paths.
  * When using this on a multi path object (e.g. text with separate paths), the `paths` property can be used to loop over every path separately, whereas the properties `points` and `beziers` contain arrays for all paths combined.
  * An optional second parameter allows to add and return additional points between existing points, which is helpful for subdividing existing paths.
  *
  * @cat    Shape
  * @method pathToPoints
  * @param  {Object} obj       The pageItem(s) to process point/bezier coordinates of.
- * @param  {Number} [addPts]  Optional amount of additional interpolated points.
+ * @param  {Number} [addPoints]  Optional amount of additional interpolated points.
  * @return {Object}           Returns object with the following arrays `points`, `beziers`, `paths`
  *
  * @example <caption>Points</caption>
  * var pts = pathToPoints(obj);
  * println(pts.points.length); // # of points
- * point(pts.points[0].x, pts.points[0].y); // first point
+ *
+ * for (var i = 0; i < pts.points.length; i++) {
+ *   var pt = pts.points[i];
+ *   point(pt.x, pt.y);
+ * }
  *
  * @example <caption>Points w/ Interpolation</caption>
  * var pts = pathToPoints(obj, 5); // adds 5 points between points
  * println(pts.points.length); # of points
  *
+ * for (var i = 0; i < pts.points.length; i++) {
+ *   var pt = pts.points[i];
+ *   point(pt.x, pt.y);
+ * }
+ *
  * @example <caption>Beziers</caption>
  * var pts = pathToPoints(obj);
  * println(pts.beziers.length); # of beziers
- * // vertex(pts.beziers[0].anchor.x, pts.beziers[0].anchor.y, pts.beziers[0].left.x, pts.beziers[0].left.y, pts.beziers[0].right.x, pts.beziers[0].right.y);
+ *
+ * beginShape();
+ * for (var i = 0; i < pts.beziers.length; i++) {
+ *   var bz = pts.beziers[i];
+ *   vertex(bz.anchor.x, bz.anchor.y, bz.left.x, bz.left.y, bz.right.x, bz.right.y);
+ * }
+ * endShape(CLOSE);
  *
  * @example <caption>Isolated Paths of Points</caption>
  * var pts = pathToPoints(obj);
+ *
  * for (var i=0; i < pts.paths.length; i++) {
  *   var path = pts.paths[i];
  *   println(path.points.length); # of points
- *   point(path.points[0].x, path.points[0].y); // first point
- * }
  *
+ *   for (var i = 0; i < path.points.length; i++) {
+ *     var pt = path.points[i];
+ *     point(pt.x, pt.y);
+ *   }
+ * }
  */
 
-pub.pathToPoints = function(obj, addPts) {
+pub.pathToPoints = function(obj, addPoints) {
   var pz = {paths:[], points:[], beziers:[]},
   pzGroup = false,
   grabPoints = function(formElm) {
@@ -607,14 +626,14 @@ pub.pathToPoints = function(obj, addPts) {
         pzBeziers.push(pzBezier)
 
         // optionally interpolated points
-        if (addPts === undefined) {
+        if (addPoints === undefined) {
           var pzPoint = {x:pt.anchor[0], y:pt.anchor[1]};
           pz.points.push(pzPoint)
           pzPoints.push(pzPoint);
         } else {
           var nextSel = (i + 1) % paths.pathPoints.length;
           var nextPt = paths.pathPoints[nextSel];
-          var amt = 1.0 / (addPts + 1);
+          var amt = 1.0 / (addPoints + 1);
 
           if (formElm.paths[0].pathType === PathType.OPEN_PATH && i === paths.pathPoints.length-1) {
             amt = 1; // don't interpolate end to start on open paths

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -553,7 +553,7 @@ pub.vertex = function() {
 
 /**
  * @summary Get points and bezier coordinates from path(s).
- * @description Returns an object containing an array of all points, an array of all beziers (points + their anchor points) and an array of all paths of a given path item in InDesign. Together with `createOutlines()` this can be used on text items to retrieve points, beziers and paths of text items. Accepts both single paths or a collection/group of paths.
+ * @description Returns an object containing an array of all points, an array of all beziers (points + their anchor points) and an array of all paths of a given path item in InDesign. Together with `createOutlines()` this can be used on text items. Accepts both single paths or a collection/group of paths.
  * When using this on a multi path object (e.g. text with separate paths), the `paths` property can be used to loop over every path separately, whereas the properties `points` and `beziers` contain arrays for all paths combined.
  * An optional second parameter allows to add and return additional points between existing points, which is helpful for subdividing existing paths.
  *
@@ -564,81 +564,25 @@ pub.vertex = function() {
  * @return {Object}           Returns object with the following arrays `points`, `beziers`, `paths`
  *
  * @example <caption>Points</caption>
- * noFill();
- * var myEllipse = ellipse(width / 2, height / 2, width / 2, width / 2);
- * var pts = pathToPoints(myEllipse);
- * var ptsExtended = pathToPoints(myEllipse, 5); // add 5 points between points
+ * var pts = pathToPoints(obj);
+ * println(pts.points.length); // # of points
+ * point(pts.points[0].x, pts.points[0].y); // first point
  *
- * noStroke();
- * fill(0, 0, 255);
+ * @example <caption>Points w/ Interpolation</caption>
+ * var pts = pathToPoints(obj, 5); // adds 5 points between points
+ * println(pts.points.length); # of points
  *
- * // draw normal points
- * for (var i=0; i < pts.points.length; i++) {
- *   var pt = pts.points[i];
- *   ellipse(pt.x, pt.y, 10, 10);
- * }
+ * @example <caption>Beziers</caption>
+ * var pts = pathToPoints(obj);
+ * println(pts.beziers.length); # of beziers
+ * // vertex(pts.beziers[0].anchor.x, pts.beziers[0].anchor.y, pts.beziers[0].left.x, pts.beziers[0].left.y, pts.beziers[0].right.x, pts.beziers[0].right.y);
  *
- * noFill();
- * stroke(255, 0, 0);
- * // draw extended points
- * for (var i=0; i < ptsExtended.points.length; i++) {
- *   var pt = ptsExtended.points[i];
- *   ellipse(pt.x, pt.y, 10, 10);
- * }
- *
- * @example <caption>Beziers from text using createOutlines()</caption>
- * textSize(400);
- * var myText = text("H", width/4, height/4, 500, 500);
- * var outlines = createOutlines(myText);
- * var pts = pathToPoints(outlines);
- * property(outlines, "fillColor", "None");
- *
- * noFill();
- * stroke(0, 255, 0);
- *
- * // draw bezier
- * beginShape();
- * for (var i=0; i < pts.beziers.length; i++) {
- *   var pt = pts.beziers[i]; // point w/ .anchor .left .right
- *   vertex(pt.anchor.x, pt.anchor.y, pt.left.x, pt.left.y, pt.right.x, pt.right.y);
- * }
- * endShape(CLOSE);
- *
- * // debug bezier
- * for (var i=0; i < pts.beziers.length; i++) {
- *   var pt = pts.beziers[i]; // point
- *   var anchor = pt.anchor; // anchor
- *   var left = pt.left; // left handle
- *   var right = pt.right; // right handle
- *   noStroke();
- *   fill(0);
- *   ellipse(anchor.x, anchor.y, 5, 5);
- *   ellipse(left.x, left.y, 5, 5);
- *   ellipse(right.x, right.y, 5, 5);
- *   stroke(0, 255, 0);
- *   line(anchor.x, anchor.y, left.x, left.y);
- *   line(anchor.x, anchor.y, right.x, right.y);
- * }
- *
- * @example <caption>Isolated Paths of Beziers from text using createOutlines()</caption>
- * textSize(200);
- * var myText = text("hello", width/4, height/4, 500, 500);
- * var outlines = createOutlines(myText);
- * var pts = pathToPoints(outlines);
- * property(outlines, "fillColor", "None");
- *
- * noFill();
- * stroke(0, 255, 0);
- *
- * // just beziers
- * for (var p=0; p < pts.paths.length; p++) {
- *   var path = pts.paths[p]; // each path isolated
- *   beginShape();
- *   for (var i=0; i<path.beziers.length; i++) {
- *     var tp = path.beziers[i];
- *     vertex(tp.anchor.x, tp.anchor.y, tp.left.x, tp.left.y, tp.right.x, tp.right.y);
- *   }
- *   endShape(CLOSE);
+ * @example <caption>Isolated Paths of Points</caption>
+ * var pts = pathToPoints(obj);
+ * for (var i=0; i < pts.paths.length; i++) {
+ *   var path = pts.paths[i];
+ *   println(path.points.length); # of points
+ *   point(path.points[0].x, path.points[0].y); // first point
  * }
  *
  */
@@ -671,6 +615,11 @@ pub.pathToPoints = function(obj, addPts) {
           var nextSel = (i + 1) % paths.pathPoints.length;
           var nextPt = paths.pathPoints[nextSel];
           var amt = 1.0 / (addPts + 1);
+
+          if (formElm.paths[0].pathType === PathType.OPEN_PATH && i === paths.pathPoints.length-1) {
+            amt = 1; // don't interpolate end to start on open paths
+          }
+
           for (var t = 0; t < 1; t += amt) {
             var ptStep = interpolateBezier(pt, nextPt, t);
             var pzPointStep = {x:ptStep.x, y:ptStep.y};

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -553,13 +553,15 @@ pub.vertex = function() {
 
 /**
  * @summary Get points and bezier coordinates from path(s).
- * @description Returns an object containing array of points, beziers, and both separated by paths. Intended for use with `createOutlines()` of text, but works with most pageItem paths. Accepts both single paths or a collection/group of paths. Both points and beziers will have connected lines (one big array), use paths followed by points or beziers for isolated shapes.
+ * @description Returns an object containing an array of all points, an array of all beziers (points + their anchor points) and an array of all paths of a given path item in InDesign. Together with `createOutlines()` this can be used on text items to retrieve points, beziers and paths of text items. Accepts both single paths or a collection/group of paths.
+ * When using this on a multi path object (e.g. text with separate paths), the `paths` property can be used to loop over every path separately, whereas the properties `points` and `beziers` contain arrays for all paths combined.
+ * An optional second parameter allows to add and return additional points between existing points, which is helpful for subdividing existing paths.
  *
  * @cat    Shape
  * @method pathToPoints
- * @param  {Object} obj       The pageItem(s) to process point/bezier coordinates of
- * @param  {Number} [addPts]  Optional amount of additional interpolated points. Ignore if using beziers.
- * @return {Object}           Returns object with following values: .points[], .beziers[], .paths[].points[], .paths[].beziers[]
+ * @param  {Object} obj       The pageItem(s) to process point/bezier coordinates of.
+ * @param  {Number} [addPts]  Optional amount of additional interpolated points.
+ * @return {Object}           Returns object with the following arrays `points`, `beziers`, `paths`
  *
  * @example <caption>Points</caption>
  * noFill();
@@ -666,7 +668,8 @@ pub.pathToPoints = function(obj, addPts) {
           pz.points.push(pzPoint)
           pzPoints.push(pzPoint);
         } else {
-          var nextPt = paths.pathPoints[(i + 1) % paths.pathPoints.length];
+          var nextSel = (i + 1) % paths.pathPoints.length;
+          var nextPt = paths.pathPoints[nextSel];
           var amt = 1.0 / (addPts + 1);
           for (var t = 0; t < 1; t += amt) {
             var ptStep = interpolateBezier(pt, nextPt, t);

--- a/src/includes/shape.js
+++ b/src/includes/shape.js
@@ -574,7 +574,7 @@ pub.vertex = function() {
  *
  * @example <caption>Points w/ Interpolation</caption>
  * var pts = pathToPoints(obj, 5); // adds 5 points between points
- * println(pts.points.length); # of points
+ * println(pts.points.length); // # of points
  *
  * for (var i = 0; i < pts.points.length; i++) {
  *   var pt = pts.points[i];
@@ -583,7 +583,7 @@ pub.vertex = function() {
  *
  * @example <caption>Beziers</caption>
  * var pts = pathToPoints(obj);
- * println(pts.beziers.length); # of beziers
+ * println(pts.beziers.length); // # of beziers
  *
  * beginShape();
  * for (var i = 0; i < pts.beziers.length; i++) {
@@ -593,16 +593,17 @@ pub.vertex = function() {
  * endShape(CLOSE);
  *
  * @example <caption>Isolated Paths of Points</caption>
- * var pts = pathToPoints(obj);
+ * var pts = pathToPoints(outlines, 3); // add 3 for more detail
  *
- * for (var i=0; i < pts.paths.length; i++) {
- *   var path = pts.paths[i];
- *   println(path.points.length); # of points
+ * for (var j=0; j < pts.paths.length; j++) {
+ *   var path = pts.paths[j];
  *
+ *   beginShape();
  *   for (var i = 0; i < path.points.length; i++) {
  *     var pt = path.points[i];
- *     point(pt.x, pt.y);
+ *     vertex(pt.x + random(5), pt.y);
  *   }
+ *   endShape(CLOSE);
  * }
  */
 

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -486,7 +486,8 @@ pub.paragraphStyle = function(textOrName, props) {
 /**
  * @summary Convert text items to outlines.
  * @description Returns an array of polygons after outlining text and optionally processes them with a callback function.
- * Use together with `pathToPoints()` for getting point and bezier coordinates from outlines.
+ * Use together with `pathToPoints()` for getting point and bezier coordinates from outlines. If used on a text frame,
+ * all linked text frames will be converted to outlines as well.
  *
  * @cat Typography
  * @method createOutlines
@@ -495,23 +496,24 @@ pub.paragraphStyle = function(textOrName, props) {
  * @param  {Function} [cb] Optional: Callback function to use with each polygon. Passed arguments: `obj`, `loopCounter`
  * @return {Array of Polygons} Returns an array of polygons.
  *
- * @example
+ * @example <caption>Convert text to outlines</caption>
  * textSize(150);
  * var myText = text("Hello", 0, 0, width, height);
  * var outlines = createOutlines(myText);
  *
- * @example <caption>w/ Callback</caption>
+ * @example <caption>Run a callback function on each resulting shape</caption>
  * textSize(150);
  * var myText = text("Hello \nWorld", 0, 0, width, height);
  * var outlines = createOutlines(myText, function(obj){
  *   var pts = pathToPoints(obj);
+ *   println(pts.length); // check number of points
  * });
  *
  */
 
 
 pub.createOutlines = function(item, cb) {
-  var outlines, changedFill = false, debugCO = false;
+  var outlines, changedFill = false;
 
   // check if textFrames
   if (item.hasOwnProperty('createOutlines')) {
@@ -552,24 +554,23 @@ pub.createOutlines = function(item, cb) {
 
   // error if neither
   } else {
-    error("Be sure to use:\n Story | TextFrame | Paragraph | Line | Word | Character | TextPath")
-    return false;
+    error("createOutlines(), incorrect first parameter. Use:\n Story | TextFrame | Paragraph | Line | Word | Character | TextPath");
   }
 
   // remove tempFill for those items
-  if(changedFill){
-    for(var i=0; i< outlines.length; i++){
+  if (changedFill) {
+    for (var i=0; i < outlines.length; i++) {
       outlines[i].fillColor = "None";
     }
 
   }
 
   // process outlines
-  if (outlines.length != undefined && outlines.length === 1) {
+  if (outlines.hasOwnProperty('length') && outlines.length === 1) {
     // multi-line text from group array
     if (outlines[0] instanceof Group) {
       outlines = ungroup(outlines[0]);
-      if (debugCO) println('group polygons'); // textframe multi-line
+      // textframe multi-line
       if (cb instanceof Function) {
         return forEach(outlines, cb);
       } else {
@@ -578,19 +579,18 @@ pub.createOutlines = function(item, cb) {
     }
 
     // single polygon
-    if (debugCO) println('solo polygons/groups'); // single normal textFrame 1 line
+    // single normal textFrame 1 line
     if (cb instanceof Function) {
       return forEach(outlines, cb);
     } else {
       return outlines;
     }
   } else {
-    if (debugCO) println('array of polygons/groups'); // textPath, linked textFrames
-
+    // textPath, linked textFrames
     // collection of polygons
     if (outlines[0] instanceof Group) {
       outlinesGroups = [];
-      for(var i=0; i < outlines.length; i++){
+      for (var i=0; i < outlines.length; i++) {
         outlinesGroups.push(ungroup(outlines[i]));
       }
       outlines = outlinesGroups;
@@ -602,7 +602,7 @@ pub.createOutlines = function(item, cb) {
       return outlines;
     }
   }
-}
+};
 
 // ----------------------------------------
 // Typography/Constants

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -485,21 +485,22 @@ pub.paragraphStyle = function(textOrName, props) {
 
 /**
  * @summary Convert text items to outlines.
- * @description Returns a polygon or array of polygons (if text is multi-line, multi-boxed, or a textPath) and optionally processes them with a callback function.
+ * @description Returns an array of polygons after outlining text and optionally processes them with a callback function.
  * Use together with `pathToPoints()` for getting point and bezier coordinates from outlines.
  *
  * @cat Typography
  * @method createOutlines
- * @param  {Story|TextFrame||Paragraph||Line||Word||Character||GraphicLine||Polygon||Oval||Rectangle} item Text or textpath to be outlined.
- * @param  {Function} [cb] Optional: The callback function to call with each polygon. Passed arguments: `obj`, `loopCounter`
+ *
+ * @param  {TextFrame|TextPath} item Text or TextPath to be outlined.
+ * @param  {Function} [cb] Optional: Callback function to use with each polygon. Passed arguments: `obj`, `loopCounter`
  * @return {Array of Polygons} Returns an array of polygons.
  *
- * @example <caption>createOutlines</caption>
+ * @example
  * textSize(150);
  * var myText = text("Hello", 0, 0, width, height);
  * var outlines = createOutlines(myText);
  *
- * @example <caption>createOutlines with Callback</caption>
+ * @example <caption>w/ Callback</caption>
  * textSize(150);
  * var myText = text("Hello \nWorld", 0, 0, width, height);
  * var outlines = createOutlines(myText, function(obj){

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -524,7 +524,7 @@ pub.createOutlines = function(item, cb) {
         changedFill = true;
       }
     }
-    inspect(item)
+
     outlines = item.createOutlines();
 
   // check if textPath

--- a/test/shape-tests.jsx
+++ b/test/shape-tests.jsx
@@ -77,6 +77,24 @@ basilTest("VertexTests", {
     assert(shape instanceof GraphicLine);
     assert(shape.paths.item(0).entirePath.length === 8); // because of overlapping points bug
 
+  },
+
+  testPathToPoints: function() {
+    textSize(100);
+    var myText = text("hello", 0, 0, width, height);
+    var outlines = createOutlines(myText);
+    var pts = pathToPoints(outlines);
+    assert(outlines instanceof Polygon);
+    assert(pts.paths.length === 7);
+    assert(pts.points instanceof Array);
+    assert(pts.beziers instanceof Array);
+
+    var myEllipse = ellipse(width/2, height/2, width/2, width/2);
+    var pts = pathToPoints(myEllipse);
+    assert(pts.points.length === 4);
+    var ptsExtended = pathToPoints(myEllipse, 2);
+    assert(ptsExtended.points.length === 12);
+
   }
 
 });

--- a/test/typography-tests.jsx
+++ b/test/typography-tests.jsx
@@ -319,6 +319,18 @@ basilTest("TypographyTests", {
 
     assert(myRect.appliedObjectStyle === objStyle);
     assert(myRect.topLeftCornerOption === CornerOptions.ROUNDED_CORNER);
+  },
+
+  testCreateOutlines: function() {
+    textSize(100);
+    var myText = text("hello", 0, 0, width, height);
+    var outlines = createOutlines(myText);
+    assert(outlines instanceof Polygon);
+
+    var myText = text("hello \n world", 0, 0, width, height);
+    var outlines = createOutlines(myText);
+    assert(outlines instanceof Array);
+
   }
 
 });


### PR DESCRIPTION
- added `createOutlines()`, handles textFrames, textPaths, multi-line text, multi-box text.
- added `pathToPoints()`, handles polygons from `createOutlines()` or most other pageItems (oval, rect, polygon, etc), also accepts groups and arrays.
- added examples per function in documentation
- added tests for both functions
- updated changelog
- added nice error message for `textSize()`, common beginner mistake giving size less than zero.
(totally new approaching, replacing #268 )