### PR TITLE
adding indexOf() prototype for arrays

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -2805,6 +2805,15 @@ pub.matchAll = function(aString, aRegExp) {
   return results.length > 0 ? results : null;
 };
 
+Array.prototype.indexOf = function ( item ) {
+  var index = 0, length = this.length;
+  for ( ; index < length; index++ ) {
+    if ( this[index] === item )
+      return index;
+  }
+  return -1;
+};
+
 // ----------------------------------------
 // src/includes/document.js
 // ----------------------------------------
@@ -3765,7 +3774,7 @@ pub.duplicate = function(item) {
   } else if(item instanceof Page) {
 
     var newPage = item.duplicate(LocationOptions.AFTER, pub.page());
-    getAndUpdatePage(newPage, "duplicate");
+    return getAndUpdatePage(newPage, "duplicate");
 
   } else {
     error("Please provide a valid Page or PageItem as parameter for duplicate().");

--- a/changelog.txt
+++ b/changelog.txt
@@ -54,6 +54,7 @@ basil.js x.x.x DAY MONTH YEAR
   checks if a given variable is an integer
 + basil scripts don't try to start ExtendScript Toolkit in the background anymore
 + Added week() to return week number of the year
++ Added standard JS Array.indexOf() for searching arrays
 
 * translate(), rotate() and scale() now behave like they do in Processing and change the current matrix
 * basil scripts will by default use the user's default units or the current units of the document,

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -1341,3 +1341,12 @@ pub.matchAll = function(aString, aRegExp) {
   }
   return results.length > 0 ? results : null;
 };
+
+Array.prototype.indexOf = function ( item ) {
+  var index = 0, length = this.length;
+  for ( ; index < length; index++ ) {
+    if ( this[index] === item )
+      return index;
+  }
+  return -1;
+};


### PR DESCRIPTION
- added `indexOf()` for searching arrays, an often needed function that's been missing from InDesign's JS engine
- seems part of the `duplicate()` function got updated on the basil.js compiled file.. @trych - maybe your merge didn't include the most up to date compiled file??