### PR TITLE
duplicate() used on a page now jumps to the duplicated page

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -3744,7 +3744,7 @@ pub.bounds = function (obj) {
 
 /**
  * @summary Duplicates a page or page item.
- * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use `rectMode()` to set center point.
+ * @description Duplicates the given page after the current page or the given page item to the current page and layer. If a page is duplicated, basil.js automatically jumps to the new page.
  *
  * @cat     Document
  * @subcat  Page Items
@@ -3765,7 +3765,7 @@ pub.duplicate = function(item) {
   } else if(item instanceof Page) {
 
     var newPage = item.duplicate(LocationOptions.AFTER, pub.page());
-    return newPage;
+    getAndUpdatePage(newPage, "duplicate");
 
   } else {
     error("Please provide a valid Page or PageItem as parameter for duplicate().");

--- a/changelog.txt
+++ b/changelog.txt
@@ -93,7 +93,7 @@ basil.js x.x.x DAY MONTH YEAR
   (Characters, Words, Lines etc.)
 * size() now can use existing page size presets as a parameter with an optional
   second parameter for page orientation (introducing PORTRAIT and LANDSCAPE)
-* duplicate() now duplicates page items reliably in place, even when in FACING canvas modes
+* duplicate() now duplicates page items reliably in place, even when in FACING canvas modes and jumps to the new page if a page is duplicated
 * selection() can now be used to set the selection
 * label() can now be used to assign a label to a page item
 * endsWith() and startsWith() now also work for arrays

--- a/src/includes/document.js
+++ b/src/includes/document.js
@@ -937,7 +937,7 @@ pub.bounds = function (obj) {
 
 /**
  * @summary Duplicates a page or page item.
- * @description Duplicates the given page after the current page or the given page item to the current page and layer. Use `rectMode()` to set center point.
+ * @description Duplicates the given page after the current page or the given page item to the current page and layer. If a page is duplicated, basil.js automatically jumps to the new page.
  *
  * @cat     Document
  * @subcat  Page Items
@@ -958,7 +958,7 @@ pub.duplicate = function(item) {
   } else if(item instanceof Page) {
 
     var newPage = item.duplicate(LocationOptions.AFTER, pub.page());
-    return newPage;
+    return getAndUpdatePage(newPage, "duplicate");
 
   } else {
     error("Please provide a valid Page or PageItem as parameter for duplicate().");


### PR DESCRIPTION
As discussed in #357. Will merge right away.