### PR TITLE
Add improvements to b.download()

### DIFF
--- a/basil.js
+++ b/basil.js
@@ -1,4 +1,4 @@
-/* Basil.js v1.1.0 2016.11.11-15:33:03 */
+
 /*
   ..-  --.- ..- -.... -..-- .-..-. -.-..---.-.-....--.-- -....-.... -..-- .-.-..-.-.... .- .--
 
@@ -57,7 +57,7 @@
    * @property VERSION {String}
    * @cat Environment
    */
-  pub.VERSION = "1.0.10";
+  pub.VERSION = "1.1.0";
 
 /**
  * Used with b.units() to set the coordinate system to points.
@@ -3355,7 +3355,7 @@ pub.savePNG = function(file, showOptions) {
  * @param {String|File} [file] A relative file path in the project folder or a File instance
  */
 pub.download = function(url, file) {
-  var projPath = projectFolder().fsName.replace(" ", "\\ ");
+  var projPath = projectFolder().fsName.replace(/ /g, "\\ ");
   // var scriptPath = "~/Documents/basiljs/bundle/lib/download.sh";
   // This is more portable then a fixed location
   // the Script looks for the lib folder next to itself
@@ -3407,12 +3407,14 @@ pub.download = function(url, file) {
   if (isURL(url)) {
     var cmd = null;
 
+	url = "\"" + url + "\"";
+
     if (file) {
       if (file instanceof File) {
         var downloadFolder = file.parent.fsName;
         var fileName = file.displayName;
-        downloadFolder = downloadFolder.replace(" ", "\\ ");
-        fileName = fileName.replace(" ", "\\ ");
+        downloadFolder = downloadFolder.replace(/ /g, "\\ ");
+        fileName = fileName.replace(/ /g, "\\ ");
         cmd = ["sh", scriptPath, downloadFolder, url, fileName].join(" ");
 
       } else {
@@ -3423,8 +3425,8 @@ pub.download = function(url, file) {
         if(startsWith(downloadFolder, "./")) downloadFolder.substr(2);
         if(startsWith(downloadFolder, "/")) downloadFolder.substr(1);
 
-        downloadFolder = downloadFolder.replace(" ", "\\ ");
-        fileName = fileName.replace(" ", "\\ ");
+        downloadFolder = downloadFolder.replace(/ /g, "\\ ");
+        fileName = fileName.replace(/ /g, "\\ ");
         downloadFolder = projPath + "/data/" + downloadFolder;
         cmd = ["sh", scriptPath, downloadFolder, url, fileName].join(" ");
 

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -988,7 +988,7 @@ pub.savePNG = function(file, showOptions) {
  * @param {String|File} [file] A relative file path in the project folder or a File instance
  */
 pub.download = function(url, file) {
-  var projPath = projectFolder().fsName.replace(" ", "\\ ");
+  var projPath = projectFolder().fsName.replace(/ /g, "\\ ");
   // var scriptPath = "~/Documents/basiljs/bundle/lib/download.sh";
   // This is more portable then a fixed location
   // the Script looks for the lib folder next to itself
@@ -1044,8 +1044,8 @@ pub.download = function(url, file) {
       if (file instanceof File) {
         var downloadFolder = file.parent.fsName;
         var fileName = file.displayName;
-        downloadFolder = downloadFolder.replace(" ", "\\ ");
-        fileName = fileName.replace(" ", "\\ ");
+        downloadFolder = downloadFolder.replace(/ /g, "\\ ");
+        fileName = fileName.replace(/ /g, "\\ ");
         cmd = ["sh", scriptPath, downloadFolder, url, fileName].join(" ");
 
       } else {
@@ -1056,8 +1056,8 @@ pub.download = function(url, file) {
         if(startsWith(downloadFolder, "./")) downloadFolder.substr(2);
         if(startsWith(downloadFolder, "/")) downloadFolder.substr(1);
 
-        downloadFolder = downloadFolder.replace(" ", "\\ ");
-        fileName = fileName.replace(" ", "\\ ");
+        downloadFolder = downloadFolder.replace(/ /g, "\\ ");
+        fileName = fileName.replace(/ /g, "\\ ");
         downloadFolder = projPath + "/data/" + downloadFolder;
         cmd = ["sh", scriptPath, downloadFolder, url, fileName].join(" ");
 

--- a/src/includes/data.js
+++ b/src/includes/data.js
@@ -1040,6 +1040,8 @@ pub.download = function(url, file) {
   if (isURL(url)) {
     var cmd = null;
 
+	url = "\"" + url + "\"";
+
     if (file) {
       if (file instanceof File) {
         var downloadFolder = file.parent.fsName;

--- a/test/download/download.jsx
+++ b/test/download/download.jsx
@@ -1,8 +1,28 @@
-﻿// @include "./basil.js";
-/* global b */
-function setup () {
-  b.download("https://raw.githubusercontent.com/basiljs/basil.js/master/changelog.txt");
+﻿if (typeof b === 'undefined') {
+  #include "../../basil.js";
 }
-function draw() {}
-b.go();
+if (typeof b.test === 'undefined') {
+  #include "../../lib/basil.test.js";  
+}
 
+b.test('download', {
+
+  testDownload: function() {
+    b.download("https://raw.githubusercontent.com/basiljs/basil.js/master/changelog.txt");
+    assert(new File("./download/changelog.txt"));
+  },
+
+  testDownloadWithQueryString: function() {
+    b.download("https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https://basiljs.ch", "qrcode.png");
+    assert(new File("./qrcode.png"));
+  },
+  
+  testDownloadWithSpacesInPath: function() {
+    b.download("https://raw.githubusercontent.com/basiljs/basil.js/master/lib/basil.png", "folder with spaces/basil.png");
+    assert(new File("./folder with spaces/basil.png"));
+  }
+
+});
+
+// print collected test results
+b.test.result();


### PR DESCRIPTION
Hi,

For a project I worked on, I faced issues trying to download a qrcode using Google's QR code generator:

[https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https://basiljs.ch](https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https://basiljs.ch)

Here are two small commits to the b.download() method, which:

- make sure all spaces in the project path are properly escaped (and not just the first one)
- avoid the query string to be stripped by the shell (because of "&") by surrounding the url with quotes

Hope it helps !