### PR TITLE
small fix to return type on createOutlines

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -9098,7 +9098,7 @@ pub.paragraphStyle = function(textOrName, props) {
  *
  * @param  {TextFrame|TextPath} item Text or TextPath to be outlined.
  * @param  {Function} [cb] Optional: Callback function to use with each polygon. Passed arguments: `obj`, `loopCounter`
- * @return {Array of Polygons} Returns an array of polygons.
+ * @return {Array} Returns an array of polygons.
  *
  * @example <caption>Convert text to outlines</caption>
  * textSize(150);

--- a/src/includes/typography.js
+++ b/src/includes/typography.js
@@ -494,7 +494,7 @@ pub.paragraphStyle = function(textOrName, props) {
  *
  * @param  {TextFrame|TextPath} item Text or TextPath to be outlined.
  * @param  {Function} [cb] Optional: Callback function to use with each polygon. Passed arguments: `obj`, `loopCounter`
- * @return {Array of Polygons} Returns an array of polygons.
+ * @return {Array} Returns an array of polygons.
  *
  * @example <caption>Convert text to outlines</caption>
  * textSize(150);


### PR DESCRIPTION
- fixed return to simply be `Array`